### PR TITLE
Add Slack error notifications for receipt parsing failures

### DIFF
--- a/src/app/api/cron/cleanup-old-receipts/route.ts
+++ b/src/app/api/cron/cleanup-old-receipts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { listReceiptFiles, deleteReceiptFiles } from '@/lib/uploadthing-storage';
+import { sendErrorNotification } from '@/lib/webhook-notifications';
 
 const RETENTION_DAYS = 90;
 const BATCH_SIZE = 100;
@@ -100,6 +101,8 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     console.error('[Cleanup] Error during cleanup job:', errorMessage);
+
+    sendErrorNotification('cleanup_job_failure', `Cleanup cron job failed: ${errorMessage}`).catch(() => {});
 
     return NextResponse.json(
       {

--- a/src/app/api/parse-receipt/route.ts
+++ b/src/app/api/parse-receipt/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { z } from "zod";
-import { sendReceiptParsedNotification } from "@/lib/webhook-notifications";
+import { sendReceiptParsedNotification, sendErrorNotification } from "@/lib/webhook-notifications";
 import { uploadReceiptFile } from "@/lib/uploadthing-storage";
 import { MAX_FILE_SIZE_BYTES } from "@/lib/constants";
 import { type GeolocationData } from "@/types";
@@ -71,6 +71,7 @@ export async function POST(request: NextRequest) {
     // Validate API key exists
     if (!process.env.ANTHROPIC_API_KEY) {
       console.error("ANTHROPIC_API_KEY environment variable is not set");
+      sendErrorNotification("missing_api_key", "ANTHROPIC_API_KEY environment variable is not set", { geolocation }).catch(() => {});
       return NextResponse.json(
         { error: "Server configuration error: API key not found" },
         { status: 500 }
@@ -132,6 +133,31 @@ export async function POST(request: NextRequest) {
         },
         { status: 400 }
       );
+    }
+
+    // Error notification context — shared across error paths
+    const errorContext = { sessionId, fileName: file.name, mimeType, fileUrl: null as string | null, geolocation };
+
+    // Upload file to UploadThing storage BEFORE parsing
+    // This ensures the file URL is available for both success and error notifications
+    let fileUrl: string | null = null;
+    if (process.env.UPLOADTHING_TOKEN) {
+      try {
+        const uploadResult = await uploadReceiptFile(
+          Buffer.from(buffer),
+          file.name,
+          file.type,
+          sessionId
+        );
+        fileUrl = uploadResult.url;
+        errorContext.fileUrl = fileUrl;
+        if (!uploadResult.success) {
+          console.warn("[API] File upload failed, continuing without file URL:", uploadResult.error);
+        }
+      } catch (error) {
+        // Upload errors shouldn't block processing - fileUrl stays null
+        console.error("[API] Unexpected upload error:", error);
+      }
     }
 
     // Prepare content based on file type
@@ -249,6 +275,7 @@ export async function POST(request: NextRequest) {
       // Use API status codes for error detection
       if (apiError instanceof Anthropic.APIError) {
         if (apiError.status === 429) {
+          sendErrorNotification("anthropic_rate_limit", `Rate limit exceeded: ${apiError.message}`, errorContext).catch(() => {});
           return NextResponse.json(
             {
               error:
@@ -259,6 +286,7 @@ export async function POST(request: NextRequest) {
         }
 
         if (apiError.status === 400) {
+          sendErrorNotification("anthropic_bad_request", `Bad request to Anthropic API: ${apiError.message}`, errorContext).catch(() => {});
           return NextResponse.json(
             {
               error:
@@ -269,6 +297,10 @@ export async function POST(request: NextRequest) {
         }
 
         console.error("Anthropic API error details:", apiError.message, apiError.status);
+        sendErrorNotification("anthropic_api_error", `Anthropic API error (${apiError.status}): ${apiError.message}`, errorContext).catch(() => {});
+      } else {
+        const msg = apiError instanceof Error ? apiError.message : "Unknown Anthropic error";
+        sendErrorNotification("anthropic_unknown_error", msg, errorContext).catch(() => {});
       }
 
       return NextResponse.json(
@@ -285,6 +317,7 @@ export async function POST(request: NextRequest) {
       const textBlock = message.content.find((block) => block.type === "text");
       if (!textBlock || textBlock.type !== "text") {
         console.error("No text content in response");
+        sendErrorNotification("empty_response", "No text content in Anthropic response", errorContext).catch(() => {});
         return NextResponse.json(
           { error: "Failed to parse receipt. Please try again later." },
           { status: 500 }
@@ -302,6 +335,7 @@ export async function POST(request: NextRequest) {
 
       if (!validationResult.success) {
         console.error("Receipt validation failed:", validationResult.error);
+        sendErrorNotification("zod_validation", `Zod validation failed: ${validationResult.error.message}`, errorContext).catch(() => {});
         return NextResponse.json(
           { error: "Failed to parse receipt. Please try again later." },
           { status: 500 }
@@ -369,28 +403,6 @@ export async function POST(request: NextRequest) {
         items: correctedItems,
       };
 
-      // Upload file to UploadThing storage
-      // This provides a public URL for the file that can be displayed in Slack
-      // We await the upload to ensure it completes before sending the webhook
-      let fileUrl: string | null = null;
-      if (process.env.UPLOADTHING_TOKEN) {
-        try {
-          const uploadResult = await uploadReceiptFile(
-            Buffer.from(buffer),
-            file.name,
-            file.type,
-            sessionId
-          );
-          fileUrl = uploadResult.url;
-          if (!uploadResult.success) {
-            console.warn("[API] File upload failed, continuing without file URL:", uploadResult.error);
-          }
-        } catch (error) {
-          // Upload errors shouldn't block the webhook - fileUrl stays null
-          console.error("[API] Unexpected upload error:", error);
-        }
-      }
-
       // Send webhook notification after upload completes (success or failure)
       // The webhook receives fileUrl (URL if upload succeeded, null if it failed)
       if (process.env.WEBHOOK_URL) {
@@ -414,6 +426,7 @@ export async function POST(request: NextRequest) {
       const errorMsg =
         parseError instanceof Error ? parseError.message : "Unknown parse error";
       console.error("Failed to parse JSON response:", errorMsg);
+      sendErrorNotification("json_parse_error", `Failed to parse JSON response: ${errorMsg}`, errorContext).catch(() => {});
       return NextResponse.json(
         {
           error: "Failed to parse receipt. Please try again later.",
@@ -434,6 +447,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    sendErrorNotification("unexpected_error", errorMessage).catch(() => {});
     return NextResponse.json(
       {
         error:

--- a/src/lib/webhook-notifications.test.ts
+++ b/src/lib/webhook-notifications.test.ts
@@ -1,4 +1,4 @@
-import { sendReceiptParsedNotification } from './webhook-notifications';
+import { sendReceiptParsedNotification, sendErrorNotification } from './webhook-notifications';
 import { type Receipt } from '@/types';
 
 // Note: global.fetch is mocked in jest.setup.ts
@@ -454,6 +454,215 @@ describe('webhook-notifications', () => {
 
         const bodyString = JSON.stringify(callBody);
         expect(bodyString).toContain('$0.00'); // Null tip should show as $0.00
+      });
+    });
+  });
+
+  describe('sendErrorNotification', () => {
+    describe('with Slack formatter (default)', () => {
+      beforeEach(() => {
+        process.env.WEBHOOK_URL = 'https://hooks.slack.com/test';
+      });
+
+      it('sends error notification with red color attachment', async () => {
+        await sendErrorNotification('anthropic_rate_limit', 'Rate limit exceeded', {
+          sessionId: 'test-session-id',
+          fileName: 'receipt.jpg',
+          mimeType: 'image/jpeg',
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://hooks.slack.com/test',
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        expect(callBody.text).toContain('Receipt Parse Error');
+        expect(callBody.attachments).toHaveLength(1);
+        expect(callBody.attachments[0].color).toBe('#E74C3C');
+
+        const blocks = callBody.attachments[0].blocks;
+        expect(blocks).toContainEqual(
+          expect.objectContaining({
+            type: 'header',
+            text: expect.objectContaining({
+              text: '⚠️ Receipt Parse Error',
+            }),
+          })
+        );
+
+        const bodyString = JSON.stringify(blocks);
+        expect(bodyString).toContain('anthropic_rate_limit');
+        expect(bodyString).toContain('Rate limit exceeded');
+        expect(bodyString).toContain('test-session-id');
+      });
+
+      it('includes file image when fileUrl and image mimeType provided', async () => {
+        await sendErrorNotification('zod_validation', 'Validation failed', {
+          sessionId: 'test-session-id',
+          fileName: 'receipt.jpg',
+          mimeType: 'image/jpeg',
+          fileUrl: 'https://example.com/receipt.jpg',
+        });
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        const blocks = callBody.attachments[0].blocks;
+        expect(blocks).toContainEqual(
+          expect.objectContaining({
+            type: 'image',
+            image_url: 'https://example.com/receipt.jpg',
+          })
+        );
+      });
+
+      it('includes file link for PDF fileUrl', async () => {
+        await sendErrorNotification('zod_validation', 'Validation failed', {
+          fileUrl: 'https://example.com/receipt.pdf',
+          mimeType: 'application/pdf',
+        });
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        const blocks = callBody.attachments[0].blocks;
+        const bodyString = JSON.stringify(blocks);
+        expect(bodyString).toContain('View Receipt File');
+        expect(bodyString).toContain('https://example.com/receipt.pdf');
+      });
+
+      it('includes geolocation when provided', async () => {
+        await sendErrorNotification('anthropic_api_error', 'API error', {
+          sessionId: 'test-session-id',
+          geolocation: {
+            country: 'US',
+            region: 'CA',
+            city: 'San Francisco',
+            latitude: '37.7749',
+            longitude: '-122.4194',
+          },
+        });
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        const bodyString = JSON.stringify(callBody);
+        expect(bodyString).toContain('San Francisco, CA, US');
+      });
+
+      it('includes context footer with file info', async () => {
+        await sendErrorNotification('json_parse_error', 'Parse failed', {
+          fileName: 'receipt.png',
+          mimeType: 'image/png',
+        });
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        const blocks = callBody.attachments[0].blocks;
+        expect(blocks).toContainEqual(
+          expect.objectContaining({
+            type: 'context',
+            elements: expect.arrayContaining([
+              expect.objectContaining({
+                text: 'File: receipt.png (image/png)',
+              }),
+            ]),
+          })
+        );
+      });
+    });
+
+    describe('with JSON formatter', () => {
+      beforeEach(() => {
+        process.env.WEBHOOK_URL = 'https://example.com/webhook';
+        process.env.WEBHOOK_TYPE = 'json';
+      });
+
+      it('sends error in generic JSON format', async () => {
+        await sendErrorNotification('anthropic_rate_limit', 'Rate limit exceeded', {
+          sessionId: 'test-session-id',
+          fileName: 'receipt.jpg',
+          mimeType: 'image/jpeg',
+          fileUrl: 'https://example.com/receipt.jpg',
+        });
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        expect(callBody).toMatchObject({
+          event: 'receipt_parse_error',
+          errorType: 'anthropic_rate_limit',
+          errorMessage: 'Rate limit exceeded',
+          sessionId: 'test-session-id',
+          file: {
+            url: 'https://example.com/receipt.jpg',
+            name: 'receipt.jpg',
+            mimeType: 'image/jpeg',
+          },
+        });
+
+        expect(callBody.timestamp).toBeDefined();
+      });
+
+      it('handles minimal context', async () => {
+        await sendErrorNotification('unexpected_error', 'Something broke');
+
+        const callBody = JSON.parse(
+          (global.fetch as jest.Mock).mock.calls[0][1].body
+        );
+
+        expect(callBody).toMatchObject({
+          event: 'receipt_parse_error',
+          errorType: 'unexpected_error',
+          errorMessage: 'Something broke',
+          sessionId: null,
+          file: { url: null, name: null, mimeType: null },
+        });
+      });
+    });
+
+    describe('error handling', () => {
+      it('skips when webhook URL not configured', async () => {
+        delete process.env.WEBHOOK_URL;
+
+        await sendErrorNotification('test_error', 'test message');
+
+        expect(global.fetch).not.toHaveBeenCalled();
+      });
+
+      it('does not throw on fetch failure', async () => {
+        process.env.WEBHOOK_URL = 'https://example.com/webhook';
+        (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+        await expect(
+          sendErrorNotification('test_error', 'test message')
+        ).resolves.toBeUndefined();
+      });
+
+      it('does not throw on HTTP error', async () => {
+        process.env.WEBHOOK_URL = 'https://example.com/webhook';
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        });
+
+        await expect(
+          sendErrorNotification('test_error', 'test message')
+        ).resolves.toBeUndefined();
       });
     });
   });

--- a/src/lib/webhook-notifications.ts
+++ b/src/lib/webhook-notifications.ts
@@ -1,6 +1,17 @@
 import { type Receipt, type GeolocationData } from '@/types';
 
 /**
+ * Context for error notifications
+ */
+export interface ErrorNotificationContext {
+  sessionId?: string;
+  fileName?: string;
+  mimeType?: string;
+  fileUrl?: string | null;
+  geolocation?: GeolocationData | null;
+}
+
+/**
  * Metadata about a parsed receipt that will be sent via webhook
  */
 export interface ReceiptWebhookData {
@@ -36,7 +47,8 @@ interface SlackBlock {
 
 interface SlackPayload {
   text: string;
-  blocks: SlackBlock[];
+  blocks?: SlackBlock[];
+  attachments?: Array<{ color: string; blocks: SlackBlock[] }>;
 }
 
 /**
@@ -234,11 +246,142 @@ class GenericJsonFormatter implements WebhookPayloadFormatter {
 }
 
 /**
+ * Error payload formatter interface
+ */
+export interface ErrorPayloadFormatter {
+  format(errorType: string, errorMessage: string, context: ErrorNotificationContext): WebhookPayload;
+}
+
+/**
+ * Slack error notification formatter
+ */
+class SlackErrorFormatter implements ErrorPayloadFormatter {
+  format(errorType: string, errorMessage: string, context: ErrorNotificationContext): SlackPayload {
+    const blocks: SlackBlock[] = [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: '⚠️ Receipt Parse Error',
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*Error Type:*\n${errorType}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Session ID:*\n\`${context.sessionId || 'unknown'}\``,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Timestamp:*\n${new Date().toISOString()}`,
+          },
+        ],
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Error Details:*\n\`\`\`${errorMessage}\`\`\``,
+        },
+      },
+    ];
+
+    // Add file preview if URL available
+    if (context.fileUrl) {
+      const imageTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+      const isImageFile = context.mimeType && imageTypes.includes(context.mimeType);
+
+      if (isImageFile) {
+        blocks.push({
+          type: 'image',
+          image_url: context.fileUrl,
+          alt_text: 'Receipt image',
+        });
+      } else {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `📎 *Attachment:* <${context.fileUrl}|View Receipt File>`,
+          },
+        });
+      }
+    }
+
+    // Add geolocation if available
+    if (context.geolocation) {
+      const { city, region, country } = context.geolocation;
+      const locationParts = [city, region, country].filter(Boolean);
+      if (locationParts.length > 0) {
+        blocks.push({
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `*Location:*\n${locationParts.join(', ')}`,
+            },
+          ],
+        });
+      }
+    }
+
+    // Add context footer
+    if (context.fileName || context.mimeType) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `File: ${context.fileName || 'unknown'} (${context.mimeType || 'unknown'})`,
+          },
+        ],
+      });
+    }
+
+    return {
+      text: `Receipt Parse Error: ${errorType}`,
+      attachments: [{ color: '#E74C3C', blocks }],
+    } as SlackPayload;
+  }
+}
+
+/**
+ * Generic JSON error notification formatter
+ */
+class GenericJsonErrorFormatter implements ErrorPayloadFormatter {
+  format(errorType: string, errorMessage: string, context: ErrorNotificationContext): Record<string, unknown> {
+    return {
+      event: 'receipt_parse_error',
+      timestamp: new Date().toISOString(),
+      errorType,
+      errorMessage,
+      sessionId: context.sessionId || null,
+      geolocation: context.geolocation || null,
+      file: {
+        url: context.fileUrl || null,
+        name: context.fileName || null,
+        mimeType: context.mimeType || null,
+      },
+    };
+  }
+}
+
+/**
  * Available webhook formatters
  */
 const FORMATTERS: Record<string, WebhookPayloadFormatter> = {
   slack: new SlackFormatter(),
   json: new GenericJsonFormatter(),
+};
+
+const ERROR_FORMATTERS: Record<string, ErrorPayloadFormatter> = {
+  slack: new SlackErrorFormatter(),
+  json: new GenericJsonErrorFormatter(),
 };
 
 /**
@@ -338,6 +481,73 @@ export async function sendReceiptParsedNotification(
       }
     } else {
       console.error('[Webhook] Unknown error type:', error);
+    }
+    // Fire-and-forget: don't throw
+  }
+}
+
+/**
+ * Send webhook notification for an error that occurred during receipt processing
+ *
+ * @param errorType - Category of error (e.g., "anthropic_rate_limit", "zod_validation")
+ * @param errorMessage - Human-readable error description
+ * @param context - Additional context about the request
+ */
+export async function sendErrorNotification(
+  errorType: string,
+  errorMessage: string,
+  context: ErrorNotificationContext = {}
+): Promise<void> {
+  try {
+    const webhookUrl = process.env.WEBHOOK_URL;
+
+    if (!webhookUrl) {
+      return;
+    }
+
+    const webhookType = (process.env.WEBHOOK_TYPE || 'slack') as WebhookType;
+    const formatter = ERROR_FORMATTERS[webhookType];
+
+    if (!formatter) {
+      console.error(`[Webhook] Unknown webhook type for error notification: ${webhookType}`);
+      return;
+    }
+
+    const payload = formatter.format(errorType, errorMessage, context);
+
+    console.log('[Webhook] Sending error notification...', {
+      type: webhookType,
+      errorType,
+      sessionId: context.sessionId,
+    });
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, 5000);
+
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Unable to read response body');
+      throw new Error(
+        `Webhook request failed: ${response.status} ${response.statusText}. Body: ${errorText.substring(0, 200)}`
+      );
+    }
+
+    console.log('[Webhook] Error notification sent successfully');
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('[Webhook] Error sending error notification (non-blocking):', error.message);
+    } else {
+      console.error('[Webhook] Unknown error sending error notification:', error);
     }
     // Fire-and-forget: don't throw
   }

--- a/src/lib/webhook-notifications.ts
+++ b/src/lib/webhook-notifications.ts
@@ -1,8 +1,5 @@
 import { type Receipt, type GeolocationData } from '@/types';
 
-/**
- * Context for error notifications
- */
 export interface ErrorNotificationContext {
   sessionId?: string;
   fileName?: string;
@@ -245,16 +242,10 @@ class GenericJsonFormatter implements WebhookPayloadFormatter {
   }
 }
 
-/**
- * Error payload formatter interface
- */
 export interface ErrorPayloadFormatter {
   format(errorType: string, errorMessage: string, context: ErrorNotificationContext): WebhookPayload;
 }
 
-/**
- * Slack error notification formatter
- */
 class SlackErrorFormatter implements ErrorPayloadFormatter {
   format(errorType: string, errorMessage: string, context: ErrorNotificationContext): SlackPayload {
     const blocks: SlackBlock[] = [
@@ -350,9 +341,6 @@ class SlackErrorFormatter implements ErrorPayloadFormatter {
   }
 }
 
-/**
- * Generic JSON error notification formatter
- */
 class GenericJsonErrorFormatter implements ErrorPayloadFormatter {
   format(errorType: string, errorMessage: string, context: ErrorNotificationContext): Record<string, unknown> {
     return {
@@ -515,12 +503,6 @@ export async function sendErrorNotification(
 
     const payload = formatter.format(errorType, errorMessage, context);
 
-    console.log('[Webhook] Sending error notification...', {
-      type: webhookType,
-      errorType,
-      sessionId: context.sessionId,
-    });
-
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
       controller.abort();
@@ -541,8 +523,6 @@ export async function sendErrorNotification(
         `Webhook request failed: ${response.status} ${response.statusText}. Body: ${errorText.substring(0, 200)}`
       );
     }
-
-    console.log('[Webhook] Error notification sent successfully');
   } catch (error) {
     if (error instanceof Error) {
       console.error('[Webhook] Error sending error notification (non-blocking):', error.message);


### PR DESCRIPTION
## Summary
- Adds `sendErrorNotification()` to the existing webhook infrastructure, with Slack (red sidebar) and JSON formatters
- Sends notifications on server-side errors: missing API key, Anthropic API failures (rate limit, bad request, other), empty responses, Zod validation failures, JSON parse failures, unexpected errors, and cron cleanup failures
- Skips notifications for client errors (400s) and receipt quality issues (422)
- Moves file upload **before** the Anthropic API call so the receipt image URL is available in error notifications for debugging

## Error paths covered

| Error | Status | Notifies? |
|---|---|---|
| Missing API key | 500 | Yes |
| No file / empty / too large / wrong type | 400 | No |
| Anthropic rate limit | 429 | Yes |
| Anthropic bad request | 400 | Yes (our bug) |
| Anthropic other API error | 503 | Yes |
| No text content in response | 500 | Yes |
| Zod validation failure | 500 | Yes |
| No items with prices | 422 | No |
| JSON parse failure | 500 | Yes |
| FormData parse error | 400 | No |
| Unexpected error | 500 | Yes |
| Cron cleanup failure | 500 | Yes |

## Test plan
- [x] All 347 existing tests pass
- [x] 10 new tests for `sendErrorNotification` (Slack format, JSON format, error handling)
- [x] `npm run build` succeeds with no type errors
- [ ] Manual: upload a corrupt/unreadable image and verify Slack notification arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)