### PR TITLE
Persist session ID and send it with upload requests

### DIFF
--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { type Receipt } from "@/types";
 import { MAX_FILE_SIZE_MB, MAX_FILE_SIZE_BYTES } from "@/lib/constants";
 import imageCompression from "browser-image-compression";
+import { getSessionId } from "@/lib/session";
 
 interface ReceiptUploaderProps {
   onReceiptParsed: (receipt: Receipt) => void;
@@ -132,6 +133,7 @@ export function ReceiptUploader({
 
         const formData = new FormData();
         formData.append("file", file);
+        formData.append("sessionId", getSessionId());
 
         const response = await fetch("/api/parse-receipt", {
           method: "POST",

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,19 @@
+import { getSessionId } from "./session";
+
+describe("getSessionId", () => {
+  it("creates and persists a session ID on first call", () => {
+    const id = getSessionId();
+    expect(id).toBe("00000000-0000-4000-8000-000000000000");
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "receiptSplitterSessionId",
+      id
+    );
+  });
+
+  it("returns the same ID on subsequent calls", () => {
+    const first = getSessionId();
+    const second = getSessionId();
+    expect(second).toBe(first);
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,10 @@
+const SESSION_KEY = "receiptSplitterSessionId";
+
+export function getSessionId(): string {
+  if (typeof window === "undefined") return crypto.randomUUID();
+  const existing = localStorage.getItem(SESSION_KEY);
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  localStorage.setItem(SESSION_KEY, id);
+  return id;
+}


### PR DESCRIPTION
Adds a small `getSessionId()` utility (`src/lib/session.ts`) that reads a UUID from localStorage key `receiptSplitterSessionId`, creating and persisting one with `crypto.randomUUID()` on first call. The uploader appends this value to the upload FormData so the backend can correlate all events (parse, upload, webhook) that belong to the same browser session instead of generating a random ID per request.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)