### PR TITLE
Update documentation for screenshot harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,43 @@ src/
 ## Common Commands
 
 ```bash
-npm run dev       # Start development server
-npm run build     # Build for production
-npm run lint      # Run ESLint
-npm test          # Run Jest tests
-npm run test:watch # Run tests in watch mode
+npm run dev           # Start development server
+npm run build         # Build for production
+npm run lint          # Run ESLint
+npm test              # Run Jest tests
+npm run test:watch    # Run tests in watch mode
+npm run screenshots   # Take screenshots at multiple viewports
 ```
+
+### Screenshot Harness
+
+The project includes a Playwright-based screenshot tool for visual testing and documentation:
+
+```bash
+# Basic usage (requires dev server running: npm run dev)
+npm run screenshots -- --mock-data
+
+# Screenshot all tabs (upload, people, assign, results)
+npm run screenshots -- --mock-data --tab all
+
+# Screenshot specific tab
+npm run screenshots -- --mock-data --tab people
+
+# Screenshot /split route
+npm run screenshots -- --route /split --mock-data
+
+# Custom output directory
+npm run screenshots -- --mock-data --output ./my-screenshots
+```
+
+Options:
+- `--route <path>`: Route to screenshot (default: `/`)
+- `--tab <name>`: Which tab to show: `upload`, `people`, `assign`, `results`, or `all` (default: `results`)
+- `--mock-data`: Inject synthetic localStorage data
+- `--params <query>`: URL query parameters
+- `--output <dir>`: Output directory (default: `screenshots`)
+
+Screenshots are saved in the `/screenshots` directory (gitignored) and include 7 viewport sizes from mobile to desktop.
 
 ## Key Types
 
@@ -90,6 +121,8 @@ import { calculateTotals } from '@/lib/receipt-utils';
 - Use `@testing-library/react` for component tests
 - Mock external dependencies (localStorage, fetch, etc.)
 - Test utilities are in `src/test/test-utils.ts`
+- Playwright configuration in `playwright.config.ts` for e2e tests
+- Screenshot harness in `scripts/screenshot-harness.js` for visual testing
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A web application for easily splitting receipts among friends and groups. No app
 - **State Management**: React hooks with localStorage persistence
 - **Validation**: Custom validation with detailed error reporting
 - **Payment Integration**: Venmo payment link generation
-- **Testing**: Jest with React Testing Library
+- **Testing**: Jest with React Testing Library, Playwright for visual testing
 - **Deployment**: Vercel with automatic deployments
 - **Analytics**: Vercel Web Analytics and SpeedInsights
 
@@ -93,6 +93,25 @@ Build for production:
 ```bash
 npm run build
 ```
+
+### Visual Testing
+
+The project includes a screenshot harness for capturing UI states across multiple viewports:
+
+```bash
+# Requires dev server running (npm run dev)
+
+# Screenshot all tabs with mock data
+npm run screenshots -- --mock-data --tab all
+
+# Screenshot specific tab
+npm run screenshots -- --mock-data --tab results
+
+# Screenshot /split route
+npm run screenshots -- --route /split --mock-data
+```
+
+Screenshots are saved to the `/screenshots` directory (gitignored) and include 7 viewport sizes: mobile-small (320px), mobile (375px), mobile-large (414px), tablet (768px), tablet-landscape (1024px), desktop (1280px), and desktop-large (1920px).
 
 ## Key Components
 


### PR DESCRIPTION
## Summary
Updates CLAUDE.md and README.md to document the new screenshot harness feature added in #79.

## Changes

### CLAUDE.md
- Added `npm run screenshots` to Common Commands section
- Added new "Screenshot Harness" section with:
  - Usage examples for all screenshot options
  - All CLI flags and options documented
  - Notes about viewport sizes and output directory
- Updated Testing Patterns to mention Playwright config and screenshot harness

### README.md
- Updated Technology Stack to mention "Playwright for visual testing"
- Added new "Visual Testing" section in Development area with:
  - Common screenshot commands
  - Documentation of 7 viewport sizes
  - Note about gitignored output directory

## Why
Developers and contributors need to know about the screenshot harness tool for:
- Visual regression testing
- UI documentation
- Cross-viewport testing
- PR reviews with visual evidence

The documentation now provides clear examples of how to use the tool for various scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)