### PR TITLE
feat: add Vercel SpeedInsights to root layout

### DIFF
--- a/CURSOR.md
+++ b/CURSOR.md
@@ -64,6 +64,8 @@ ANTHROPIC_API_KEY=your_api_key_here
 
 Vercel Web Analytics is integrated using the `@vercel/analytics` package. The `<Analytics />` component is included in the root layout (`src/app/layout.tsx`) to enable privacy-friendly, cookieless analytics and page view tracking. Analytics data is viewable in the Vercel dashboard under the Analytics tab for the project.
 
+**Vercel SpeedInsights** is also integrated using the `@vercel/speed-insights` package. The `<SpeedInsights />` component is included in the root layout (`src/app/layout.tsx`) after `<Analytics />` to provide real user performance metrics. SpeedInsights data is available in the Vercel dashboard under the Speed Insights tab for the project.
+
 ## Development Commands
 
 - `npm run dev` - Start development server

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-slot": "^1.2.1",
         "@radix-ui/react-tabs": "^1.1.10",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "decimal.js": "^10.5.0",
@@ -2579,6 +2580,41 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-slot": "^1.2.1",
     "@radix-ui/react-tabs": "^1.1.10",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "decimal.js": "^10.5.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -40,6 +41,7 @@ export default function RootLayout({
           <Toaster />
         </ThemeProvider>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
# Add Vercel SpeedInsights to Receipt Splitter

## Summary

This PR adds [Vercel SpeedInsights](https://vercel.com/docs/analytics/speed-insights) to the project to provide real user performance metrics alongside existing Vercel Analytics.

## Implementation Details

- Installed `@vercel/speed-insights` package.
- Imported and rendered the `<SpeedInsights />` component in `src/app/layout.tsx`, immediately after `<Analytics />`.
- No breaking changes; SpeedInsights works automatically in Vercel deployments.

## Documentation

- Updated `CURSOR.md` to document the addition of SpeedInsights in the Analytics section.

## Testing

- Confirmed that the app builds and runs locally.
- SpeedInsights will appear in the Vercel dashboard under the Speed Insights tab after deployment.

---

Let me know if you have any questions or need further changes!
