### PR TITLE
fix: Split Equally selects all people if none are selected

### DIFF
--- a/src/components/item-assignment.tsx
+++ b/src/components/item-assignment.tsx
@@ -101,11 +101,21 @@ export function ItemAssignment({
     if (currentItemIndex === null) return;
 
     // Get selected people (those with any value assigned)
-    const selectedPeopleIds = Array.from(assignments.keys());
+    let selectedPeopleIds = Array.from(assignments.keys());
 
+    // If none are selected, select all people
     if (selectedPeopleIds.length === 0) {
-      toast.error("Please select at least one person");
-      return;
+      selectedPeopleIds = people.map((p) => p.id);
+      if (selectedPeopleIds.length === 0) {
+        toast.error("No people to assign");
+        return;
+      }
+      // Update assignments state to include all people with 0% (will be set below)
+      const newAssignments = new Map(assignments);
+      selectedPeopleIds.forEach((personId) => {
+        newAssignments.set(personId, 0);
+      });
+      setAssignments(newAssignments);
     }
 
     // Calculate equal share with 2 decimal places


### PR DESCRIPTION
## What does this PR do?

This PR fixes [issue #12](https://github.com/narulaskaran/receipt-splitter/issues/12).

### Problem

Previously, clicking the Split Equally button would do nothing if no people were selected for an item. This was confusing for users who expected the button to select all people and split the item equally among them.

### Solution

Now, if no people are selected when Split Equally is clicked, the app will automatically select all people and split the item equally among them. This improves usability and matches user expectations.

---

**Closes #12**
