### PR TITLE
fix(tests): add missing currency property to all test fixtures (#119)

### DIFF
--- a/src/components/split-summary.test.tsx
+++ b/src/components/split-summary.test.tsx
@@ -13,6 +13,7 @@ const mockSplitData: SharedSplitData = {
   total: 65.0,
   note: "Pizza Palace",
   phone: "5551234567",
+  currency: "USD",
   date: "2024-01-15",
 };
 
@@ -22,6 +23,7 @@ const mockMinimalSplitData: SharedSplitData = {
   total: 25.0,
   note: "Test Split",
   phone: "5551234567",
+  currency: "USD",
 };
 
 describe("SplitSummary", () => {

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -391,6 +391,7 @@ describe("validateReceiptInvariants", () => {
         tax: 1.00,
         tip: 2.00,
         total: 13.00,
+        currency: "USD",
         items: [
           { name: "Item 1", price: 3.33, quantity: 1 },
           { name: "Item 2", price: 3.33, quantity: 1 },
@@ -415,6 +416,7 @@ describe("validateReceiptInvariants", () => {
         tax: 1.00,
         tip: 2.00,
         total: 13.00,
+        currency: "USD",
         items: [
           { name: "Shared Item", price: 10.00, quantity: 1 },
         ],
@@ -527,6 +529,7 @@ describe("validateReceiptInvariants", () => {
         tax: 10.00,
         tip: 15.00,
         total: 125.00,
+        currency: "USD",
         items: [
           { name: "Item 1", price: 25, quantity: 1 },
           { name: "Item 2", price: 25, quantity: 1 },
@@ -552,6 +555,7 @@ describe("validateReceiptInvariants", () => {
         tax: 1.00,
         tip: 2.00,
         total: 13.00,
+        currency: "USD",
         items: [
           { name: "Item 1", price: 3.33, quantity: 1 },
           { name: "Item 2", price: 3.34, quantity: 1 },
@@ -573,6 +577,7 @@ describe("validateReceiptInvariants", () => {
         tax: 10.00,
         tip: 15.00,
         total: 125.00,
+        currency: "USD",
         items: [
           { name: "Shared Item", price: 100, quantity: 1 },
         ],
@@ -604,6 +609,7 @@ describe("validateReceiptInvariants", () => {
         tax: 1.00,
         tip: 2.00,
         total: 13.00,
+        currency: "USD",
         items: [
           { name: "Shared Item", price: 10.00, quantity: 1 },
         ],
@@ -629,6 +635,7 @@ describe("validateReceiptInvariants", () => {
         tax: 10.00,
         tip: 15.00,
         total: 125.00,
+        currency: "USD",
         items: [
           { name: "Unassigned Item", price: 100, quantity: 1 },
         ],
@@ -653,6 +660,7 @@ describe("validateReceiptInvariants", () => {
         tax: -1, // Negative
         tip: -2, // Negative
         total: -13, // Negative
+        currency: "USD",
         items: [
           { name: "Bad Item", price: -5, quantity: -1 }, // Both negative
         ],
@@ -673,6 +681,7 @@ describe("validateReceiptInvariants", () => {
         tax: 10,
         tip: 15,
         total: 200,  // Should be 125
+        currency: "USD",
         items: [],
       };
       const result = validateReceiptInvariants(receipt, new Map(), []);
@@ -694,6 +703,7 @@ describe("validateReceiptInvariants", () => {
         tax: 10,
         tip: 15,
         total: 125,  // Correct
+        currency: "USD",
         items: [],
       };
       const result = validateReceiptInvariants(receipt, new Map(), []);
@@ -708,6 +718,7 @@ describe("validateReceiptInvariants", () => {
         tax: 1.50,
         tip: 2.25,
         total: 13.75,  // Correct sum
+        currency: "USD",
         items: [],
       };
       const result = validateReceiptInvariants(receipt, new Map(), []);

--- a/src/lib/split-sharing.test.ts
+++ b/src/lib/split-sharing.test.ts
@@ -84,6 +84,7 @@ describe("serializeSplitData", () => {
 
     expect(params.get("note")).toBe("Test Note");
     expect(params.get("phone")).toBe("5551234567");
+    expect(params.get("currency")).toBe("USD");
     expect(params.get("date")).toBeNull();
   });
 
@@ -807,11 +808,14 @@ describe("minor-unit migration (pre-implementation tests)", () => {
       people,
       "Test",
       "5551234567",
-      "2024-01-01"
+      "USD",         // currency
+      "2024-01-01"  // date
     );
 
     expect(params.get("amounts")).toBe("101,202");
     expect(params.get("total")).toBe("303");
+    expect(params.get("currency")).toBe("USD");
+    expect(params.get("date")).toBe("2024-01-01");
   });
 
   it("deserializes cents back to dollars for internal math or exposes cents variant API", () => {

--- a/src/lib/split-sharing.test.ts
+++ b/src/lib/split-sharing.test.ts
@@ -78,6 +78,7 @@ describe("serializeSplitData", () => {
       mockPeople,
       "Test Note",
       "5551234567",
+      "USD",
       null
     );
 
@@ -367,6 +368,7 @@ describe("validateSplitData", () => {
     total: 50.0,
     note: "Test Restaurant",
     phone: "5551234567",
+    currency: "USD",
     date: "2024-01-15",
   };
 
@@ -381,6 +383,7 @@ describe("validateSplitData", () => {
       total: 25.0,
       note: "Test Split",
       phone: "5551234567",
+      currency: "USD",
     };
 
     expect(validateSplitData(minimalData)).toBe(true);
@@ -488,6 +491,7 @@ describe("validateSplitData", () => {
       total: 67.52, // difference = 0.02, people = 4 → tolerance = 0.04
       note: "Love Mama",
       phone: "5551234567",
+      currency: "USD",
       date: "2025-09-05",
     };
 
@@ -503,6 +507,7 @@ describe("validateSplitData", () => {
       total: 50.06, // difference 0.06; tolerance = 5 * 0.01 = 0.05 → should fail
       note: "Test",
       phone: "5551234567",
+      currency: "USD",
     };
 
     expect(validateSplitData(data)).toBe(false);
@@ -630,6 +635,7 @@ describe("validateSplitDataDetailed", () => {
     total: 50.0,
     note: "Test Restaurant",
     phone: "5551234567",
+    currency: "USD",
     date: "2024-01-15",
   };
 

--- a/src/lib/webhook-notifications.test.ts
+++ b/src/lib/webhook-notifications.test.ts
@@ -19,6 +19,7 @@ describe('webhook-notifications', () => {
     tax: 2.0,
     tip: 3.0,
     total: 25.0,
+    currency: 'USD',
     items: [
       { name: 'Burger', price: 10.0, quantity: 2 },
       { name: 'Fries', price: 5.0, quantity: 1 },


### PR DESCRIPTION
Closes #119.

## What
Adds the required `currency: "USD"` property to 19 inline fixture objects across 4 test files that were missing it after `currency` was made a required field on `Receipt` and `SharedSplitData` types. Also addresses Claude's PR review feedback.

## Changes
- **`src/components/split-summary.test.tsx`** (2 fixtures): `mockSplitData` and `mockMinimalSplitData`
- **`src/lib/receipt-utils.test.ts`** (11 fixtures): all inline `const receipt: Receipt = {...}` objects
- **`src/lib/split-sharing.test.ts`** (5 fixtures + 2 fixes): all inline `const ...: SharedSplitData = {...}` objects; fixed a test calling `serializeSplitData` with `null` as 4th arg (currency); fixed arg-order bug in minor-unit migration test (was passing `"2024-01-01"` as currency instead of date); added missing `currency` assertion to "should work without optional date" test
- **`src/lib/webhook-notifications.test.ts`** (1 fixture): `mockReceipt`

## Testing
- `npx tsc --noEmit` — clean
- `npx jest --passWithNoTests` — 23 suites, 440 tests, all passed

## Review feedback addressed
- ✅ Fixed arg-order bug in minor-unit migration test (`serializeSplitData` call at line 806)
- ✅ Added missing `currency` assertion in "should work without optional date" test

---
🤖 Draft by Hermes — review required, will not auto-merge.