### PR TITLE
Add receipt-level invariant validation helper

### DIFF
--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -3,9 +3,10 @@ import {
   validateItemAssignments,
   formatCurrency,
   getUnassignedItems,
+  validateReceiptInvariants,
 } from "./receipt-utils";
 import { mockPeople, mockReceipt, mockAssignedItems } from "@/test/test-utils";
-import { type PersonItemAssignment } from "@/types";
+import { type PersonItemAssignment, type Receipt, type Person } from "@/types";
 import { formatAmount } from "./utils";
 
 describe("receipt-utils", () => {
@@ -206,5 +207,429 @@ describe("$0 item handling", () => {
     ]);
 
     expect(validateItemAssignments(receiptWithZeroItem, incompleteAssignments)).toBe(false);
+  });
+});
+
+describe("validateReceiptInvariants", () => {
+  describe("valid receipts", () => {
+    it("returns valid for null receipt", () => {
+      const result = validateReceiptInvariants(null, new Map(), []);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("returns valid for properly structured receipt with valid splits", () => {
+      const people = calculatePersonTotals(mockReceipt, mockPeople, mockAssignedItems);
+      const result = validateReceiptInvariants(mockReceipt, mockAssignedItems, people);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("returns valid for receipt with items that sum to subtotal within tolerance", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 10.00,
+        tax: 1.00,
+        tip: 2.00,
+        total: 13.00,
+        items: [
+          { name: "Item 1", price: 3.33, quantity: 1 },
+          { name: "Item 2", price: 3.33, quantity: 1 },
+          { name: "Item 3", price: 3.34, quantity: 1 },
+        ],
+      };
+      const assignments = new Map<number, PersonItemAssignment[]>([
+        [0, [{ personId: "a", sharePercentage: 100 }]],
+        [1, [{ personId: "b", sharePercentage: 100 }]],
+        [2, [{ personId: "a", sharePercentage: 100 }]],
+      ]);
+      const people = calculatePersonTotals(receipt, mockPeople, assignments);
+      const result = validateReceiptInvariants(receipt, assignments, people);
+      expect(result.isValid).toBe(true);
+    });
+
+    it("returns valid for items with splits that sum to item price within tolerance", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 10.00,
+        tax: 1.00,
+        tip: 2.00,
+        total: 13.00,
+        items: [
+          { name: "Shared Item", price: 10.00, quantity: 1 },
+        ],
+      };
+      const assignments = new Map<number, PersonItemAssignment[]>([
+        [0, [
+          { personId: "a", sharePercentage: 33.33 },
+          { personId: "b", sharePercentage: 33.33 },
+          { personId: "c", sharePercentage: 33.34 },
+        ]],
+      ]);
+      const people = calculatePersonTotals(receipt, mockPeople, assignments);
+      const result = validateReceiptInvariants(receipt, assignments, people);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe("negative amounts in receipt", () => {
+    it("detects negative subtotal", () => {
+      const receipt: Receipt = {
+        ...mockReceipt,
+        subtotal: -10,
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_SUBTOTAL',
+          message: 'Receipt subtotal cannot be negative',
+        })
+      );
+    });
+
+    it("detects negative tax", () => {
+      const receipt: Receipt = {
+        ...mockReceipt,
+        tax: -5,
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_TAX',
+          message: 'Receipt tax cannot be negative',
+        })
+      );
+    });
+
+    it("detects negative tip", () => {
+      const receipt: Receipt = {
+        ...mockReceipt,
+        tip: -2,
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_TIP',
+          message: 'Receipt tip cannot be negative',
+        })
+      );
+    });
+
+    it("detects negative total", () => {
+      const receipt: Receipt = {
+        ...mockReceipt,
+        total: -100,
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_TOTAL',
+          message: 'Receipt total cannot be negative',
+        })
+      );
+    });
+  });
+
+  describe("negative amounts in items", () => {
+    it("detects negative item price", () => {
+      const receipt: Receipt = {
+        ...mockReceipt,
+        items: [{ name: "Bad Item", price: -10, quantity: 1 }],
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_ITEM_PRICE',
+          message: 'Item "Bad Item" has negative price',
+          itemName: 'Bad Item',
+        })
+      );
+    });
+
+    it("detects negative item quantity", () => {
+      const receipt: Receipt = {
+        ...mockReceipt,
+        items: [{ name: "Bad Quantity", price: 10, quantity: -2 }],
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_ITEM_QUANTITY',
+          message: 'Item "Bad Quantity" has negative quantity',
+          itemName: 'Bad Quantity',
+        })
+      );
+    });
+  });
+
+  describe("items sum validation", () => {
+    it("detects when items do not sum to subtotal", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 100.00, // Items sum to 50, but subtotal says 100
+        tax: 10.00,
+        tip: 15.00,
+        total: 125.00,
+        items: [
+          { name: "Item 1", price: 25, quantity: 1 },
+          { name: "Item 2", price: 25, quantity: 1 },
+        ],
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'ITEMS_SUBTOTAL_MISMATCH',
+          message: 'Sum of item prices does not match subtotal',
+          expected: 100.00,
+          actual: 50.00,
+        })
+      );
+    });
+
+    it("allows small rounding differences within tolerance", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 10.00,
+        tax: 1.00,
+        tip: 2.00,
+        total: 13.00,
+        items: [
+          { name: "Item 1", price: 3.33, quantity: 1 },
+          { name: "Item 2", price: 3.34, quantity: 1 },
+          { name: "Item 3", price: 3.33, quantity: 1 },
+        ],
+      };
+      // Items sum to 10.00, subtotal is 10.00 - should be valid
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe("item splits validation", () => {
+    it("detects when splits do not sum to item price", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 100.00,
+        tax: 10.00,
+        tip: 15.00,
+        total: 125.00,
+        items: [
+          { name: "Shared Item", price: 100, quantity: 1 },
+        ],
+      };
+      // Assignments only add up to 90%, not 100%
+      const assignments = new Map<number, PersonItemAssignment[]>([
+        [0, [
+          { personId: "a", sharePercentage: 45 },
+          { personId: "b", sharePercentage: 45 },
+        ]],
+      ]);
+      const people = calculatePersonTotals(receipt, mockPeople, assignments);
+      const result = validateReceiptInvariants(receipt, assignments, people);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'ITEM_SPLITS_MISMATCH',
+          message: 'Sum of splits for item "Shared Item" does not match item price',
+          itemName: 'Shared Item',
+        })
+      );
+    });
+
+    it("allows small rounding differences in splits within tolerance", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 10.00,
+        tax: 1.00,
+        tip: 2.00,
+        total: 13.00,
+        items: [
+          { name: "Shared Item", price: 10.00, quantity: 1 },
+        ],
+      };
+      // 33.33 + 33.33 + 33.34 = 100%, should be within tolerance
+      const assignments = new Map<number, PersonItemAssignment[]>([
+        [0, [
+          { personId: "a", sharePercentage: 33.33 },
+          { personId: "b", sharePercentage: 33.33 },
+          { personId: "c", sharePercentage: 33.34 },
+        ]],
+      ]);
+      const people = calculatePersonTotals(receipt, mockPeople, assignments);
+      const result = validateReceiptInvariants(receipt, assignments, people);
+      expect(result.isValid).toBe(true);
+    });
+
+    it("skips validation for unassigned items", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: 100.00,
+        tax: 10.00,
+        tip: 15.00,
+        total: 125.00,
+        items: [
+          { name: "Unassigned Item", price: 100, quantity: 1 },
+        ],
+      };
+      const assignments = new Map<number, PersonItemAssignment[]>();
+      const result = validateReceiptInvariants(receipt, assignments, []);
+      // Should not fail on splits mismatch for unassigned items
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({
+          type: 'ITEM_SPLITS_MISMATCH',
+        })
+      );
+    });
+  });
+
+  describe("negative amounts in person data", () => {
+    it("detects negative person totalBeforeTax", () => {
+      const person: Person = {
+        id: "test",
+        name: "Test Person",
+        items: [],
+        totalBeforeTax: -10,
+        tax: 0,
+        tip: 0,
+        finalTotal: 0,
+      };
+      const result = validateReceiptInvariants(mockReceipt, new Map(), [person]);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_PERSON_TOTAL',
+          message: 'Person "Test Person" has negative total before tax',
+        })
+      );
+    });
+
+    it("detects negative person tax", () => {
+      const person: Person = {
+        id: "test",
+        name: "Test Person",
+        items: [],
+        totalBeforeTax: 10,
+        tax: -1,
+        tip: 0,
+        finalTotal: 9,
+      };
+      const result = validateReceiptInvariants(mockReceipt, new Map(), [person]);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_PERSON_TAX',
+          message: 'Person "Test Person" has negative tax',
+        })
+      );
+    });
+
+    it("detects negative person tip", () => {
+      const person: Person = {
+        id: "test",
+        name: "Test Person",
+        items: [],
+        totalBeforeTax: 10,
+        tax: 1,
+        tip: -2,
+        finalTotal: 9,
+      };
+      const result = validateReceiptInvariants(mockReceipt, new Map(), [person]);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_PERSON_TIP',
+          message: 'Person "Test Person" has negative tip',
+        })
+      );
+    });
+
+    it("detects negative person finalTotal", () => {
+      const person: Person = {
+        id: "test",
+        name: "Test Person",
+        items: [],
+        totalBeforeTax: 0,
+        tax: 0,
+        tip: 0,
+        finalTotal: -10,
+      };
+      const result = validateReceiptInvariants(mockReceipt, new Map(), [person]);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_PERSON_FINAL_TOTAL',
+          message: 'Person "Test Person" has negative final total',
+        })
+      );
+    });
+
+    it("detects negative person item amount", () => {
+      const person: Person = {
+        id: "test",
+        name: "Test Person",
+        items: [
+          {
+            itemId: 0,
+            itemName: "Bad Item",
+            originalPrice: 10,
+            quantity: 1,
+            sharePercentage: 100,
+            amount: -10,
+          },
+        ],
+        totalBeforeTax: 0,
+        tax: 0,
+        tip: 0,
+        finalTotal: 0,
+      };
+      const result = validateReceiptInvariants(mockReceipt, new Map(), [person]);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          type: 'NEGATIVE_PERSON_ITEM_AMOUNT',
+          message: 'Person "Test Person" has negative amount for item "Bad Item"',
+          itemName: 'Bad Item',
+        })
+      );
+    });
+  });
+
+  describe("multiple errors", () => {
+    it("reports all validation errors found", () => {
+      const receipt: Receipt = {
+        restaurant: "Test Restaurant",
+        date: "2024-01-01",
+        subtotal: -10, // Negative
+        tax: -1, // Negative
+        tip: -2, // Negative
+        total: -13, // Negative
+        items: [
+          { name: "Bad Item", price: -5, quantity: -1 }, // Both negative
+        ],
+      };
+      const result = validateReceiptInvariants(receipt, new Map(), []);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThanOrEqual(6);
+      expect(result.errors).toContainEqual(expect.objectContaining({ type: 'NEGATIVE_SUBTOTAL' }));
+      expect(result.errors).toContainEqual(expect.objectContaining({ type: 'NEGATIVE_TAX' }));
+      expect(result.errors).toContainEqual(expect.objectContaining({ type: 'NEGATIVE_TIP' }));
+      expect(result.errors).toContainEqual(expect.objectContaining({ type: 'NEGATIVE_TOTAL' }));
+      expect(result.errors).toContainEqual(expect.objectContaining({ type: 'NEGATIVE_ITEM_PRICE' }));
+      expect(result.errors).toContainEqual(expect.objectContaining({ type: 'NEGATIVE_ITEM_QUANTITY' }));
+    });
   });
 });

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -1,5 +1,6 @@
 import Decimal from 'decimal.js';
 import { type Person, type Receipt, type PersonItem, type PersonItemAssignment } from '@/types';
+import { VALIDATION_LIMITS } from './split-sharing';
 
 /**
  * Calculates the proportion of tax and tip each person should pay based on their items
@@ -121,23 +122,270 @@ export function getUnassignedItems(
   assignedItems: Map<number, PersonItemAssignment[]>
 ): number[] {
   if (!receipt?.items?.length) return [];
-  
+
   const unassignedItems: number[] = [];
-  
+
   for (let i = 0; i < receipt.items.length; i++) {
     const assignments = assignedItems.get(i) || [];
-    
+
     // Sum up all share percentages for this item
     const totalPercentage = assignments.reduce(
-      (sum, assignment) => sum + assignment.sharePercentage, 
+      (sum, assignment) => sum + assignment.sharePercentage,
       0
     );
-    
+
     // If not fully assigned, add to unassigned list
     if (Math.abs(totalPercentage - 100) > 0.01) {
       unassignedItems.push(i);
     }
   }
-  
+
   return unassignedItems;
+}
+
+/**
+ * Error information for receipt validation
+ */
+export interface ReceiptValidationError {
+  type: string;
+  message: string;
+  itemId?: string;
+  itemName?: string;
+  expected?: number;
+  actual?: number;
+  diff?: number;
+  tolerance?: number;
+}
+
+/**
+ * Result of receipt invariant validation
+ */
+export interface ReceiptValidationResult {
+  isValid: boolean;
+  errors: ReceiptValidationError[];
+}
+
+/**
+ * Validates receipt-level invariants to catch state inconsistencies
+ *
+ * This function checks that:
+ * - Items sum to subtotal (within tolerance)
+ * - Each item's splits sum to that item's price (within tolerance)
+ * - No negative amounts in items or splits
+ *
+ * @param receipt - The receipt to validate
+ * @param assignedItems - Map of item assignments
+ * @param people - Array of people with calculated amounts
+ * @returns ReceiptValidationResult with detailed error information
+ */
+export function validateReceiptInvariants(
+  receipt: Receipt | null,
+  assignedItems: Map<number, PersonItemAssignment[]>,
+  people: Person[]
+): ReceiptValidationResult {
+  const errors: ReceiptValidationError[] = [];
+
+  // Return valid if no receipt
+  if (!receipt) {
+    return { isValid: true, errors: [] };
+  }
+
+  // 1. Validate no negative amounts in receipt
+  if (receipt.subtotal < 0) {
+    errors.push({
+      type: 'NEGATIVE_SUBTOTAL',
+      message: 'Receipt subtotal cannot be negative',
+      expected: 0,
+      actual: receipt.subtotal,
+    });
+  }
+
+  if (receipt.tax < 0) {
+    errors.push({
+      type: 'NEGATIVE_TAX',
+      message: 'Receipt tax cannot be negative',
+      expected: 0,
+      actual: receipt.tax,
+    });
+  }
+
+  if (receipt.tip !== null && receipt.tip < 0) {
+    errors.push({
+      type: 'NEGATIVE_TIP',
+      message: 'Receipt tip cannot be negative',
+      expected: 0,
+      actual: receipt.tip,
+    });
+  }
+
+  if (receipt.total < 0) {
+    errors.push({
+      type: 'NEGATIVE_TOTAL',
+      message: 'Receipt total cannot be negative',
+      expected: 0,
+      actual: receipt.total,
+    });
+  }
+
+  // 2. Validate no negative amounts in items
+  receipt.items.forEach((item, index) => {
+    if (item.price < 0) {
+      errors.push({
+        type: 'NEGATIVE_ITEM_PRICE',
+        message: `Item "${item.name}" has negative price`,
+        itemId: String(index),
+        itemName: item.name,
+        expected: 0,
+        actual: item.price,
+      });
+    }
+
+    if (item.quantity < 0) {
+      errors.push({
+        type: 'NEGATIVE_ITEM_QUANTITY',
+        message: `Item "${item.name}" has negative quantity`,
+        itemId: String(index),
+        itemName: item.name,
+        expected: 0,
+        actual: item.quantity,
+      });
+    }
+  });
+
+  // 3. Validate items sum to subtotal (within tolerance)
+  if (receipt.items.length > 0) {
+    const itemsTotal = new Decimal(
+      receipt.items.reduce((sum, item) => {
+        const itemPrice = new Decimal(item.price);
+        const itemQuantity = new Decimal(item.quantity || 1);
+        return sum.add(itemPrice.mul(itemQuantity));
+      }, new Decimal(0))
+    );
+
+    const subtotal = new Decimal(receipt.subtotal);
+    const difference = itemsTotal.sub(subtotal).abs();
+
+    // Dynamic tolerance: 1 cent per item to account for rounding
+    const dynamicTolerance = VALIDATION_LIMITS.SPLIT_AMOUNT_DEVIATION_PER_PERSON * receipt.items.length;
+    const toleranceDecimal = new Decimal(dynamicTolerance);
+
+    // Round to 2 decimal places to avoid floating point precision issues
+    const roundedDifference = difference.toDecimalPlaces(2).toNumber();
+    const roundedTolerance = toleranceDecimal.toDecimalPlaces(2).toNumber();
+
+    if (roundedDifference > roundedTolerance) {
+      errors.push({
+        type: 'ITEMS_SUBTOTAL_MISMATCH',
+        message: 'Sum of item prices does not match subtotal',
+        expected: subtotal.toNumber(),
+        actual: itemsTotal.toNumber(),
+        diff: difference.toNumber(),
+        tolerance: dynamicTolerance,
+      });
+    }
+  }
+
+  // 4. Validate each item's splits sum to that item's price (within tolerance)
+  receipt.items.forEach((item, itemIndex) => {
+    const assignments = assignedItems.get(itemIndex) || [];
+
+    if (assignments.length === 0) {
+      // Skip unassigned items
+      return;
+    }
+
+    const itemPrice = new Decimal(item.price);
+    const itemQuantity = new Decimal(item.quantity || 1);
+    const totalItemPrice = itemPrice.mul(itemQuantity);
+
+    // Calculate sum of all split amounts for this item
+    const splitsTotal = assignments.reduce((sum, assignment) => {
+      const sharePercentage = new Decimal(assignment.sharePercentage);
+      const personShare = totalItemPrice.isZero()
+        ? new Decimal(0)
+        : totalItemPrice.mul(sharePercentage).div(100);
+      return sum.add(personShare);
+    }, new Decimal(0));
+
+    const difference = splitsTotal.sub(totalItemPrice).abs();
+
+    // Dynamic tolerance: 1 cent per person assigned to this item
+    const participantCount = assignments.length;
+    const dynamicTolerance = VALIDATION_LIMITS.SPLIT_AMOUNT_DEVIATION_PER_PERSON * participantCount;
+    const toleranceDecimal = new Decimal(dynamicTolerance);
+
+    // Round to 2 decimal places to avoid floating point precision issues
+    const roundedDifference = difference.toDecimalPlaces(2).toNumber();
+    const roundedTolerance = toleranceDecimal.toDecimalPlaces(2).toNumber();
+
+    if (roundedDifference > roundedTolerance) {
+      errors.push({
+        type: 'ITEM_SPLITS_MISMATCH',
+        message: `Sum of splits for item "${item.name}" does not match item price`,
+        itemId: String(itemIndex),
+        itemName: item.name,
+        expected: totalItemPrice.toNumber(),
+        actual: splitsTotal.toNumber(),
+        diff: difference.toNumber(),
+        tolerance: dynamicTolerance,
+      });
+    }
+  });
+
+  // 5. Validate no negative amounts in person items
+  people.forEach((person) => {
+    if (person.totalBeforeTax < 0) {
+      errors.push({
+        type: 'NEGATIVE_PERSON_TOTAL',
+        message: `Person "${person.name}" has negative total before tax`,
+        expected: 0,
+        actual: person.totalBeforeTax,
+      });
+    }
+
+    if (person.tax < 0) {
+      errors.push({
+        type: 'NEGATIVE_PERSON_TAX',
+        message: `Person "${person.name}" has negative tax`,
+        expected: 0,
+        actual: person.tax,
+      });
+    }
+
+    if (person.tip < 0) {
+      errors.push({
+        type: 'NEGATIVE_PERSON_TIP',
+        message: `Person "${person.name}" has negative tip`,
+        expected: 0,
+        actual: person.tip,
+      });
+    }
+
+    if (person.finalTotal < 0) {
+      errors.push({
+        type: 'NEGATIVE_PERSON_FINAL_TOTAL',
+        message: `Person "${person.name}" has negative final total`,
+        expected: 0,
+        actual: person.finalTotal,
+      });
+    }
+
+    person.items.forEach((item) => {
+      if (item.amount < 0) {
+        errors.push({
+          type: 'NEGATIVE_PERSON_ITEM_AMOUNT',
+          message: `Person "${person.name}" has negative amount for item "${item.itemName}"`,
+          itemId: String(item.itemId),
+          itemName: item.itemName,
+          expected: 0,
+          actual: item.amount,
+        });
+      }
+    });
+  });
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
 }


### PR DESCRIPTION
## Summary

Implements comprehensive validation function that checks receipt-level invariants to catch state inconsistencies early during development.

## Changes

- Added `validateReceiptInvariants()` function to `receipt-utils.ts`
- Added `ReceiptValidationError` and `ReceiptValidationResult` interfaces
- Comprehensive test coverage with 21 new tests
- Uses existing `VALIDATION_LIMITS.SPLIT_AMOUNT_DEVIATION_PER_PERSON` tolerance system

## Validation Features

The function validates:
- ✅ Items sum to subtotal (within tolerance)
- ✅ Each item's splits sum to that item's price (within tolerance)
- ✅ No negative amounts in receipt fields (subtotal, tax, tip, total)
- ✅ No negative amounts in items (price, quantity)
- ✅ No negative amounts in person data (totals, tax, tip, item amounts)

## Dynamic Tolerance System

- For items-to-subtotal validation: 1 cent per item
- For item splits validation: 1 cent per person assigned to the item
- Follows same rounding logic as `validateSplitDataDetailed()`

## Test Coverage

- 21 new tests covering all validation scenarios
- Tests for valid receipts, negative amounts, sum mismatches, tolerance handling
- All tests passing ✅

## Next Steps

This validation helper is ready to be integrated into the UI in issue #55, which will:
- Display validation errors to users
- Remove console logging (not added in this PR as per requirements)
- Add visual indicators for validation issues

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)