### PR TITLE
Integrate Vercel Web Analytics

### DIFF
--- a/CURSOR.md
+++ b/CURSOR.md
@@ -35,20 +35,27 @@ ANTHROPIC_API_KEY=your_api_key_here
 ## Core Functionality
 
 1. **Receipt Parsing**
+
    - Upload receipt images
    - Parse receipt items, totals, and metadata using Claude API
 
 2. **People Management**
+
    - Add and remove people
    - Track individual expenses
 
 3. **Item Assignment**
+
    - Assign items to specific people
-   - Split items proportionally among multiple people  
+   - Split items proportionally among multiple people
 
 4. **Expense Calculation**
    - Calculate tax and tip proportionally
    - Compute final amounts owed by each person
+
+## Analytics
+
+Vercel Web Analytics is integrated using the `@vercel/analytics` package. The `<Analytics />` component is included in the root layout (`src/app/layout.tsx`) to enable privacy-friendly, cookieless analytics and page view tracking. Analytics data is viewable in the Vercel dashboard under the Analytics tab for the project.
 
 ## Development Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-select": "^2.2.3",
         "@radix-ui/react-slot": "^1.2.1",
         "@radix-ui/react-tabs": "^1.1.10",
+        "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "decimal.js": "^10.5.0",
@@ -2559,6 +2560,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-select": "^2.2.3",
     "@radix-ui/react-slot": "^1.2.1",
     "@radix-ui/react-tabs": "^1.1.10",
+    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "decimal.js": "^10.5.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Analytics } from "@vercel/analytics/react";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,15 +30,16 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <ThemeProvider 
-          attribute="class" 
-          defaultTheme="system" 
-          enableSystem 
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
           disableTransitionOnChange
         >
           {children}
           <Toaster />
         </ThemeProvider>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
This PR integrates Vercel Web Analytics into the project using the @vercel/analytics package.
- Adds @vercel/analytics as a dependency
- Injects the <Analytics /> component into the root layout (src/app/layout.tsx)
- Updates CURSOR.md to document the analytics integration

Once merged and deployed, analytics data will be available in the Vercel dashboard under the Analytics tab for this project.