### PR TITLE
Add root error boundary (#120)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { AlertCircle, RotateCcw } from 'lucide-react';
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RootError({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    // Log the error for debugging
+    console.error('Root error:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md animate-in fade-in-0 slide-in-from-bottom-4 duration-500">
+        <CardContent className="flex flex-col items-center justify-center py-8 px-6">
+          <div className="relative mb-6">
+            <AlertCircle className="h-16 w-16 text-destructive" />
+            <div className="absolute inset-0 h-16 w-16 animate-pulse rounded-full bg-destructive/10" />
+          </div>
+          <h2 className="text-xl font-semibold mb-3 text-center">
+            Something went wrong
+          </h2>
+          <p className="text-sm text-muted-foreground text-center mb-6 leading-relaxed">
+            We encountered an unexpected error. Please try again or start a new
+            split.
+          </p>
+          <div className="flex flex-col gap-3 w-full">
+            <Button
+              onClick={reset}
+              className="w-full h-11 text-base transition-all duration-200 active:scale-95"
+            >
+              <RotateCcw className="h-5 w-5 mr-2" />
+              Try Again
+            </Button>
+          </div>
+          {process.env.NODE_ENV === 'development' && (
+            <details className="mt-4 w-full">
+              <summary className="text-xs text-muted-foreground cursor-pointer">
+                Error details (development only)
+              </summary>
+              <pre className="text-xs bg-muted p-2 rounded mt-2 overflow-auto">
+                {error.message}
+                {error.stack && `\n\n${error.stack}`}
+              </pre>
+            </details>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #120.

## What
Adds `src/app/error.tsx` — a root-level error boundary for the app, following the existing pattern in `src/app/split/error.tsx`.

- Same `'use client'` pattern and `ErrorPageProps` interface
- Card layout with `AlertCircle` icon and pulsing background
- `Try Again` button that calls `reset()` to re-render the segment
- Dev-mode error details collapsible section (message + stack trace)
- Generic error message (no route-specific copy)
- No toast notifications (consistent with the split error boundary)

## Why
The `/split` route already has an `error.tsx` boundary, but the root app lacked one. Without a root error boundary, any unhandled error in the app would show Next.js's default error overlay in development or a blank page in production — a poor user experience.

## Testing
- `npm run build` — compiles successfully
- `npm run lint` — passes (no new warnings)
- `npm test` — 23 suites, 440 tests all pass
- Pattern matched against existing `src/app/split/error.tsx`

---
🤖 Draft by Hermes — review required, will not auto-merge.