### PR TITLE
feat: Add Venmo payment link generation to Results Summary

### DIFF
--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -1,16 +1,17 @@
-import { Share } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { 
-  Table, 
-  TableHeader, 
-  TableBody, 
-  TableRow, 
-  TableHead, 
-  TableCell 
-} from '@/components/ui/table';
-import { type Person } from '@/types';
-import { formatCurrency } from '@/lib/receipt-utils';
+import { Share } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import { type Person } from "@/types";
+import { formatCurrency } from "@/lib/receipt-utils";
+import { useState } from "react";
 
 interface ResultsSummaryProps {
   people: Person[];
@@ -18,60 +19,91 @@ interface ResultsSummaryProps {
   receiptDate: string | null;
 }
 
-export function ResultsSummary({ people, receiptName, receiptDate }: ResultsSummaryProps) {
+export function ResultsSummary({
+  people,
+  receiptName,
+  receiptDate,
+}: ResultsSummaryProps) {
+  const [phoneNumber, setPhoneNumber] = useState("");
   // Sort people by final total (highest first)
   const sortedPeople = [...people].sort((a, b) => b.finalTotal - a.finalTotal);
-  
+
   // Create a shareable text summary
   const createShareText = (): string => {
-    let text = '';
-    
+    let text = "";
+
     // Add receipt info
     if (receiptName) {
       text += `Receipt for ${receiptName}\n`;
     }
-    
+
     if (receiptDate) {
       text += `Date: ${new Date(receiptDate).toLocaleDateString()}\n`;
     }
-    
-    text += '\nAmount owed by each person:\n';
-    
+
+    text += "\nAmount owed by each person:\n";
+
     // Add each person's total
-    sortedPeople.forEach(person => {
+    sortedPeople.forEach((person) => {
       text += `${person.name}: ${formatCurrency(person.finalTotal)}\n`;
     });
-    
+
     return text;
   };
-  
+
   // Share results via native sharing API or fallback to clipboard
   const shareResults = async () => {
     const text = createShareText();
-    
+
     if (navigator.share) {
       try {
         await navigator.share({
-          title: 'Receipt Split Results',
+          title: "Receipt Split Results",
           text: text,
         });
       } catch (error) {
-        console.error('Error sharing results:', error);
+        console.error("Error sharing results:", error);
         copyToClipboard(text);
       }
     } else {
       copyToClipboard(text);
     }
   };
-  
+
   // Fallback to clipboard
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      alert('Results copied to clipboard!');
+      alert("Results copied to clipboard!");
     } catch (error) {
-      console.error('Failed to copy to clipboard:', error);
-      alert('Failed to copy results. Please try again.');
+      console.error("Failed to copy to clipboard:", error);
+      alert("Failed to copy results. Please try again.");
+    }
+  };
+
+  // Helper to generate Venmo payment link
+  const getVenmoLink = (amount: number, note: string) => {
+    // Remove non-digits from phone number
+    const phone = phoneNumber.replace(/\D/g, "");
+    // Venmo expects amount in decimal, note as string
+    // https://venmo.com/paymentlinks/
+    // Example: https://venmo.com/?txn=pay&recipients=PHONE&amount=10.00&note=Restaurant
+    return `https://venmo.com/?txn=pay&recipients=${phone}&amount=${amount.toFixed(
+      2
+    )}&note=${encodeURIComponent(note)}`;
+  };
+
+  // Share or open Venmo link
+  const handleVenmoClick = (person: Person) => {
+    const note = receiptName || "Receipt Split";
+    const link = getVenmoLink(person.finalTotal, note);
+    if (navigator.share) {
+      navigator.share({
+        title: `Pay ${person.name} via Venmo`,
+        url: link,
+      });
+    } else {
+      window.open(link, "_blank");
     }
   };
 
@@ -80,44 +112,77 @@ export function ResultsSummary({ people, receiptName, receiptDate }: ResultsSumm
   }
 
   return (
-    <Card className="w-full">
-      <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle className="text-xl">Results Summary</CardTitle>
-        <Button 
-          variant="outline" 
-          size="sm" 
-          className="flex items-center gap-1"
-          onClick={shareResults}
-        >
-          <Share className="h-4 w-4" />
-          <span>Share</span>
-        </Button>
-      </CardHeader>
-      
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Person</TableHead>
-              <TableHead className="text-right">Subtotal</TableHead>
-              <TableHead className="text-right">Tax</TableHead>
-              <TableHead className="text-right">Tip</TableHead>
-              <TableHead className="text-right">Total</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {sortedPeople.map((person) => (
-              <TableRow key={person.id}>
-                <TableCell className="font-medium">{person.name}</TableCell>
-                <TableCell className="text-right">{formatCurrency(person.totalBeforeTax)}</TableCell>
-                <TableCell className="text-right">{formatCurrency(person.tax)}</TableCell>
-                <TableCell className="text-right">{formatCurrency(person.tip)}</TableCell>
-                <TableCell className="text-right font-bold">{formatCurrency(person.finalTotal)}</TableCell>
+    <div className="w-full flex flex-col gap-4">
+      <div className="flex flex-col sm:flex-row items-center gap-2 mb-2">
+        <label htmlFor="venmo-phone" className="font-medium">
+          Your Phone Number (for Venmo):
+        </label>
+        <input
+          id="venmo-phone"
+          type="tel"
+          placeholder="e.g. 555-123-4567"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+          className="w-full sm:w-64 border rounded px-3 py-1"
+        />
+      </div>
+      <Card className="w-full">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-xl">Results Summary</CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex items-center gap-1"
+            onClick={shareResults}
+          >
+            <Share className="h-4 w-4" />
+            <span>Share</span>
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Person</TableHead>
+                <TableHead className="text-right">Subtotal</TableHead>
+                <TableHead className="text-right">Tax</TableHead>
+                <TableHead className="text-right">Tip</TableHead>
+                <TableHead className="text-right">Total</TableHead>
+                <TableHead className="text-right">Venmo</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
+            </TableHeader>
+            <TableBody>
+              {sortedPeople.map((person) => (
+                <TableRow key={person.id}>
+                  <TableCell className="font-medium">{person.name}</TableCell>
+                  <TableCell className="text-right">
+                    {formatCurrency(person.totalBeforeTax)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {formatCurrency(person.tax)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {formatCurrency(person.tip)}
+                  </TableCell>
+                  <TableCell className="text-right font-bold">
+                    {formatCurrency(person.finalTotal)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={!phoneNumber.replace(/\D/g, "")}
+                      onClick={() => handleVenmoClick(person)}
+                    >
+                      Venmo Link
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

This PR implements the feature described in [issue #14](https://github.com/narulaskaran/receipt-splitter/issues/14):

- Adds a phone number input above the Results Summary card for the user to enter their phone number (used to generate Venmo payment links).
- Adds a new column to the Results Summary table with a Venmo button for each person.
- Clicking the Venmo button generates a Venmo payment link for the amount owed by that person, pre-populates the note with the restaurant name, and uses the entered phone number as the recipient.
- On mobile, clicking the button uses the device's share menu if available; otherwise, it opens the link in a new tab.

### Why?

This makes it easy to send or share Venmo payment links for each person directly from the results screen, improving the payment experience after splitting a receipt.

---

**Closes #14**
