### PR TITLE
Add client-side image compression for large receipt uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-tabs": "^1.1.10",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "decimal.js": "^10.5.0",
@@ -6837,6 +6838,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -14671,6 +14681,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2114,7 +2114,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2404,7 +2403,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2426,7 +2424,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2448,7 +2445,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2464,7 +2460,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2480,7 +2475,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2496,7 +2490,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2512,7 +2505,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2528,7 +2520,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2544,7 +2535,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2560,7 +2550,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2576,7 +2565,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2592,7 +2580,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2608,7 +2595,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2630,7 +2616,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2652,7 +2637,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2674,7 +2658,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2696,7 +2679,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2718,7 +2700,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2740,7 +2721,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2762,7 +2742,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2784,7 +2763,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
@@ -2803,7 +2781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2822,7 +2799,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2841,7 +2817,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -12349,7 +12324,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-tabs": "^1.1.10",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "decimal.js": "^10.5.0",

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -230,6 +230,45 @@ describe("ReceiptUploader", () => {
     }
   });
 
+  it("shows single error when compression succeeds but result still exceeds limit", async () => {
+    const mockOnReceiptParsed = jest.fn();
+    const mockSetIsLoading = jest.fn();
+
+    // Mock compression that returns a file still over 4.5MB
+    const stillTooLargeFile = new File([new ArrayBuffer(4.8 * 1024 * 1024)], "still-large.jpg", {
+      type: "image/jpeg",
+    });
+    (imageCompression as unknown as jest.Mock).mockResolvedValueOnce(stillTooLargeFile);
+
+    render(
+      <ReceiptUploader
+        onReceiptParsed={mockOnReceiptParsed}
+        isLoading={false}
+        setIsLoading={mockSetIsLoading}
+        resetImageTrigger={0}
+      />
+    );
+
+    const largeFile = new File([new ArrayBuffer(10 * 1024 * 1024)], "large.jpg", {
+      type: "image/jpeg",
+    });
+
+    const input = screen.getByRole("presentation").querySelector("input");
+    if (input) {
+      await userEvent.upload(input, largeFile);
+
+      // Should show a single descriptive error, not a success followed by an error
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledTimes(1);
+        expect(toast.error).toHaveBeenCalledWith(
+          expect.stringMatching(/Compressed from.*still over the 4\.5MB limit/)
+        );
+      });
+      expect(toast.success).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    }
+  });
+
   it("shows error when compression fails", async () => {
     const mockOnReceiptParsed = jest.fn();
     const mockSetIsLoading = jest.fn();

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -2,6 +2,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { ReceiptUploader } from "./receipt-uploader";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
+import imageCompression from "browser-image-compression";
+
+jest.mock("browser-image-compression", () => jest.fn());
 
 describe("ReceiptUploader", () => {
 
@@ -131,9 +134,29 @@ describe("ReceiptUploader", () => {
     }
   });
 
-  it("rejects files larger than 4.5MB", async () => {
+  it("compresses images larger than 4.5MB before uploading", async () => {
     const mockOnReceiptParsed = jest.fn();
     const mockSetIsLoading = jest.fn();
+
+    // Mock successful compression (returns a smaller file)
+    const compressedFile = new File([new ArrayBuffer(2 * 1024 * 1024)], "compressed.jpg", {
+      type: "image/jpeg",
+    });
+    (imageCompression as unknown as jest.Mock).mockResolvedValueOnce(compressedFile);
+
+    // Mock successful API response
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        restaurant: "Test Restaurant",
+        total: 100,
+        items: [],
+        subtotal: 100,
+        tax: 0,
+        tip: 0,
+        currency: "USD",
+      }),
+    });
 
     render(
       <ReceiptUploader
@@ -153,14 +176,88 @@ describe("ReceiptUploader", () => {
     if (input) {
       await userEvent.upload(input, largeFile);
 
-      // Should show error toast without calling API
+      // Should attempt compression and then upload
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledTimes(1);
-        expect(toast.error).toHaveBeenCalledWith(
-          expect.stringMatching(/File is too large.*Maximum size is 4\.5MB.*Your file is 5\.0MB/)
+        expect(imageCompression).toHaveBeenCalledWith(largeFile, {
+          maxSizeMB: 4,
+          maxWidthOrHeight: 2048,
+          useWebWorker: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(
+          expect.stringMatching(/Compressed from 5\.0MB to 2\.0MB/)
         );
       });
-      expect(mockSetIsLoading).not.toHaveBeenCalled();
+
+      // Should proceed to upload the compressed file
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+    }
+  });
+
+  it("rejects images over 50MB without attempting compression", async () => {
+    const mockOnReceiptParsed = jest.fn();
+    const mockSetIsLoading = jest.fn();
+
+    render(
+      <ReceiptUploader
+        onReceiptParsed={mockOnReceiptParsed}
+        isLoading={false}
+        setIsLoading={mockSetIsLoading}
+        resetImageTrigger={0}
+      />
+    );
+
+    // Create a file larger than 50MB (60MB)
+    const hugeFile = new File([new ArrayBuffer(60 * 1024 * 1024)], "huge.jpg", {
+      type: "image/jpeg",
+    });
+
+    const input = screen.getByRole("presentation").querySelector("input");
+    if (input) {
+      await userEvent.upload(input, hugeFile);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          expect.stringMatching(/too large to compress.*60\.0MB.*Maximum is 50MB/)
+        );
+      });
+      expect(imageCompression).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("shows error when compression fails", async () => {
+    const mockOnReceiptParsed = jest.fn();
+    const mockSetIsLoading = jest.fn();
+
+    (imageCompression as unknown as jest.Mock).mockRejectedValueOnce(new Error("Compression failed"));
+
+    render(
+      <ReceiptUploader
+        onReceiptParsed={mockOnReceiptParsed}
+        isLoading={false}
+        setIsLoading={mockSetIsLoading}
+        resetImageTrigger={0}
+      />
+    );
+
+    const largeFile = new File([new ArrayBuffer(5 * 1024 * 1024)], "large.jpg", {
+      type: "image/jpeg",
+    });
+
+    const input = screen.getByRole("presentation").querySelector("input");
+    if (input) {
+      await userEvent.upload(input, largeFile);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          expect.stringMatching(/Compression failed/)
+        );
+      });
       expect(global.fetch).not.toHaveBeenCalled();
     }
   });

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -147,6 +147,19 @@ describe("ReceiptUploader", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects PDFs over the size limit without compressing", async () => {
+    renderUploader();
+
+    const largePdf = new File([new ArrayBuffer(5 * 1024 * 1024)], "large.pdf", { type: "application/pdf" });
+    await userEvent.upload(getFileInput(), largePdf);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/too large.*4\.5MB/i));
+    });
+    expect(imageCompression).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("shows error when compression fails", async () => {
     (imageCompression as unknown as jest.Mock).mockRejectedValueOnce(new Error("Compression failed"));
 

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -7,297 +7,157 @@ import imageCompression from "browser-image-compression";
 jest.mock("browser-image-compression", () => jest.fn());
 
 describe("ReceiptUploader", () => {
+  let mockOnReceiptParsed: jest.Mock;
+  let mockSetIsLoading: jest.Mock;
 
-  it("renders upload prompt", () => {
-    render(
+  beforeEach(() => {
+    mockOnReceiptParsed = jest.fn();
+    mockSetIsLoading = jest.fn();
+  });
+
+  function renderUploader() {
+    return render(
       <ReceiptUploader
-        onReceiptParsed={() => {}}
+        onReceiptParsed={mockOnReceiptParsed}
         isLoading={false}
-        setIsLoading={() => {}}
+        setIsLoading={mockSetIsLoading}
         resetImageTrigger={0}
       />
     );
+  }
+
+  function getFileInput() {
+    const input = screen.getByRole("presentation").querySelector("input");
+    expect(input).not.toBeNull();
+    return input!;
+  }
+
+  it("renders upload prompt", () => {
+    renderUploader();
     expect(screen.getByText(/upload your receipt/i)).toBeInTheDocument();
   });
 
   it("accepts PDF files", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
-
-    // Mock successful API response
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({
-        restaurant: "Test Restaurant",
-        total: 100,
-        items: [],
-      }),
+      json: async () => ({ restaurant: "Test Restaurant", total: 100, items: [] }),
     });
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    renderUploader();
 
-    // Create a mock PDF file
-    const pdfFile = new File(["mock pdf content"], "receipt.pdf", {
-      type: "application/pdf",
+    const pdfFile = new File(["mock pdf content"], "receipt.pdf", { type: "application/pdf" });
+    await userEvent.upload(getFileInput(), pdfFile);
+
+    await waitFor(() => {
+      expect(mockSetIsLoading).toHaveBeenCalledWith(true);
     });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, pdfFile);
-
-      await waitFor(() => {
-        expect(mockSetIsLoading).toHaveBeenCalledWith(true);
-      });
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(
-          "/api/parse-receipt",
-          expect.objectContaining({
-            method: "POST",
-          })
-        );
-      });
-    }
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/parse-receipt",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
   });
 
   it("shows PDF placeholder when PDF is uploaded", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
-
-    // Mock successful API response
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({
-        restaurant: "Test Restaurant",
-        total: 100,
-        items: [],
-      }),
+      json: async () => ({ restaurant: "Test Restaurant", total: 100, items: [] }),
     });
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    renderUploader();
 
-    const pdfFile = new File(["mock pdf content"], "receipt.pdf", {
-      type: "application/pdf",
+    const pdfFile = new File(["mock pdf content"], "receipt.pdf", { type: "application/pdf" });
+    await userEvent.upload(getFileInput(), pdfFile);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("svg").length).toBeGreaterThan(0);
     });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, pdfFile);
-
-      // Wait for the FileText icon to be rendered (PDF placeholder)
-      await waitFor(() => {
-        // Check that a file icon is displayed (via the FileText component)
-        const svgs = document.querySelectorAll("svg");
-        expect(svgs.length).toBeGreaterThan(0);
-      });
-    }
   });
 
   it("rejects non-image and non-PDF files", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
+    renderUploader();
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    const txtFile = new File(["test content"], "test.txt", { type: "text/plain" });
+    await userEvent.upload(getFileInput(), txtFile);
 
-    const txtFile = new File(["test content"], "test.txt", {
-      type: "text/plain",
-    });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, txtFile);
-
-      // Should not call the API
-      expect(global.fetch).not.toHaveBeenCalled();
-      expect(mockSetIsLoading).not.toHaveBeenCalled();
-    }
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockSetIsLoading).not.toHaveBeenCalled();
   });
 
   it("compresses images larger than 4.5MB before uploading", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
-
-    // Mock successful compression (returns a smaller file)
-    const compressedFile = new File([new ArrayBuffer(2 * 1024 * 1024)], "compressed.jpg", {
-      type: "image/jpeg",
-    });
+    const compressedFile = new File([new ArrayBuffer(2 * 1024 * 1024)], "compressed.jpg", { type: "image/jpeg" });
     (imageCompression as unknown as jest.Mock).mockResolvedValueOnce(compressedFile);
-
-    // Mock successful API response
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({
-        restaurant: "Test Restaurant",
-        total: 100,
-        items: [],
-        subtotal: 100,
-        tax: 0,
-        tip: 0,
-        currency: "USD",
-      }),
+      json: async () => ({ restaurant: "Test Restaurant", total: 100, items: [], subtotal: 100, tax: 0, tip: 0, currency: "USD" }),
     });
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    renderUploader();
 
-    // Create a file larger than 4.5MB (5MB)
-    const largeFile = new File([new ArrayBuffer(5 * 1024 * 1024)], "large.jpg", {
-      type: "image/jpeg",
+    const largeFile = new File([new ArrayBuffer(5 * 1024 * 1024)], "large.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), largeFile);
+
+    await waitFor(() => {
+      expect(imageCompression).toHaveBeenCalledWith(largeFile, {
+        maxSizeMB: 4,
+        maxWidthOrHeight: 2048,
+        useWebWorker: true,
+      });
     });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, largeFile);
-
-      // Should attempt compression and then upload
-      await waitFor(() => {
-        expect(imageCompression).toHaveBeenCalledWith(largeFile, {
-          maxSizeMB: 4,
-          maxWidthOrHeight: 2048,
-          useWebWorker: true,
-        });
-      });
-
-      await waitFor(() => {
-        expect(toast.success).toHaveBeenCalledWith(
-          expect.stringMatching(/Compressed from 5\.0MB to 2\.0MB/)
-        );
-      });
-
-      // Should proceed to upload the compressed file
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled();
-      });
-    }
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/Compressed from 5\.0MB to 2\.0MB/));
+    });
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
   });
 
   it("rejects images over 50MB without attempting compression", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
+    renderUploader();
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    const hugeFile = new File([new ArrayBuffer(60 * 1024 * 1024)], "huge.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), hugeFile);
 
-    // Create a file larger than 50MB (60MB)
-    const hugeFile = new File([new ArrayBuffer(60 * 1024 * 1024)], "huge.jpg", {
-      type: "image/jpeg",
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/too large to compress.*60\.0MB.*Maximum is 50MB/)
+      );
     });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, hugeFile);
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          expect.stringMatching(/too large to compress.*60\.0MB.*Maximum is 50MB/)
-        );
-      });
-      expect(imageCompression).not.toHaveBeenCalled();
-      expect(global.fetch).not.toHaveBeenCalled();
-    }
+    expect(imageCompression).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("shows single error when compression succeeds but result still exceeds limit", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
-
-    // Mock compression that returns a file still over 4.5MB
-    const stillTooLargeFile = new File([new ArrayBuffer(4.8 * 1024 * 1024)], "still-large.jpg", {
-      type: "image/jpeg",
-    });
+  it("shows single error when compression result still exceeds limit", async () => {
+    const stillTooLargeFile = new File([new ArrayBuffer(4.8 * 1024 * 1024)], "still-large.jpg", { type: "image/jpeg" });
     (imageCompression as unknown as jest.Mock).mockResolvedValueOnce(stillTooLargeFile);
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    renderUploader();
 
-    const largeFile = new File([new ArrayBuffer(10 * 1024 * 1024)], "large.jpg", {
-      type: "image/jpeg",
+    const largeFile = new File([new ArrayBuffer(10 * 1024 * 1024)], "large.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), largeFile);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/Compressed from.*still over the 4\.5MB limit/)
+      );
     });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, largeFile);
-
-      // Should show a single descriptive error, not a success followed by an error
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledTimes(1);
-        expect(toast.error).toHaveBeenCalledWith(
-          expect.stringMatching(/Compressed from.*still over the 4\.5MB limit/)
-        );
-      });
-      expect(toast.success).not.toHaveBeenCalled();
-      expect(global.fetch).not.toHaveBeenCalled();
-    }
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("shows error when compression fails", async () => {
-    const mockOnReceiptParsed = jest.fn();
-    const mockSetIsLoading = jest.fn();
-
     (imageCompression as unknown as jest.Mock).mockRejectedValueOnce(new Error("Compression failed"));
 
-    render(
-      <ReceiptUploader
-        onReceiptParsed={mockOnReceiptParsed}
-        isLoading={false}
-        setIsLoading={mockSetIsLoading}
-        resetImageTrigger={0}
-      />
-    );
+    renderUploader();
 
-    const largeFile = new File([new ArrayBuffer(5 * 1024 * 1024)], "large.jpg", {
-      type: "image/jpeg",
+    const largeFile = new File([new ArrayBuffer(5 * 1024 * 1024)], "large.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), largeFile);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/Compression failed/));
     });
-
-    const input = screen.getByRole("presentation").querySelector("input");
-    if (input) {
-      await userEvent.upload(input, largeFile);
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          expect.stringMatching(/Compression failed/)
-        );
-      });
-      expect(global.fetch).not.toHaveBeenCalled();
-    }
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "sonner";
 import { type Receipt } from "@/types";
 import { MAX_FILE_SIZE_MB, MAX_FILE_SIZE_BYTES } from "@/lib/constants";
+import imageCompression from "browser-image-compression";
 
 interface ReceiptUploaderProps {
   onReceiptParsed: (receipt: Receipt) => void;
@@ -13,6 +14,9 @@ interface ReceiptUploaderProps {
   resetImageTrigger?: number;
 }
 
+const MAX_COMPRESSION_FILE_SIZE_MB = 50;
+const COMPRESSION_TARGET_SIZE_MB = 4;
+
 export function ReceiptUploader({
   onReceiptParsed,
   isLoading,
@@ -20,6 +24,7 @@ export function ReceiptUploader({
   resetImageTrigger,
 }: ReceiptUploaderProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isCompressing, setIsCompressing] = useState(false);
   const IMAGE_STORAGE_KEY = "receiptSplitterImage";
 
   // Restore preview image from localStorage on mount
@@ -48,7 +53,7 @@ export function ReceiptUploader({
       if (acceptedFiles.length === 0) return;
 
       // Get the first file
-      const file = acceptedFiles[0];
+      let file = acceptedFiles[0];
 
       // Check file type
       if (!file.type.startsWith("image/") && file.type !== "application/pdf") {
@@ -56,7 +61,42 @@ export function ReceiptUploader({
         return;
       }
 
-      // Check file size before uploading
+      const fileSizeMB = file.size / (1024 * 1024);
+
+      // Attempt client-side compression for images that exceed the upload limit
+      if (file.type.startsWith("image/") && file.size > MAX_FILE_SIZE_BYTES) {
+        if (fileSizeMB > MAX_COMPRESSION_FILE_SIZE_MB) {
+          toast.error(
+            `File is too large to compress (${fileSizeMB.toFixed(1)}MB). Maximum is ${MAX_COMPRESSION_FILE_SIZE_MB}MB.`
+          );
+          return;
+        }
+
+        try {
+          setIsCompressing(true);
+          const compressed = await imageCompression(file, {
+            maxSizeMB: COMPRESSION_TARGET_SIZE_MB,
+            maxWidthOrHeight: 2048,
+            useWebWorker: true,
+          });
+          const originalSize = fileSizeMB.toFixed(1);
+          const newSize = (compressed.size / (1024 * 1024)).toFixed(1);
+          toast.success(
+            `Compressed from ${originalSize}MB to ${newSize}MB`
+          );
+          file = compressed;
+        } catch (error) {
+          console.error("Image compression error:", error);
+          toast.error(
+            `File is too large (${fileSizeMB.toFixed(1)}MB). Maximum size is ${MAX_FILE_SIZE_MB}MB. Compression failed — please use a smaller file.`
+          );
+          return;
+        } finally {
+          setIsCompressing(false);
+        }
+      }
+
+      // Final size check (after potential compression)
       if (file.size > MAX_FILE_SIZE_BYTES) {
         toast.error(
           `File is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB. Your file is ${(file.size / (1024 * 1024)).toFixed(1)}MB.`
@@ -126,8 +166,10 @@ export function ReceiptUploader({
       "application/pdf": [".pdf"],
     },
     maxFiles: 1,
-    disabled: isLoading,
+    disabled: isLoading || isCompressing,
   });
+
+  const isBusy = isLoading || isCompressing;
 
   return (
     <Card className="w-full">
@@ -136,11 +178,19 @@ export function ReceiptUploader({
           {...getRootProps()}
           className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
             isDragActive ? "border-primary bg-primary/5" : "border-input"
-          } ${isLoading ? "opacity-60 cursor-not-allowed" : ""}`}
+          } ${isBusy ? "opacity-60 cursor-not-allowed" : ""}`}
         >
-          <input {...getInputProps()} disabled={isLoading} />
+          <input {...getInputProps()} disabled={isBusy} />
 
-          {previewUrl ? (
+          {isCompressing ? (
+            <div className="flex flex-col items-center">
+              <Loader2 className="h-10 w-10 mb-4 animate-spin text-primary" />
+              <p className="mb-1 font-medium">Compressing image...</p>
+              <p className="text-sm text-muted-foreground">
+                Reducing file size to under {MAX_FILE_SIZE_MB}MB
+              </p>
+            </div>
+          ) : previewUrl ? (
             <div className="flex flex-col items-center">
               {previewUrl === "pdf-placeholder" ? (
                 <FileText className="h-32 w-32 mb-4 text-muted-foreground" />

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -81,6 +81,12 @@ export function ReceiptUploader({
           });
           const originalSize = fileSizeMB.toFixed(1);
           const newSize = (compressed.size / (1024 * 1024)).toFixed(1);
+          if (compressed.size > MAX_FILE_SIZE_BYTES) {
+            toast.error(
+              `Compressed from ${originalSize}MB to ${newSize}MB, but it's still over the ${MAX_FILE_SIZE_MB}MB limit. Please use a smaller or lower-resolution image.`
+            );
+            return;
+          }
           toast.success(
             `Compressed from ${originalSize}MB to ${newSize}MB`
           );


### PR DESCRIPTION
## Summary
Implemented automatic client-side image compression for receipt uploads that exceed the 4.5MB limit, improving user experience by allowing larger images to be processed without rejection.

## Key Changes
- **Image Compression Logic**: Added automatic compression for image files larger than 4.5MB using the `browser-image-compression` library, targeting a maximum of 4MB with a 2048px dimension limit
- **File Size Validation**: Implemented a hard limit of 50MB for compression attempts; files larger than this are rejected without attempting compression
- **User Feedback**: Added toast notifications to inform users of compression progress and results, including before/after file sizes
- **UI State Management**: Added `isCompressing` state to disable file input and show a loading spinner during compression
- **Error Handling**: Graceful error handling for compression failures with user-friendly error messages
- **Test Coverage**: Updated and added comprehensive tests covering:
  - Successful compression of files between 4.5MB and 50MB
  - Rejection of files over 50MB without compression attempt
  - Compression failure scenarios

## Implementation Details
- Compression uses Web Workers for non-blocking processing
- Original file is replaced with compressed version before upload if compression succeeds
- Final size validation still occurs after compression to ensure safety
- Loading state prevents multiple simultaneous uploads during compression
- Added `browser-image-compression` as a production dependency

https://claude.ai/code/session_01WBZKXgYqSYmioShaqU8aca