### PR TITLE
Remove verbose console.logs from webhook notifications

### DIFF
--- a/src/lib/webhook-notifications.ts
+++ b/src/lib/webhook-notifications.ts
@@ -286,7 +286,6 @@ export async function sendReceiptParsedNotification(
       return;
     }
 
-    // Format the payload
     const data: ReceiptWebhookData = {
       receipt,
       fileUrl,
@@ -297,21 +296,12 @@ export async function sendReceiptParsedNotification(
     };
     const payload = formatter.format(data);
 
-    console.log('[Webhook] Sending notification...', {
-      type: webhookType,
-      sessionId,
-      restaurant: receipt.restaurant,
-      webhookUrl: webhookUrl.substring(0, 30) + '...' // Log partial URL for debugging
-    });
-
-    // Create timeout signal (with fallback for environments that don't support AbortSignal.timeout)
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
       console.error('[Webhook] Request timed out after 5 seconds');
       controller.abort();
     }, 5000);
 
-    console.log('[Webhook] Making fetch request...');
     const response = await fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -320,7 +310,6 @@ export async function sendReceiptParsedNotification(
     });
 
     clearTimeout(timeoutId);
-    console.log(`[Webhook] Got response: ${response.status} ${response.statusText}`);
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'Unable to read response body');
@@ -328,8 +317,6 @@ export async function sendReceiptParsedNotification(
         `Webhook request failed: ${response.status} ${response.statusText}. Body: ${errorText.substring(0, 200)}`
       );
     }
-
-    console.log('[Webhook] Notification sent successfully');
   } catch (error) {
     if (error instanceof Error) {
       console.error('[Webhook] Error sending notification (non-blocking):', error.message);


### PR DESCRIPTION
Removes the 4 success-path `console.log` calls from `sendReceiptParsedNotification` (sending, making fetch request, got response, sent successfully). Only `console.error` paths remain, which matches the project's convention that fire-and-forget async functions should not log on success.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)