### PR TITLE
fix: ensure item price is per unit when quantity > 1 (fixes #6)

### DIFF
--- a/src/app/api/parse-receipt/route.ts
+++ b/src/app/api/parse-receipt/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
-import Anthropic from '@anthropic-ai/sdk';
-import { TextBlock } from '@anthropic-ai/sdk/resources';
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { TextBlock } from "@anthropic-ai/sdk/resources";
 
 // Initialize Anthropic client
 const anthropic = new Anthropic({
@@ -8,61 +8,66 @@ const anthropic = new Anthropic({
 });
 
 // Valid media types for Anthropic API
-type ValidMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+type ValidMediaType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
 
 export async function POST(request: NextRequest) {
   try {
     // Validate API key exists
     if (!process.env.ANTHROPIC_API_KEY) {
       return NextResponse.json(
-        { error: 'Anthropic API key is not configured' },
+        { error: "Anthropic API key is not configured" },
         { status: 500 }
       );
     }
 
     // Get receipt image data
     const formData = await request.formData();
-    const file = formData.get('file') as File | null;
+    const file = formData.get("file") as File | null;
 
     if (!file) {
-      return NextResponse.json(
-        { error: 'No file provided' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
     }
 
     // Convert file to base64
     const buffer = await file.arrayBuffer();
-    const base64 = Buffer.from(buffer).toString('base64');
+    const base64 = Buffer.from(buffer).toString("base64");
     const mimeType = file.type;
-    
+
     // Validate mime type
-    const validMediaTypes: ValidMediaType[] = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    const validMediaTypes: ValidMediaType[] = [
+      "image/jpeg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+    ];
     if (!validMediaTypes.includes(mimeType as ValidMediaType)) {
       return NextResponse.json(
-        { error: 'Unsupported image format. Please use JPEG, PNG, GIF, or WebP.' },
+        {
+          error:
+            "Unsupported image format. Please use JPEG, PNG, GIF, or WebP.",
+        },
         { status: 400 }
       );
     }
 
     // Call Anthropic with the image
     const message = await anthropic.messages.create({
-      model: 'claude-3-5-haiku-20241022',
+      model: "claude-3-5-haiku-20241022",
       max_tokens: 4096,
       messages: [
         {
-          role: 'user',
+          role: "user",
           content: [
             {
-              type: 'image',
+              type: "image",
               source: {
-                type: 'base64',
+                type: "base64",
                 media_type: mimeType as ValidMediaType,
                 data: base64,
               },
             },
             {
-              type: 'text',
+              type: "text",
               text: `Parse this receipt image and return a JSON object with the following structure:
               {
                 "restaurant": "Name of the restaurant or store",
@@ -74,13 +79,12 @@ export async function POST(request: NextRequest) {
                 "items": [
                   {
                     "name": "Item name",
-                    "price": "Item price as number",
+                    "price": "Item price as number (this should always be the price for a single unit, not the total for all units)",
                     "quantity": "Quantity as number (default to 1 if not specified)"
                   }
                 ]
               }
-              
-              Only include items that were actually purchased. If you can't determine any field, use null. Keep the item names exactly as they appear on the receipt. Return ONLY the JSON with no explanations or additional text.`,
+              \nInstructions for items:\n- If the receipt lists a line item with a quantity greater than 1, and shows a total price for that line, divide the total price by the quantity to get the per-unit price, and use that value for the 'price' field.\n- Do NOT multiply the price by the quantity in the output.\n- The 'price' field should always be the price for a single unit, even if the receipt shows a total for multiple units.\n- Only include items that were actually purchased.\n- If you can't determine any field, use null.\n- Keep the item names exactly as they appear on the receipt.\n- Return ONLY the JSON with no explanations or additional text.`,
             },
           ],
         },
@@ -88,38 +92,38 @@ export async function POST(request: NextRequest) {
     });
 
     // Extract the JSON from the response and handle potential type issues
-    let jsonText = '';
-    
+    let jsonText = "";
+
     // Safely get text content from the response
     for (const block of message.content) {
-      if (block.type === 'text') {
+      if (block.type === "text") {
         jsonText = (block as TextBlock).text;
         break;
       }
     }
-    
+
     if (!jsonText) {
       return NextResponse.json(
-        { error: 'No text response received from Claude' },
+        { error: "No text response received from Claude" },
         { status: 500 }
       );
     }
-    
+
     // Try to parse the JSON
     try {
       const parsedData = JSON.parse(jsonText);
       return NextResponse.json(parsedData);
     } catch {
-      console.error('Failed to parse JSON from Claude response:', jsonText);
+      console.error("Failed to parse JSON from Claude response:", jsonText);
       return NextResponse.json(
-        { error: 'Failed to parse receipt data' },
+        { error: "Failed to parse receipt data" },
         { status: 500 }
       );
     }
   } catch (error) {
-    console.error('Error processing receipt:', error);
+    console.error("Error processing receipt:", error);
     return NextResponse.json(
-      { error: 'Failed to process receipt' },
+      { error: "Failed to process receipt" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Fix: Ensure Item Price is Per Unit When Quantity > 1 ([#6](https://github.com/narulaskaran/receipt-splitter/issues/6))

### Summary

This PR fixes a bug where the price for items with quantity greater than 1 was incorrectly calculated as the total for all units, rather than the per-unit price. Now, the Claude prompt explicitly instructs the model to always return the per-unit price for each item. If the receipt shows a total for multiple units, the prompt tells Claude to divide the total by the quantity to get the per-unit price, and to never multiply the price by the quantity in the output.

### Changes

- **Prompt Update:**  
  The prompt in `src/app/api/parse-receipt/route.ts` now includes clear instructions for handling line items with quantity > 1, ensuring the `price` field is always per unit.

### Linked Issue

Closes [#6](https://github.com/narulaskaran/receipt-splitter/issues/6)