### PR TITLE
Fix screenshot harness server connectivity check

### DIFF
--- a/scripts/screenshot-harness.js
+++ b/scripts/screenshot-harness.js
@@ -189,8 +189,8 @@ function parseArgs() {
  */
 async function checkServerRunning(baseUrl) {
   try {
-    const response = await fetch(baseUrl, { method: 'HEAD' });
-    return response.ok;
+    await fetch(baseUrl, { method: 'HEAD' });
+    return true; // any response (including 500) means the server is up
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- The `checkServerRunning` health check used `response.ok`, which fails for any non-2xx status code
- In dev mode, Next.js can return 500 (e.g. due to SSR accessing `localStorage` before hydration) while the server is still fully operational and capable of serving client-side rendered pages
- Changed to treat **any HTTP response** as "server is up" — only a thrown network error means the server isn't running

## Test plan

- [ ] Start dev server (`npm run dev`)
- [ ] Confirm `npm run screenshots -- --mock-data --tab all` runs successfully even when dev server returns 500 on initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)