### PR TITLE
Add geolocation data to Slack webhook notifications

### DIFF
--- a/src/lib/webhook-notifications.test.ts
+++ b/src/lib/webhook-notifications.test.ts
@@ -37,7 +37,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         expect(global.fetch).toHaveBeenCalledWith(
@@ -87,7 +88,8 @@ describe('webhook-notifications', () => {
           null, // No file URL
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         const callBody = JSON.parse(
@@ -111,7 +113,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         const callBody = JSON.parse(
@@ -141,7 +144,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         expect(global.fetch).toHaveBeenCalledWith(
@@ -188,7 +192,8 @@ describe('webhook-notifications', () => {
           null,
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         const callBody = JSON.parse(
@@ -208,7 +213,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         expect(global.fetch).not.toHaveBeenCalled();
@@ -223,7 +229,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         expect(global.fetch).not.toHaveBeenCalled();
@@ -240,7 +247,8 @@ describe('webhook-notifications', () => {
             'https://example.com/receipt.jpg',
             'test-session-id',
             'receipt.jpg',
-            'image/jpeg'
+            'image/jpeg',
+            null
           )
         ).resolves.toBeUndefined();
       });
@@ -260,7 +268,8 @@ describe('webhook-notifications', () => {
             'https://example.com/receipt.jpg',
             'test-session-id',
             'receipt.jpg',
-            'image/jpeg'
+            'image/jpeg',
+            null
           )
         ).resolves.toBeUndefined();
       });
@@ -273,12 +282,92 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         const fetchCall = (global.fetch as jest.Mock).mock.calls[0][1];
         expect(fetchCall.signal).toBeDefined();
         expect(fetchCall.signal.constructor.name).toBe('AbortSignal');
+      });
+    });
+
+    describe('with geolocation data', () => {
+      it('includes geolocation in Slack webhook when provided', async () => {
+        process.env.WEBHOOK_URL = 'https://hooks.slack.com/test';
+
+        const geolocation = {
+          country: 'US',
+          region: 'CA',
+          city: 'San Francisco',
+          latitude: '37.7749',
+          longitude: '-122.4194',
+        };
+
+        await sendReceiptParsedNotification(
+          mockReceipt,
+          'https://example.com/receipt.jpg',
+          'test-session-id',
+          'receipt.jpg',
+          'image/jpeg',
+          geolocation
+        );
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        const bodyString = JSON.stringify(callBody);
+        expect(bodyString).toContain('San Francisco, CA, US');
+      });
+
+      it('includes geolocation in JSON webhook when provided', async () => {
+        process.env.WEBHOOK_URL = 'https://example.com/webhook';
+        process.env.WEBHOOK_TYPE = 'json';
+
+        const geolocation = {
+          country: 'US',
+          region: 'CA',
+          city: 'San Francisco',
+          latitude: '37.7749',
+          longitude: '-122.4194',
+        };
+
+        await sendReceiptParsedNotification(
+          mockReceipt,
+          'https://example.com/receipt.jpg',
+          'test-session-id',
+          'receipt.jpg',
+          'image/jpeg',
+          geolocation
+        );
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        expect(callBody.geolocation).toEqual(geolocation);
+      });
+
+      it('handles null geolocation gracefully', async () => {
+        process.env.WEBHOOK_URL = 'https://hooks.slack.com/test';
+
+        await sendReceiptParsedNotification(
+          mockReceipt,
+          'https://example.com/receipt.jpg',
+          'test-session-id',
+          'receipt.jpg',
+          'image/jpeg',
+          null
+        );
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        // Should not have a location section when geolocation is null
+        const bodyString = JSON.stringify(callBody);
+        expect(bodyString).not.toContain('*Location:*');
       });
     });
 
@@ -297,7 +386,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         const callBody = JSON.parse(
@@ -321,7 +411,8 @@ describe('webhook-notifications', () => {
           'https://example.com/receipt.jpg',
           'test-session-id',
           'receipt.jpg',
-          'image/jpeg'
+          'image/jpeg',
+          null
         );
 
         const callBody = JSON.parse(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,3 +65,12 @@ export interface ItemAssignment {
   personId: string;
   sharePercentage: number;
 }
+
+// Geolocation data from Vercel headers
+export interface GeolocationData {
+  country: string | null;      // x-vercel-ip-country
+  region: string | null;        // x-vercel-ip-country-region
+  city: string | null;          // x-vercel-ip-city
+  latitude: string | null;      // x-vercel-ip-latitude
+  longitude: string | null;     // x-vercel-ip-longitude
+}


### PR DESCRIPTION
This PR adds geolocation data from Vercel's built-in headers to the webhook notifications sent when a receipt is parsed.

## Changes

- New `GeolocationData` type for country, region, city, latitude, and longitude
- Updated `ReceiptWebhookData` interface to include geolocation field
- Geolocation extraction helper function in parse-receipt API route
- Updated Slack formatter to display location (city, region, country)
- Updated JSON formatter to include geolocation in the payload
- Comprehensive test coverage for geolocation handling

## Testing

The feature gracefully handles missing geolocation data (returns null in local dev without Vercel CLI) and maintains backward compatibility.

Closes #97

---
Generated with [Claude Code](https://claude.ai/code)