### PR TITLE
fix: add safeSetItem helper to guard localStorage write paths (#118)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import Home from "./page";
 import { toast } from "sonner";
 import { mockReceipt, mockPeople } from "@/test/test-utils";
+import { RECEIPT_IMAGE_STORAGE_KEY } from "@/lib/storage";
 
 type SerializedAssignments = [number, { personId: string; sharePercentage: number }[]][];
 
@@ -23,6 +24,15 @@ function loadSession(overrides: Partial<typeof baseState> = {}, activeTab = "upl
 }
 
 describe("Home Page", () => {
+  let originalSetItem: typeof localStorage.setItem;
+
+  afterEach(() => {
+    if (originalSetItem) {
+      localStorage.setItem = originalSetItem;
+      originalSetItem = undefined as never;
+    }
+  });
+
   describe("empty state", () => {
     it("starts on the upload tab with all downstream tabs and nav disabled", () => {
       render(<Home />);
@@ -60,6 +70,40 @@ describe("Home Page", () => {
       localStorage.setItem("receiptSplitterSession", "invalid json {");
       render(<Home />);
       expect(screen.getByRole("tab", { name: /upload receipt/i })).toHaveAttribute("data-state", "active");
+    });
+
+    it("evicts the cached image and retries when saving the session fails", async () => {
+      let sessionWriteFailures = 0;
+      originalSetItem = localStorage.setItem;
+      localStorage.setItem = jest.fn((key: string, value: string) => {
+        if (key === "receiptSplitterSession" && sessionWriteFailures === 0) {
+          sessionWriteFailures += 1;
+          throw new DOMException("Quota exceeded", "QuotaExceededError");
+        }
+        return originalSetItem(key, value);
+      }) as typeof localStorage.setItem;
+
+      render(<Home />);
+
+      await waitFor(() => {
+        expect(localStorage.getItem("receiptSplitterSession")).not.toBeNull();
+      });
+      expect(localStorage.removeItem).toHaveBeenCalledWith(RECEIPT_IMAGE_STORAGE_KEY);
+      expect(sessionWriteFailures).toBe(1);
+    });
+
+    it("continues rendering when the session retry also fails", () => {
+      originalSetItem = localStorage.setItem;
+      localStorage.setItem = jest.fn((key: string) => {
+        if (key === "receiptSplitterSession") {
+          throw new DOMException("Quota exceeded", "QuotaExceededError");
+        }
+      }) as typeof localStorage.setItem;
+
+      render(<Home />);
+
+      expect(screen.getByRole("tab", { name: /upload receipt/i })).toHaveAttribute("data-state", "active");
+      expect(localStorage.removeItem).toHaveBeenCalledWith(RECEIPT_IMAGE_STORAGE_KEY);
     });
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ import {
   getUniqueGroupEmoji,
   getRandomGroupEmojiExcluding,
 } from "@/lib/emoji-utils";
+import { safeSetItem } from "@/lib/storage";
 
 export default function Home() {
   const LOCAL_STORAGE_KEY = "receiptSplitterSession";
@@ -112,10 +113,16 @@ export default function Home() {
         },
         activeTab,
       };
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(toSave));
+      const serialized = JSON.stringify(toSave);
+      const ok = safeSetItem(LOCAL_STORAGE_KEY, serialized);
+      if (!ok) {
+        // Quota exhausted — evict the cached image (largest consumer) and retry once
+        localStorage.removeItem("receiptSplitterImage");
+        safeSetItem(LOCAL_STORAGE_KEY, serialized);
+      }
       // Check if session is not default
       const isDefault =
-        JSON.stringify(toSave) === JSON.stringify(defaultSession);
+        serialized === JSON.stringify(defaultSession);
       setHasSession(!isDefault);
     }
   }, [state, activeTab, defaultSession]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,12 @@ import {
   getUniqueGroupEmoji,
   getRandomGroupEmojiExcluding,
 } from "@/lib/emoji-utils";
-import { safeSetItem } from "@/lib/storage";
+import {
+  RECEIPT_IMAGE_STORAGE_KEY,
+  safeGetItem,
+  safeRemoveItem,
+  safeSetItem,
+} from "@/lib/storage";
 
 export default function Home() {
   const LOCAL_STORAGE_KEY = "receiptSplitterSession";
@@ -78,7 +83,7 @@ export default function Home() {
 
   // Restore session from localStorage on mount
   useEffect(() => {
-    const session = localStorage.getItem(LOCAL_STORAGE_KEY);
+    const session = safeGetItem(LOCAL_STORAGE_KEY);
     if (session) {
       try {
         const parsed = JSON.parse(session);
@@ -117,7 +122,7 @@ export default function Home() {
       const ok = safeSetItem(LOCAL_STORAGE_KEY, serialized);
       if (!ok) {
         // Quota exhausted — evict the cached image (largest consumer) and retry once
-        localStorage.removeItem("receiptSplitterImage");
+        safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
         safeSetItem(LOCAL_STORAGE_KEY, serialized);
       }
       // Check if session is not default
@@ -129,8 +134,8 @@ export default function Home() {
 
   // Handler for New Split button
   const handleNewSplit = () => {
-    localStorage.removeItem(LOCAL_STORAGE_KEY);
-    localStorage.removeItem("receiptSplitterImage");
+    safeRemoveItem(LOCAL_STORAGE_KEY);
+    safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
     setState({
       originalReceipt: null,
       people: [],

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -173,4 +173,32 @@ describe("ReceiptUploader", () => {
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it("continues with preview when image caching fails due to QuotaExceededError", async () => {
+    // Override setItem directly (not spyOn) so global clearAllMocks doesn't interfere
+    const originalSetItem = localStorage.setItem;
+    localStorage.setItem = jest.fn((key: string, value: string) => {
+      if (key === "receiptSplitterImage") {
+        throw new DOMException("Quota exceeded", "QuotaExceededError");
+      }
+      return originalSetItem(key, value);
+    }) as typeof localStorage.setItem;
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ restaurant: "Test Restaurant", total: 100, items: [], subtotal: 100, tax: 0, tip: 0, currency: "USD" }),
+    });
+
+    renderUploader();
+
+    const imageFile = new File([new ArrayBuffer(1024)], "test.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), imageFile);
+
+    // Should still show preview and call fetch — caching is best-effort
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    // No error toast for caching failure
+    expect(toast.error).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -9,10 +9,18 @@ jest.mock("browser-image-compression", () => jest.fn());
 describe("ReceiptUploader", () => {
   let mockOnReceiptParsed: jest.Mock;
   let mockSetIsLoading: jest.Mock;
+  let originalSetItem: typeof localStorage.setItem;
 
   beforeEach(() => {
     mockOnReceiptParsed = jest.fn();
     mockSetIsLoading = jest.fn();
+  });
+
+  afterEach(() => {
+    if (originalSetItem) {
+      localStorage.setItem = originalSetItem;
+      originalSetItem = undefined as never;
+    }
   });
 
   function renderUploader() {
@@ -175,8 +183,7 @@ describe("ReceiptUploader", () => {
   });
 
   it("continues with preview when image caching fails due to QuotaExceededError", async () => {
-    // Override setItem directly (not spyOn) so global clearAllMocks doesn't interfere
-    const originalSetItem = localStorage.setItem;
+    originalSetItem = localStorage.setItem;
     localStorage.setItem = jest.fn((key: string, value: string) => {
       if (key === "receiptSplitterImage") {
         throw new DOMException("Quota exceeded", "QuotaExceededError");

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -7,6 +7,7 @@ import { type Receipt } from "@/types";
 import { MAX_FILE_SIZE_MB, MAX_FILE_SIZE_BYTES } from "@/lib/constants";
 import imageCompression from "browser-image-compression";
 import { getSessionId } from "@/lib/session";
+import { safeSetItem } from "@/lib/storage";
 
 interface ReceiptUploaderProps {
   onReceiptParsed: (receipt: Receipt) => void;
@@ -116,7 +117,7 @@ export function ReceiptUploader({
         const reader = new FileReader();
         reader.onload = () => {
           if (reader.result) {
-            localStorage.setItem(IMAGE_STORAGE_KEY, reader.result as string);
+            safeSetItem(IMAGE_STORAGE_KEY, reader.result as string);
             setPreviewUrl(reader.result as string);
           }
         };

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -7,7 +7,12 @@ import { type Receipt } from "@/types";
 import { MAX_FILE_SIZE_MB, MAX_FILE_SIZE_BYTES } from "@/lib/constants";
 import imageCompression from "browser-image-compression";
 import { getSessionId } from "@/lib/session";
-import { safeSetItem } from "@/lib/storage";
+import {
+  RECEIPT_IMAGE_STORAGE_KEY,
+  safeGetItem,
+  safeRemoveItem,
+  safeSetItem,
+} from "@/lib/storage";
 
 interface ReceiptUploaderProps {
   onReceiptParsed: (receipt: Receipt) => void;
@@ -27,11 +32,10 @@ export function ReceiptUploader({
 }: ReceiptUploaderProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isCompressing, setIsCompressing] = useState(false);
-  const IMAGE_STORAGE_KEY = "receiptSplitterImage";
 
   // Restore preview image from localStorage on mount
   useEffect(() => {
-    const savedImage = localStorage.getItem(IMAGE_STORAGE_KEY);
+    const savedImage = safeGetItem(RECEIPT_IMAGE_STORAGE_KEY);
     if (savedImage) {
       setPreviewUrl(savedImage);
     }
@@ -45,7 +49,7 @@ export function ReceiptUploader({
       prevResetImageTrigger.current !== resetImageTrigger
     ) {
       setPreviewUrl(null);
-      localStorage.removeItem(IMAGE_STORAGE_KEY);
+      safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
     }
     prevResetImageTrigger.current = resetImageTrigger;
   }, [resetImageTrigger]);
@@ -117,7 +121,7 @@ export function ReceiptUploader({
         const reader = new FileReader();
         reader.onload = () => {
           if (reader.result) {
-            safeSetItem(IMAGE_STORAGE_KEY, reader.result as string);
+            safeSetItem(RECEIPT_IMAGE_STORAGE_KEY, reader.result as string);
             setPreviewUrl(reader.result as string);
           }
         };
@@ -125,7 +129,7 @@ export function ReceiptUploader({
       } else {
         // For PDFs, just set a placeholder preview
         setPreviewUrl("pdf-placeholder");
-        localStorage.removeItem(IMAGE_STORAGE_KEY);
+        safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
       }
 
       // Parse receipt

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,4 +1,4 @@
-import { safeSetItem, safeGetItem } from "./storage";
+import { safeSetItem, safeGetItem, measureStorageUsage, formatBytes } from "./storage";
 
 // Store original handlers to restore after tests that override them
 let originalSetItem: typeof localStorage.setItem;
@@ -67,5 +67,51 @@ describe("safeGetItem", () => {
 
     const result = safeGetItem("testKey");
     expect(result).toBeNull();
+  });
+});
+
+describe("measureStorageUsage", () => {
+  beforeEach(() => {
+    // Restore getItem if it was mocked by a previous test
+    if (originalGetItem) localStorage.getItem = originalGetItem;
+    localStorage.clear();
+  });
+
+  it("returns 0 when localStorage is empty", () => {
+    expect(measureStorageUsage()).toBe(0);
+  });
+
+  it("counts key and value bytes (UTF-16 = 2 bytes per char)", () => {
+    localStorage.setItem("abc", "xyz");     // (3 + 3) * 2 = 12
+    expect(measureStorageUsage()).toBe(12);
+  });
+
+  it("returns combined size of multiple entries", () => {
+    localStorage.setItem("k1", "v1");       // (2 + 2) * 2 = 8
+    localStorage.setItem("key2", "val2");   // (4 + 4) * 2 = 16
+    expect(measureStorageUsage()).toBe(24);
+  });
+
+  it("does not count the key parameter of setItem, only stored keys", () => {
+    localStorage.setItem("a", "aaaa");      // (1 + 4) * 2 = 10
+    localStorage.setItem("bb", "bb");       // (2 + 2) * 2 = 8
+    expect(measureStorageUsage()).toBe(18);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(500)).toBe("500 B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatBytes(1048576)).toBe("1.0 MB");
+    expect(formatBytes(1572864)).toBe("1.5 MB");
   });
 });

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,0 +1,71 @@
+import { safeSetItem, safeGetItem } from "./storage";
+
+// Store original handlers to restore after tests that override them
+let originalSetItem: typeof localStorage.setItem;
+let originalGetItem: typeof localStorage.getItem;
+
+describe("safeSetItem", () => {
+  beforeEach(() => {
+    // Restore originals if they were overridden
+    if (originalSetItem) localStorage.setItem = originalSetItem;
+    if (originalGetItem) localStorage.getItem = originalGetItem;
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it("returns true and persists value on success", () => {
+    const result = safeSetItem("testKey", "testValue");
+    expect(result).toBe(true);
+    expect(localStorage.getItem("testKey")).toBe("testValue");
+  });
+
+  it("returns false when setItem throws QuotaExceededError", () => {
+    originalSetItem = localStorage.setItem;
+    localStorage.setItem = jest.fn(() => {
+      throw new DOMException("Quota exceeded", "QuotaExceededError");
+    });
+
+    const result = safeSetItem("testKey", "testValue");
+    expect(result).toBe(false);
+    expect(localStorage.getItem("testKey")).toBeNull();
+  });
+
+  it("returns false when setItem throws any error", () => {
+    originalSetItem = localStorage.setItem;
+    localStorage.setItem = jest.fn(() => {
+      throw new Error("Some other error");
+    });
+
+    const result = safeSetItem("testKey", "testValue");
+    expect(result).toBe(false);
+  });
+
+  it("integrated: safeSetItem then safeGetItem roundtrip", () => {
+    const ok = safeSetItem("roundtripKey", "roundtripValue");
+    expect(ok).toBe(true);
+    expect(safeGetItem("roundtripKey")).toBe("roundtripValue");
+  });
+});
+
+describe("safeGetItem", () => {
+  beforeEach(() => {
+    if (originalGetItem) localStorage.getItem = originalGetItem;
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it("returns the stored value on success", () => {
+    localStorage.setItem("testKey", "testValue");
+    expect(safeGetItem("testKey")).toBe("testValue");
+  });
+
+  it("returns null when getItem throws", () => {
+    originalGetItem = localStorage.getItem;
+    localStorage.getItem = jest.fn(() => {
+      throw new Error("Access denied");
+    });
+
+    const result = safeGetItem("testKey");
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,8 +1,25 @@
-import { safeSetItem, safeGetItem, measureStorageUsage, formatBytes } from "./storage";
+import {
+  safeSetItem,
+  safeGetItem,
+  safeRemoveItem,
+  measureStorageUsage,
+  formatBytes,
+} from "./storage";
 
 // Store original handlers to restore after tests that override them
 let originalSetItem: typeof localStorage.setItem;
 let originalGetItem: typeof localStorage.getItem;
+
+afterEach(() => {
+  if (originalSetItem) {
+    localStorage.setItem = originalSetItem;
+    originalSetItem = undefined as never;
+  }
+  if (originalGetItem) {
+    localStorage.getItem = originalGetItem;
+    originalGetItem = undefined as never;
+  }
+});
 
 describe("safeSetItem", () => {
   beforeEach(() => {
@@ -40,6 +57,24 @@ describe("safeSetItem", () => {
     expect(result).toBe(false);
   });
 
+  it("returns false when measuring storage usage throws", () => {
+    const setItem = localStorage.setItem;
+    localStorage.setItem = jest.fn(() => {
+      throw new Error("Storage unavailable");
+    });
+    const originalKey = localStorage.key;
+    localStorage.key = jest.fn(() => {
+      throw new Error("Storage unavailable");
+    }) as typeof localStorage.key;
+
+    try {
+      expect(safeSetItem("testKey", "testValue")).toBe(false);
+    } finally {
+      localStorage.setItem = setItem;
+      localStorage.key = originalKey;
+    }
+  });
+
   it("integrated: safeSetItem then safeGetItem roundtrip", () => {
     const ok = safeSetItem("roundtripKey", "roundtripValue");
     expect(ok).toBe(true);
@@ -67,6 +102,27 @@ describe("safeGetItem", () => {
 
     const result = safeGetItem("testKey");
     expect(result).toBeNull();
+  });
+});
+
+describe("safeRemoveItem", () => {
+  it("returns true and removes the value on success", () => {
+    localStorage.setItem("testKey", "testValue");
+    expect(safeRemoveItem("testKey")).toBe(true);
+    expect(localStorage.getItem("testKey")).toBeNull();
+  });
+
+  it("returns false when removeItem throws", () => {
+    const removeItem = localStorage.removeItem;
+    localStorage.removeItem = jest.fn(() => {
+      throw new Error("Storage unavailable");
+    }) as typeof localStorage.removeItem;
+
+    try {
+      expect(safeRemoveItem("testKey")).toBe(false);
+    } finally {
+      localStorage.removeItem = removeItem;
+    }
   });
 });
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,13 +1,32 @@
 /**
  * Safe localStorage wrapper that handles QuotaExceededError.
  * Returns true on success, false on failure (logs the error to console).
+ *
+ * Real-world localStorage limits:
+ *   - iOS Safari:           5 MB (smallest in common use)
+ *   - Safari (desktop):     5 MB (some newer versions up to 10 MB)
+ *   - Chrome (desktop):    10 MB
+ *   - Firefox:             10 MB
+ *   - Chrome Android:      10 MB (varies by device RAM)
+ *   - Samsung Internet:    10 MB
+ *
+ * This app's main consumer is the cached receipt image stored as a base64
+ * data URL. With a 4 MB compression target, the base64-encoded string is
+ * ~5.3 MB (33% overhead), which can exceed the 5 MB limit on Safari.
+ * The safeSetItem wrapper catches that case and the caller can fall back
+ * to evicting the image cache.
  */
 export function safeSetItem(key: string, value: string): boolean {
   try {
     localStorage.setItem(key, value);
     return true;
   } catch (err) {
-    console.warn("localStorage.setItem failed:", err);
+    const usage = measureStorageUsage();
+    console.warn(
+      `localStorage.setItem failed for key "${key}"` +
+        ` (current usage: ~${formatBytes(usage)})`,
+      err,
+    );
     return false;
   }
 }
@@ -22,4 +41,38 @@ export function safeGetItem(key: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns the approximate total bytes used by all keys and values in
+ * localStorage. Each character is counted as 2 bytes (UTF-16), which
+ * matches the ECMAScript specification for string storage and is the
+ * metric browsers use for quota accounting.
+ *
+ * Use this to get a rough picture of storage pressure — for example, to
+ * decide whether to pre-emptively evict the cached receipt image.
+ */
+export function measureStorageUsage(): number {
+  let total = 0;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key) {
+      // Each JS string character is 2 bytes (UTF-16)
+      total += key.length * 2;
+      const value = localStorage.getItem(key);
+      if (value) {
+        total += value.length * 2;
+      }
+    }
+  }
+  return total;
+}
+
+/**
+ * Format a byte count to a human-readable string (B, KB, or MB).
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,25 @@
+/**
+ * Safe localStorage wrapper that handles QuotaExceededError.
+ * Returns true on success, false on failure (logs the error to console).
+ */
+export function safeSetItem(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch (err) {
+    console.warn("localStorage.setItem failed:", err);
+    return false;
+  }
+}
+
+/**
+ * Safe localStorage.getItem wrapper.
+ * Returns null on any error, or the stored value on success.
+ */
+export function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,3 +1,5 @@
+export const RECEIPT_IMAGE_STORAGE_KEY = "receiptSplitterImage";
+
 /**
  * Safe localStorage wrapper that handles QuotaExceededError.
  * Returns true on success, false on failure (logs the error to console).
@@ -43,6 +45,15 @@ export function safeGetItem(key: string): string | null {
   }
 }
 
+export function safeRemoveItem(key: string): boolean {
+  try {
+    localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Returns the approximate total bytes used by all keys and values in
  * localStorage. Each character is counted as 2 bytes (UTF-16), which
@@ -53,19 +64,23 @@ export function safeGetItem(key: string): string | null {
  * decide whether to pre-emptively evict the cached receipt image.
  */
 export function measureStorageUsage(): number {
-  let total = 0;
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key) {
-      // Each JS string character is 2 bytes (UTF-16)
-      total += key.length * 2;
-      const value = localStorage.getItem(key);
-      if (value) {
-        total += value.length * 2;
+  try {
+    let total = 0;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key) {
+        // Each JS string character is 2 bytes (UTF-16)
+        total += key.length * 2;
+        const value = localStorage.getItem(key);
+        if (value) {
+          total += value.length * 2;
+        }
       }
     }
+    return total;
+  } catch {
+    return 0;
   }
-  return total;
 }
 
 /**


### PR DESCRIPTION
Closes #118.

## What

Added resilient localStorage helpers in `src/lib/storage.ts`:

- `safeSetItem` catches quota and other storage exceptions.
- `safeGetItem` protects session and image restore paths.
- `safeRemoveItem` protects cleanup and eviction paths.
- `measureStorageUsage` reports approximate usage without allowing diagnostic failures to escape.
- `RECEIPT_IMAGE_STORAGE_KEY` keeps the shared image-cache key consistent.

Applied the helpers to the session persistence and receipt preview flows. If saving the session fails, the cached image is evicted and the session save is retried once.

## Why

A compressed receipt image can exceed the smallest common browser localStorage quota, especially in Safari. Storage failures should not crash the app or prevent a receipt upload from completing.

## Testing

- Full Jest suite: 459 tests pass, 0 failures across 24 suites
- `npm run lint`: passes; retains one pre-existing exhaustive-deps warning in `receipt-details.tsx`
- `npm run build`: passes
- Added coverage for protected reads, usage-measurement failures, cleanup failures, image eviction/retry, retry failure, and restoration of test storage overrides