### PR TITLE
Refactor item-assignment.tsx: extract duplicate equal-split logic and split out dialogs (#122)

### DIFF
--- a/src/components/add-item-dialog.tsx
+++ b/src/components/add-item-dialog.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { formatCurrency } from "@/lib/receipt-utils";
+
+interface AddItemDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (name: string, price: number, quantity: number) => void;
+}
+
+export function AddItemDialog({
+  open,
+  onOpenChange,
+  onSave,
+}: AddItemDialogProps) {
+  const [name, setName] = useState("");
+  const [price, setPrice] = useState(0);
+  const [quantity, setQuantity] = useState(1);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(name, price, quantity);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add New Item</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="new-item-name">Item Name</Label>
+              <Input
+                id="new-item-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., Burger, Pizza, Salad"
+                autoFocus
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="new-item-price">Price</Label>
+              <Input
+                id="new-item-price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={price}
+                onChange={(e) => setPrice(parseFloat(e.target.value) || 0)}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="new-item-quantity">Quantity</Label>
+              <Input
+                id="new-item-quantity"
+                type="number"
+                min="1"
+                step="1"
+                value={quantity}
+                onChange={(e) => setQuantity(parseInt(e.target.value) || 1)}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <span className="font-medium">Total:</span>
+              <span>{formatCurrency(price * quantity)}</span>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              type="button"
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Add Item</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/add-item-dialog.tsx
+++ b/src/components/add-item-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -25,6 +25,14 @@ export function AddItemDialog({
   const [name, setName] = useState("");
   const [price, setPrice] = useState(0);
   const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setPrice(0);
+      setQuantity(1);
+    }
+  }, [open]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/add-item-dialog.tsx
+++ b/src/components/add-item-dialog.tsx
@@ -14,12 +14,14 @@ import { formatCurrency } from "@/lib/receipt-utils";
 interface AddItemDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  currency: string;
   onSave: (name: string, price: number, quantity: number) => void;
 }
 
 export function AddItemDialog({
   open,
   onOpenChange,
+  currency,
   onSave,
 }: AddItemDialogProps) {
   const [name, setName] = useState("");
@@ -86,7 +88,7 @@ export function AddItemDialog({
 
             <div className="flex items-center justify-between">
               <span className="font-medium">Total:</span>
-              <span>{formatCurrency(price * quantity)}</span>
+              <span>{formatCurrency(price * quantity, currency)}</span>
             </div>
           </div>
 

--- a/src/components/edit-item-dialog.tsx
+++ b/src/components/edit-item-dialog.tsx
@@ -1,0 +1,100 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { formatCurrency } from "@/lib/receipt-utils";
+
+interface EditItemDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  itemName: string;
+  initialPrice: number;
+  initialQuantity: number;
+  onSave: (price: number, quantity: number) => void;
+}
+
+export function EditItemDialog({
+  open,
+  onOpenChange,
+  itemName,
+  initialPrice,
+  initialQuantity,
+  onSave,
+}: EditItemDialogProps) {
+  const [price, setPrice] = useState(initialPrice);
+  const [quantity, setQuantity] = useState(initialQuantity);
+
+  useEffect(() => {
+    if (open) {
+      setPrice(initialPrice);
+      setQuantity(initialQuantity);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(price, quantity);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Item: {itemName}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="item-price">Item Price</Label>
+              <Input
+                id="item-price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={price || ""}
+                onChange={(e) => setPrice(parseFloat(e.target.value) || 0)}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="item-quantity">Quantity</Label>
+              <Input
+                id="item-quantity"
+                type="number"
+                min="1"
+                step="1"
+                value={quantity || ""}
+                onChange={(e) => setQuantity(parseInt(e.target.value) || 1)}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <span className="font-medium">Total:</span>
+              <span>{formatCurrency(price * quantity)}</span>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              type="button"
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Save Changes</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/edit-item-dialog.tsx
+++ b/src/components/edit-item-dialog.tsx
@@ -17,6 +17,7 @@ interface EditItemDialogProps {
   itemName: string;
   initialPrice: number;
   initialQuantity: number;
+  currency: string;
   onSave: (price: number, quantity: number) => void;
 }
 
@@ -26,6 +27,7 @@ export function EditItemDialog({
   itemName,
   initialPrice,
   initialQuantity,
+  currency,
   onSave,
 }: EditItemDialogProps) {
   const [price, setPrice] = useState(initialPrice);
@@ -79,7 +81,7 @@ export function EditItemDialog({
 
             <div className="flex items-center justify-between">
               <span className="font-medium">Total:</span>
-              <span>{formatCurrency(price * quantity)}</span>
+              <span>{formatCurrency(price * quantity, currency)}</span>
             </div>
           </div>
 

--- a/src/components/edit-split-dialog.test.tsx
+++ b/src/components/edit-split-dialog.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, within } from "@testing-library/react";
+import { EditSplitDialog } from "./edit-split-dialog";
+
+const people = [
+  { id: "a", name: "Alice", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+  { id: "b", name: "Bob", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+];
+
+describe("EditSplitDialog", () => {
+  it("restores selected people when assignments are missing", () => {
+    render(
+      <EditSplitDialog
+        open
+        onOpenChange={jest.fn()}
+        itemIndex={0}
+        itemName="Drinks"
+        itemPrice={30}
+        itemQuantity={1}
+        currency="USD"
+        people={people}
+        existingAssignments={[]}
+        selectedPersonIds={["a"]}
+        onSave={jest.fn()}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog", { name: /Edit Split/i });
+
+    expect(within(dialog).getByRole("checkbox", { name: /Alice/i })).toBeChecked();
+    expect(within(dialog).getByDisplayValue("100")).toBeInTheDocument();
+    expect(within(dialog).getByRole("checkbox", { name: /Bob/i })).not.toBeChecked();
+  });
+});

--- a/src/components/edit-split-dialog.tsx
+++ b/src/components/edit-split-dialog.tsx
@@ -1,0 +1,360 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { toast } from "sonner";
+import Decimal from "decimal.js";
+
+import { type Person, type PersonItemAssignment } from "@/types";
+import { formatCurrency, distributeEqualShares } from "@/lib/receipt-utils";
+
+type SplitMode = "percent" | "amount";
+
+interface EditSplitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  itemIndex: number;
+  itemName: string;
+  itemPrice: number;
+  itemQuantity: number;
+  currency: string;
+  people: Person[];
+  existingAssignments: PersonItemAssignment[];
+  onSave: (itemIndex: number, assignments: PersonItemAssignment[]) => void;
+}
+
+export function EditSplitDialog({
+  open,
+  onOpenChange,
+  itemIndex,
+  itemName,
+  itemPrice,
+  itemQuantity,
+  currency,
+  people,
+  existingAssignments,
+  onSave,
+}: EditSplitDialogProps) {
+  const [assignments, setAssignments] = useState<Map<string, number>>(
+    new Map()
+  );
+  const [rawInputs, setRawInputs] = useState<Map<string, string>>(new Map());
+  const [splitMode, setSplitMode] = useState<SplitMode>("percent");
+
+  const itemTotal = new Decimal(itemPrice).times(itemQuantity || 1);
+
+  // Initialize from existing assignments when dialog opens
+  useEffect(() => {
+    if (open) {
+      setRawInputs(new Map());
+      setSplitMode("percent");
+
+      if (existingAssignments.length > 0) {
+        const newAssignments = new Map<string, number>();
+        existingAssignments.forEach((a) => {
+          newAssignments.set(a.personId, a.sharePercentage);
+        });
+        setAssignments(newAssignments);
+      } else {
+        setAssignments(new Map());
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, itemIndex]);
+
+  const getDisplayValue = (personId: string): string => {
+    if (rawInputs.has(personId)) {
+      return rawInputs.get(personId) || "";
+    }
+    const pct = assignments.get(personId);
+    if (pct === undefined) return "";
+
+    if (splitMode === "percent") {
+      return pct.toString();
+    } else {
+      const amount = itemTotal.mul(pct).div(100);
+      return amount.toNumber().toFixed(2);
+    }
+  };
+
+  const handleChange = (personId: string, value: string) => {
+    const newRawInputs = new Map(rawInputs);
+    const newAssignments = new Map(assignments);
+
+    if (value === "") {
+      newRawInputs.delete(personId);
+      newAssignments.delete(personId);
+    } else {
+      newRawInputs.set(personId, value);
+      const numValue = parseFloat(value);
+      if (!isNaN(numValue) && numValue >= 0) {
+        if (splitMode === "percent") {
+          newAssignments.set(personId, numValue);
+        } else {
+          // Convert dollar amount to percentage
+          if (itemTotal.isZero()) {
+            newAssignments.set(personId, 0);
+          } else {
+            const pct = new Decimal(numValue).div(itemTotal).mul(100).toNumber();
+            newAssignments.set(personId, pct);
+          }
+        }
+      }
+    }
+
+    setRawInputs(newRawInputs);
+    setAssignments(newAssignments);
+  };
+
+  const splitEqually = () => {
+    let selectedPeopleIds = Array.from(assignments.keys());
+
+    if (selectedPeopleIds.length === 0) {
+      selectedPeopleIds = people.map((p) => p.id);
+      if (selectedPeopleIds.length === 0) {
+        toast.error("No people to assign");
+        return;
+      }
+      const tmpAssignments = new Map(assignments);
+      selectedPeopleIds.forEach((personId) => {
+        tmpAssignments.set(personId, 0);
+      });
+      setAssignments(tmpAssignments);
+    }
+
+    const result = distributeEqualShares(selectedPeopleIds);
+    const newAssignments = new Map<string, number>();
+    result.forEach((a) => {
+      newAssignments.set(a.personId, a.sharePercentage);
+    });
+    setAssignments(newAssignments);
+    setRawInputs(new Map());
+  };
+
+  const saveAssignment = () => {
+    let assignmentArray: PersonItemAssignment[];
+
+    if (splitMode === "amount") {
+      const dollarSum = Array.from(assignments.values()).reduce(
+        (sum, pct) =>
+          sum.plus(new Decimal(pct || 0).dividedBy(100).times(itemTotal)),
+        new Decimal(0)
+      );
+
+      if (dollarSum.minus(itemTotal).abs().greaterThan(0.01)) {
+        toast.error(
+          `Dollar amounts must sum to ${formatCurrency(
+            itemTotal.toNumber(),
+            currency
+          )}`
+        );
+        return;
+      }
+
+      const entries = Array.from(assignments.entries()).filter(
+        ([, pct]) => pct > 0
+      );
+
+      assignmentArray = [];
+      let runningPct = new Decimal(0);
+
+      entries.forEach(([personId, pct], index) => {
+        if (index === entries.length - 1) {
+          const lastPct = new Decimal(100).minus(runningPct);
+          assignmentArray.push({
+            personId,
+            sharePercentage: +lastPct.toFixed(2),
+          });
+        } else {
+          const rounded = new Decimal(pct).toDecimalPlaces(2);
+          assignmentArray.push({
+            personId,
+            sharePercentage: rounded.toNumber(),
+          });
+          runningPct = runningPct.plus(rounded);
+        }
+      });
+    } else {
+      const totalPercentage = Array.from(assignments.values()).reduce(
+        (sum, value) => sum + (value || 0),
+        0
+      );
+
+      if (Math.abs(totalPercentage - 100) > 0.01) {
+        toast.error("Total percentage must be 100%");
+        return;
+      }
+
+      assignmentArray = [];
+      assignments.forEach((percentage, personId) => {
+        if (percentage > 0) {
+          assignmentArray.push({
+            personId,
+            sharePercentage: percentage,
+          });
+        }
+      });
+    }
+
+    onSave(itemIndex, assignmentArray);
+    onOpenChange(false);
+  };
+
+  const totalPct = Array.from(assignments.values()).reduce(
+    (sum, v) => sum + (v || 0),
+    0
+  );
+  const dollarSum = Array.from(assignments.values()).reduce(
+    (sum, pct) =>
+      sum.plus(new Decimal(pct || 0).dividedBy(100).times(itemTotal)),
+    new Decimal(0)
+  );
+  const isValid =
+    splitMode === "amount"
+      ? dollarSum.minus(itemTotal).abs().lessThanOrEqualTo(0.01)
+      : Math.abs(totalPct - 100) <= 0.01;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Edit Split: {itemName}
+            {itemQuantity > 1 ? ` (x${itemQuantity})` : ""}
+          </DialogTitle>
+        </DialogHeader>
+        {(() => {
+          return (
+            <>
+              <div className="grid gap-4 py-4">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">Item Total:</span>
+                  <span>
+                    {formatCurrency(itemTotal.toNumber(), currency)}
+                  </span>
+                </div>
+                <div className="flex rounded-md border overflow-hidden">
+                  <Button
+                    type="button"
+                    variant={splitMode === "percent" ? "default" : "ghost"}
+                    size="sm"
+                    className="rounded-none h-7 px-2 text-xs"
+                    onClick={() => {
+                      setSplitMode("percent");
+                      setRawInputs(new Map());
+                    }}
+                  >
+                    %
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={splitMode === "amount" ? "default" : "ghost"}
+                    size="sm"
+                    className="rounded-none h-7 px-2 text-xs"
+                    onClick={() => {
+                      setSplitMode("amount");
+                      setRawInputs(new Map());
+                    }}
+                  >
+                    $
+                  </Button>
+                </div>
+              </div>
+
+              {people.map((person) => (
+                <div
+                  key={person.id}
+                  className="grid grid-cols-2 items-center gap-4"
+                >
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id={`person-${person.id}-dialog`}
+                      checked={assignments.has(person.id)}
+                      onCheckedChange={(checked) => {
+                        const newAssignments = new Map(assignments);
+                        if (checked) {
+                          newAssignments.set(person.id, 0);
+                        } else {
+                          newAssignments.delete(person.id);
+                        }
+                        setAssignments(newAssignments);
+                      }}
+                    />
+                    <Label htmlFor={`person-${person.id}-dialog`}>
+                      {person.name}
+                    </Label>
+                  </div>
+                  <div className="flex items-center">
+                    <Input
+                      id={`person-${person.id}-${splitMode}`}
+                      type="text"
+                      inputMode="decimal"
+                      value={getDisplayValue(person.id)}
+                      onChange={(e) =>
+                        handleChange(person.id, e.target.value)
+                      }
+                      onBlur={() => {
+                        const newRawInputs = new Map(rawInputs);
+                        newRawInputs.delete(person.id);
+                        setRawInputs(newRawInputs);
+                      }}
+                      className="w-20 text-right"
+                    />
+                    <span className="ml-2">
+                      {splitMode === "percent" ? "%" : ""}
+                    </span>
+                  </div>
+                </div>
+              ))}
+
+              <div className="flex items-center justify-between pt-2">
+                <span className="font-medium">Total:</span>
+                <span
+                  className={
+                    isValid
+                      ? "text-green-500 font-medium"
+                      : "text-destructive font-medium"
+                  }
+                >
+                  {splitMode === "amount"
+                    ? `${formatCurrency(
+                        dollarSum.toNumber(),
+                        currency
+                      )} / ${formatCurrency(itemTotal.toNumber(), currency)}`
+                    : `${totalPct}%`}
+                </span>
+              </div>
+
+              <DialogFooter className="flex flex-col sm:flex-row gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={splitEqually}
+                  className="w-full sm:w-auto"
+                >
+                  Split Equally
+                </Button>
+                <Button
+                  type="button"
+                  onClick={saveAssignment}
+                  className="w-full sm:w-auto"
+                  disabled={!isValid}
+                >
+                  Save Assignment
+                </Button>
+              </DialogFooter>
+            </>
+          );
+        })()}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/edit-split-dialog.tsx
+++ b/src/components/edit-split-dialog.tsx
@@ -21,13 +21,14 @@ type SplitMode = "percent" | "amount";
 interface EditSplitDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  itemIndex: number;
+  itemIndex: number | null;
   itemName: string;
   itemPrice: number;
   itemQuantity: number;
   currency: string;
   people: Person[];
   existingAssignments: PersonItemAssignment[];
+  selectedPersonIds: string[];
   onSave: (itemIndex: number, assignments: PersonItemAssignment[]) => void;
 }
 
@@ -41,6 +42,7 @@ export function EditSplitDialog({
   currency,
   people,
   existingAssignments,
+  selectedPersonIds,
   onSave,
 }: EditSplitDialogProps) {
   const [assignments, setAssignments] = useState<Map<string, number>>(
@@ -62,6 +64,14 @@ export function EditSplitDialog({
         existingAssignments.forEach((a) => {
           newAssignments.set(a.personId, a.sharePercentage);
         });
+        setAssignments(newAssignments);
+      } else if (selectedPersonIds.length > 0) {
+        const newAssignments = new Map(
+          distributeEqualShares(selectedPersonIds).map((a) => [
+            a.personId,
+            a.sharePercentage,
+          ])
+        );
         setAssignments(newAssignments);
       } else {
         setAssignments(new Map());
@@ -140,6 +150,8 @@ export function EditSplitDialog({
   };
 
   const saveAssignment = () => {
+    if (itemIndex === null) return;
+
     let assignmentArray: PersonItemAssignment[];
 
     if (splitMode === "amount") {

--- a/src/components/edit-split-dialog.tsx
+++ b/src/components/edit-split-dialog.tsx
@@ -226,21 +226,14 @@ export function EditSplitDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>
-            Edit Split: {itemName}
-            {itemQuantity > 1 ? ` (x${itemQuantity})` : ""}
-          </DialogTitle>
+          <DialogTitle>Edit Split: {itemName}</DialogTitle>
         </DialogHeader>
-        {(() => {
-          return (
-            <>
-              <div className="grid gap-4 py-4">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium">Item Total:</span>
-                  <span>
-                    {formatCurrency(itemTotal.toNumber(), currency)}
-                  </span>
-                </div>
+        <>
+          <div className="grid gap-4 py-4">
+            <div className="flex items-center justify-between">
+              <span className="font-medium">Item Price:</span>
+              <div className="flex items-center gap-3">
+                <span>{formatCurrency(itemTotal.toNumber(), currency)}</span>
                 <div className="flex rounded-md border overflow-hidden">
                   <Button
                     type="button"
@@ -268,92 +261,90 @@ export function EditSplitDialog({
                   </Button>
                 </div>
               </div>
+            </div>
 
-              {people.map((person) => (
-                <div
-                  key={person.id}
-                  className="grid grid-cols-2 items-center gap-4"
-                >
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id={`person-${person.id}-dialog`}
-                      checked={assignments.has(person.id)}
-                      onCheckedChange={(checked) => {
-                        const newAssignments = new Map(assignments);
-                        if (checked) {
-                          newAssignments.set(person.id, 0);
-                        } else {
-                          newAssignments.delete(person.id);
-                        }
-                        setAssignments(newAssignments);
-                      }}
-                    />
-                    <Label htmlFor={`person-${person.id}-dialog`}>
-                      {person.name}
-                    </Label>
-                  </div>
-                  <div className="flex items-center">
-                    <Input
-                      id={`person-${person.id}-${splitMode}`}
-                      type="text"
-                      inputMode="decimal"
-                      value={getDisplayValue(person.id)}
-                      onChange={(e) =>
-                        handleChange(person.id, e.target.value)
+            {people.map((person) => (
+              <div
+                key={person.id}
+                className="grid grid-cols-2 items-center gap-4"
+              >
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id={`person-${person.id}-dialog`}
+                    checked={assignments.has(person.id)}
+                    onCheckedChange={(checked) => {
+                      const newAssignments = new Map(assignments);
+                      if (checked) {
+                        newAssignments.set(person.id, 0);
+                      } else {
+                        newAssignments.delete(person.id);
                       }
-                      onBlur={() => {
-                        const newRawInputs = new Map(rawInputs);
-                        newRawInputs.delete(person.id);
-                        setRawInputs(newRawInputs);
-                      }}
-                      className="w-20 text-right"
-                    />
-                    <span className="ml-2">
-                      {splitMode === "percent" ? "%" : ""}
-                    </span>
-                  </div>
+                      setAssignments(newAssignments);
+                    }}
+                  />
+                  <Label htmlFor={`person-${person.id}-dialog`}>
+                    {person.name}
+                  </Label>
                 </div>
-              ))}
-
-              <div className="flex items-center justify-between pt-2">
-                <span className="font-medium">Total:</span>
-                <span
-                  className={
-                    isValid
-                      ? "text-green-500 font-medium"
-                      : "text-destructive font-medium"
-                  }
-                >
-                  {splitMode === "amount"
-                    ? `${formatCurrency(
-                        dollarSum.toNumber(),
-                        currency
-                      )} / ${formatCurrency(itemTotal.toNumber(), currency)}`
-                    : `${totalPct}%`}
-                </span>
+                <div className="flex items-center">
+                  <Input
+                    id={`person-${person.id}-${splitMode}`}
+                    type="text"
+                    inputMode="decimal"
+                    value={getDisplayValue(person.id)}
+                    onChange={(e) => handleChange(person.id, e.target.value)}
+                    onBlur={() => {
+                      const newRawInputs = new Map(rawInputs);
+                      newRawInputs.delete(person.id);
+                      setRawInputs(newRawInputs);
+                    }}
+                    className="w-20 text-right"
+                  />
+                  <span className="ml-2">
+                    {splitMode === "percent" ? "%" : ""}
+                  </span>
+                </div>
               </div>
+            ))}
 
-              <DialogFooter className="flex flex-col sm:flex-row gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={splitEqually}
-                  className="w-full sm:w-auto"
-                >
-                  Split Equally
-                </Button>
-                <Button
-                  type="button"
-                  onClick={saveAssignment}
-                  className="w-full sm:w-auto"
-                  disabled={!isValid}
-                >
-                  Save Assignment
-                </Button>
-              </DialogFooter>
-            </>
-          );
-        })()}
+            <div className="flex items-center justify-between pt-2">
+              <span className="font-medium">Total:</span>
+              <span
+                className={
+                  isValid
+                    ? "text-green-500 font-medium"
+                    : "text-destructive font-medium"
+                }
+              >
+                {splitMode === "amount"
+                  ? `${formatCurrency(
+                      dollarSum.toNumber(),
+                      currency
+                    )} / ${formatCurrency(itemTotal.toNumber(), currency)}`
+                  : `${totalPct}%`}
+              </span>
+            </div>
+          </div>
+
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={splitEqually}
+              className="w-full sm:w-auto"
+            >
+              Split Equally
+            </Button>
+            <Button
+              type="button"
+              onClick={saveAssignment}
+              className="w-full sm:w-auto"
+              disabled={!isValid}
+            >
+              Save Assignment
+            </Button>
+          </DialogFooter>
+        </>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/item-assignment.test.tsx
+++ b/src/components/item-assignment.test.tsx
@@ -105,6 +105,41 @@ describe("ItemAssignment", () => {
       expect(toast.error).toHaveBeenCalledWith("Item name is required");
     });
 
+    it("resets the form when reopened", () => {
+      render(
+        <ItemAssignment
+          receipt={mockReceipt}
+          people={mockPeople}
+          assignedItems={new Map()}
+          unassignedItems={[]}
+          onAssignItems={jest.fn()}
+          onReceiptUpdate={jest.fn()}
+        />
+      );
+
+      const addButton = screen.getByRole("button", { name: /add item/i });
+      fireEvent.click(addButton);
+
+      const dialog = screen.getByRole("dialog");
+      fireEvent.change(within(dialog).getByLabelText(/item name/i), {
+        target: { value: "Pizza" },
+      });
+      fireEvent.change(within(dialog).getByLabelText(/price/i), {
+        target: { value: "12.99" },
+      });
+      fireEvent.change(within(dialog).getByLabelText(/quantity/i), {
+        target: { value: "2" },
+      });
+      fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+
+      fireEvent.click(addButton);
+      const reopenedDialog = screen.getByRole("dialog");
+
+      expect(within(reopenedDialog).getByLabelText(/item name/i)).toHaveValue("");
+      expect(within(reopenedDialog).getByLabelText(/price/i)).toHaveValue(0);
+      expect(within(reopenedDialog).getByLabelText(/quantity/i)).toHaveValue(1);
+    });
+
     // Note: Price/quantity validation tests removed because HTML5 min attributes
     // and onChange fallbacks (|| 0, || 1) prevent invalid values from reaching
     // the validation logic in saveNewItem()

--- a/src/components/item-assignment.test.tsx
+++ b/src/components/item-assignment.test.tsx
@@ -353,6 +353,7 @@ describe("ItemAssignment", () => {
       expect(bobCheckbox).toBeChecked();
       expect(bobInput).toHaveDisplayValue("50");
     });
+
   });
 
   describe("Edit Split dialog (dollar-amount mode)", () => {

--- a/src/components/item-assignment.tsx
+++ b/src/components/item-assignment.tsx
@@ -10,15 +10,6 @@ import {
   TableHead,
   TableCell,
 } from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -26,7 +17,6 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
-import Decimal from "decimal.js";
 
 import {
   type Receipt,
@@ -38,9 +28,11 @@ import {
   formatCurrency,
   calculateSubtotal,
   remapAssignmentsAfterDelete,
+  distributeEqualShares,
 } from "@/lib/receipt-utils";
-
-type SplitMode = "percent" | "amount";
+import { EditSplitDialog } from "./edit-split-dialog";
+import { EditItemDialog } from "./edit-item-dialog";
+import { AddItemDialog } from "./add-item-dialog";
 
 interface ItemAssignmentProps {
   receipt: Receipt;
@@ -74,118 +66,9 @@ export function ItemAssignment({
   const [currentEditItemIndex, setCurrentEditItemIndex] = useState<
     number | null
   >(null);
-  const [editedItem, setEditedItem] = useState<{
-    price: number;
-    quantity: number;
-  } | null>(null);
-  const [newItem, setNewItem] = useState<{
-    name: string;
-    price: number;
-    quantity: number;
-  }>({
-    name: "",
-    price: 0,
-    quantity: 1,
-  });
-  const [assignments, setAssignments] = useState<Map<string, number>>(
-    new Map()
-  );
-  const [rawInputs, setRawInputs] = useState<Map<string, string>>(new Map());
-  const [splitMode, setSplitMode] = useState<SplitMode>("percent");
   const [selectedPeople, setSelectedPeople] = useState<
     Map<number, Set<string>>
   >(new Map());
-
-  // Apply selections to assignments when the dialog opens
-  useEffect(() => {
-    if (currentItemIndex !== null && open) {
-      setRawInputs(new Map()); // Clear raw inputs when dialog reinitializes
-      setSplitMode("percent"); // Reset to percent mode for each new item
-      // Load existing custom percentages if available
-      const existingAssignments = assignedItems.get(currentItemIndex) || [];
-
-      if (existingAssignments.length > 0) {
-        const newAssignments = new Map<string, number>();
-        existingAssignments.forEach((a) => {
-          newAssignments.set(a.personId, a.sharePercentage);
-        });
-        setAssignments(newAssignments);
-      } else {
-        // No existing assignments — initialize with equal split for selected people
-        const selected = selectedPeople.get(currentItemIndex) || new Set();
-
-        if (selected.size > 0) {
-          const peopleToAssign = Array.from(selected);
-          const equalShare = +(100 / peopleToAssign.length).toFixed(2);
-
-          const newAssignments = new Map<string, number>();
-          let runningSum = 0;
-
-          peopleToAssign.forEach((personId, index) => {
-            // Last person gets the remainder to ensure total is exactly 100%
-            if (index === peopleToAssign.length - 1) {
-              const lastShare = +(100 - runningSum).toFixed(2);
-              newAssignments.set(personId, lastShare);
-            } else {
-              newAssignments.set(personId, equalShare);
-              runningSum += equalShare;
-            }
-          });
-
-          setAssignments(newAssignments);
-        }
-      }
-    }
-    // Only re-initialize when the dialog opens or switches to a different item.
-    // Intentionally excluding selectedPeople and assignedItems to prevent
-    // in-flight edits from being reset by parent prop updates.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentItemIndex, open]);
-
-  // Handle split equally between selected people
-  const splitEqually = () => {
-    if (currentItemIndex === null) return;
-
-    // Get selected people (those with any value assigned)
-    let selectedPeopleIds = Array.from(assignments.keys());
-
-    // If none are selected, select all people
-    if (selectedPeopleIds.length === 0) {
-      selectedPeopleIds = people.map((p) => p.id);
-      if (selectedPeopleIds.length === 0) {
-        toast.error("No people to assign");
-        return;
-      }
-      // Update assignments state to include all people with 0% (will be set below)
-      const newAssignments = new Map(assignments);
-      selectedPeopleIds.forEach((personId) => {
-        newAssignments.set(personId, 0);
-      });
-      setAssignments(newAssignments);
-    }
-
-    // Calculate equal share with 2 decimal places
-    const equalShare = +(100 / selectedPeopleIds.length).toFixed(2);
-
-    // Distribute shares equally
-    const newAssignments = new Map<string, number>();
-    let runningSum = 0;
-
-    // Assign equal shares
-    selectedPeopleIds.forEach((personId, index) => {
-      // Last person gets the remainder to ensure total is exactly 100%
-      if (index === selectedPeopleIds.length - 1) {
-        const lastShare = +(100 - runningSum).toFixed(2);
-        newAssignments.set(personId, lastShare);
-      } else {
-        newAssignments.set(personId, equalShare);
-        runningSum += equalShare;
-      }
-    });
-
-    setAssignments(newAssignments);
-    setRawInputs(new Map()); // Clear raw inputs when split equally is applied
-  };
 
   // Check if all members of a group are selected for an item
   const isGroupFullySelected = (itemIndex: number, group: Group): boolean => {
@@ -227,27 +110,7 @@ export function ItemAssignment({
     // Auto-assign equal shares immediately
     if (newSelected.size > 0) {
       const peopleToAssign = Array.from(newSelected);
-      const equalShare = +(100 / peopleToAssign.length).toFixed(2);
-
-      const assignments: PersonItemAssignment[] = [];
-      let runningSum = 0;
-
-      peopleToAssign.forEach((personId, index) => {
-        // Last person gets the remainder to ensure total is exactly 100%
-        if (index === peopleToAssign.length - 1) {
-          const lastShare = +(100 - runningSum).toFixed(2);
-          assignments.push({
-            personId,
-            sharePercentage: lastShare,
-          });
-        } else {
-          assignments.push({
-            personId,
-            sharePercentage: equalShare,
-          });
-          runningSum += equalShare;
-        }
-      });
+      const assignments = distributeEqualShares(peopleToAssign);
 
       // Call the parent handler to update assignments
       onAssignItems(itemIndex, assignments);
@@ -277,27 +140,7 @@ export function ItemAssignment({
     // Auto-assign equal shares immediately
     if (newSelected.size > 0) {
       const peopleToAssign = Array.from(newSelected);
-      const equalShare = +(100 / peopleToAssign.length).toFixed(2);
-
-      const assignments: PersonItemAssignment[] = [];
-      let runningSum = 0;
-
-      peopleToAssign.forEach((personId, index) => {
-        // Last person gets the remainder to ensure total is exactly 100%
-        if (index === peopleToAssign.length - 1) {
-          const lastShare = +(100 - runningSum).toFixed(2);
-          assignments.push({
-            personId,
-            sharePercentage: lastShare,
-          });
-        } else {
-          assignments.push({
-            personId,
-            sharePercentage: equalShare,
-          });
-          runningSum += equalShare;
-        }
-      });
+      const assignments = distributeEqualShares(peopleToAssign);
 
       // Call the parent handler to update assignments
       onAssignItems(itemIndex, assignments);
@@ -307,88 +150,13 @@ export function ItemAssignment({
     }
   };
 
-  // Save the assignment
-  const saveAssignment = () => {
-    if (currentItemIndex === null) return;
-
-    let assignmentArray: PersonItemAssignment[];
-
-    if (splitMode === "amount") {
-      const item = receipt.items[currentItemIndex];
-      const itemTotal = new Decimal(item.price).times(item.quantity || 1);
-
-      // assignments stores percentages; convert to dollar sum for validation
-      const dollarSum = Array.from(assignments.values()).reduce(
-        (sum, pct) => sum.plus(new Decimal(pct || 0).dividedBy(100).times(itemTotal)),
-        new Decimal(0)
-      );
-
-      if (dollarSum.minus(itemTotal).abs().greaterThan(0.01)) {
-        toast.error(
-          `Dollar amounts must sum to ${formatCurrency(itemTotal.toNumber(), receipt.currency)}`
-        );
-        return;
-      }
-
-      // assignments stores percentages — pass them through directly,
-      // giving the last person the remainder so they sum to exactly 100.
-      const entries = Array.from(assignments.entries()).filter(
-        ([, pct]) => pct > 0
-      );
-
-      assignmentArray = [];
-      let runningPct = new Decimal(0);
-
-      entries.forEach(([personId, pct], index) => {
-        if (index === entries.length - 1) {
-          const lastPct = new Decimal(100).minus(runningPct);
-          assignmentArray.push({
-            personId,
-            sharePercentage: +lastPct.toFixed(2),
-          });
-        } else {
-          const rounded = new Decimal(pct).toDecimalPlaces(2);
-          assignmentArray.push({
-            personId,
-            sharePercentage: rounded.toNumber(),
-          });
-          runningPct = runningPct.plus(rounded);
-        }
-      });
-    } else {
-      // Calculate total percentage
-      const totalPercentage = Array.from(assignments.values()).reduce(
-        (sum, value) => sum + (value || 0),
-        0
-      );
-
-      // Ensure total is 100%
-      if (Math.abs(totalPercentage - 100) > 0.01) {
-        toast.error("Total percentage must be 100%");
-        return;
-      }
-
-      assignmentArray = [];
-      assignments.forEach((percentage, personId) => {
-        if (percentage > 0) {
-          assignmentArray.push({
-            personId,
-            sharePercentage: percentage,
-          });
-        }
-      });
-    }
-
-    // Update selected people to match assignments
-    const newSelected = new Set(assignmentArray.map((a) => a.personId));
+  // Handle split save from dialog
+  const handleSaveSplit = (itemIndex: number, assignments: PersonItemAssignment[]) => {
+    const newSelected = new Set(assignments.map((a) => a.personId));
     const newSelectedPeople = new Map(selectedPeople);
-    newSelectedPeople.set(currentItemIndex, newSelected);
+    newSelectedPeople.set(itemIndex, newSelected);
     setSelectedPeople(newSelectedPeople);
-
-    // Call the parent handler
-    onAssignItems(currentItemIndex, assignmentArray);
-
-    // Close dialog
+    onAssignItems(itemIndex, assignments);
     setOpen(false);
     setCurrentItemIndex(null);
   };
@@ -438,25 +206,20 @@ export function ItemAssignment({
 
   // Handle item edit
   const handleEditItem = (index: number) => {
-    const item = receipt.items[index];
     setCurrentEditItemIndex(index);
-    setEditedItem({
-      price: item.price,
-      quantity: item.quantity || 1,
-    });
     setEditItemDialogOpen(true);
   };
 
   // Save item edit
-  const saveItemEdit = () => {
-    if (currentEditItemIndex === null || !editedItem) return;
+  const saveItemEdit = (price: number, quantity: number) => {
+    if (currentEditItemIndex === null) return;
 
     const updatedReceipt = { ...receipt };
     updatedReceipt.items = [...receipt.items];
     updatedReceipt.items[currentEditItemIndex] = {
       ...updatedReceipt.items[currentEditItemIndex],
-      price: editedItem.price,
-      quantity: editedItem.quantity,
+      price,
+      quantity,
     };
 
     // Recalculate subtotal using Decimal.js
@@ -466,7 +229,6 @@ export function ItemAssignment({
     onReceiptUpdate(updatedReceipt);
     setEditItemDialogOpen(false);
     setCurrentEditItemIndex(null);
-    setEditedItem(null);
     toast.success("Item updated successfully");
   };
 
@@ -489,27 +251,22 @@ export function ItemAssignment({
 
   // Handle adding a new item
   const handleAddItem = () => {
-    setNewItem({
-      name: "",
-      price: 0,
-      quantity: 1,
-    });
     setAddItemDialogOpen(true);
   };
 
   // Save new item
-  const saveNewItem = () => {
-    if (!newItem.name.trim()) {
+  const saveNewItem = (name: string, price: number, quantity: number) => {
+    if (!name.trim()) {
       toast.error("Item name is required");
       return;
     }
 
-    if (newItem.price < 0) {
+    if (price < 0) {
       toast.error("Price must be positive");
       return;
     }
 
-    if (newItem.quantity < 1) {
+    if (quantity < 1) {
       toast.error("Quantity must be at least 1");
       return;
     }
@@ -518,9 +275,9 @@ export function ItemAssignment({
     updatedReceipt.items = [
       ...receipt.items,
       {
-        name: newItem.name.trim(),
-        price: newItem.price,
-        quantity: newItem.quantity,
+        name: name.trim(),
+        price,
+        quantity,
       },
     ];
 
@@ -530,8 +287,7 @@ export function ItemAssignment({
     // Update the receipt
     onReceiptUpdate(updatedReceipt);
     setAddItemDialogOpen(false);
-    setNewItem({ name: "", price: 0, quantity: 1 });
-    toast.success(`Added "${newItem.name}"`);
+    toast.success(`Added "${name.trim()}"`);
   };
 
   return (
@@ -920,372 +676,65 @@ export function ItemAssignment({
           </>
         )}
 
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogContent>
-            {(() => {
-              const itemTotal =
-                currentItemIndex !== null
-                  ? new Decimal(
-                      receipt.items[currentItemIndex]?.price ?? 0
-                    ).times(receipt.items[currentItemIndex]?.quantity || 1)
-                  : new Decimal(0);
+        <EditSplitDialog
+          open={open}
+          onOpenChange={setOpen}
+          itemIndex={currentItemIndex ?? 0}
+          itemName={
+            currentItemIndex !== null
+              ? receipt.items[currentItemIndex]?.name
+              : ""
+          }
+          itemPrice={
+            currentItemIndex !== null
+              ? receipt.items[currentItemIndex]?.price ?? 0
+              : 0
+          }
+          itemQuantity={
+            currentItemIndex !== null
+              ? receipt.items[currentItemIndex]?.quantity ?? 1
+              : 1
+          }
+          currency={receipt.currency}
+          people={people}
+          existingAssignments={
+            currentItemIndex !== null
+              ? assignedItems.get(currentItemIndex) || []
+              : []
+          }
+          onSave={handleSaveSplit}
+        />
 
-              const totalPct = Array.from(assignments.values()).reduce(
-                (sum, val) => sum + (val || 0),
-                0
-              );
+        <EditItemDialog
+          open={editItemDialogOpen}
+          onOpenChange={setEditItemDialogOpen}
+          itemName={
+            currentEditItemIndex !== null
+              ? receipt.items[currentEditItemIndex]?.name
+              : ""
+          }
+          initialPrice={
+            currentEditItemIndex !== null
+              ? receipt.items[currentEditItemIndex]?.price ?? 0
+              : 0
+          }
+          initialQuantity={
+            currentEditItemIndex !== null
+              ? receipt.items[currentEditItemIndex]?.quantity ?? 1
+              : 1
+          }
+          onSave={(price, quantity) =>
+            saveItemEdit(price, quantity)
+          }
+        />
 
-              const dollarSum = new Decimal(totalPct)
-                .dividedBy(100)
-                .times(itemTotal);
-
-              const isValid =
-                splitMode === "amount"
-                  ? dollarSum.minus(itemTotal).abs().lessThanOrEqualTo(0.01)
-                  : Math.abs(totalPct - 100) <= 0.01;
-
-              const getDisplayValue = (personId: string): string => {
-                if (rawInputs.has(personId)) return rawInputs.get(personId)!;
-                if (!assignments.has(personId)) return "";
-                const pct = assignments.get(personId)!;
-                if (splitMode === "amount") {
-                  return new Decimal(pct)
-                    .dividedBy(100)
-                    .times(itemTotal)
-                    .toFixed(2);
-                }
-                return String(pct);
-              };
-
-              const handleChange = (personId: string, raw: string) => {
-                const newRawInputs = new Map(rawInputs);
-                const newAssignments = new Map(assignments);
-                if (raw === "") {
-                  newRawInputs.delete(personId);
-                  newAssignments.delete(personId);
-                } else {
-                  newRawInputs.set(personId, raw);
-                  const parsed = parseFloat(raw);
-                  if (!isNaN(parsed) && parsed >= 0) {
-                    if (splitMode === "amount") {
-                      const pct = itemTotal.isZero()
-                        ? new Decimal(0)
-                        : new Decimal(parsed)
-                            .dividedBy(itemTotal)
-                            .times(100);
-                      newAssignments.set(personId, pct.toNumber());
-                    } else {
-                      newAssignments.set(personId, parsed);
-                    }
-                  }
-                }
-                setRawInputs(newRawInputs);
-                setAssignments(newAssignments);
-              };
-
-              return (
-                <>
-                  <DialogHeader>
-                    <DialogTitle>
-                      Edit Split:{" "}
-                      {currentItemIndex !== null
-                        ? receipt.items[currentItemIndex]?.name
-                        : ""}
-                    </DialogTitle>
-                  </DialogHeader>
-
-                  <div className="grid gap-4 py-4">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium">Item Price:</span>
-                      <div className="flex items-center gap-3">
-                        <span>
-                          {currentItemIndex !== null
-                            ? formatCurrency(
-                                itemTotal.toNumber(),
-                                receipt.currency
-                              )
-                            : ""}
-                        </span>
-                        <div className="flex rounded-md border overflow-hidden">
-                          <Button
-                            type="button"
-                            variant={
-                              splitMode === "percent" ? "default" : "ghost"
-                            }
-                            size="sm"
-                            className="rounded-none h-7 px-2 text-xs"
-                            onClick={() => {
-                              setSplitMode("percent");
-                              setRawInputs(new Map());
-                            }}
-                          >
-                            %
-                          </Button>
-                          <Button
-                            type="button"
-                            variant={
-                              splitMode === "amount" ? "default" : "ghost"
-                            }
-                            size="sm"
-                            className="rounded-none h-7 px-2 text-xs"
-                            onClick={() => {
-                              setSplitMode("amount");
-                              setRawInputs(new Map());
-                            }}
-                          >
-                            $
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-
-                    {people.map((person) => (
-                      <div
-                        key={person.id}
-                        className="grid grid-cols-2 items-center gap-4"
-                      >
-                        <div className="flex items-center gap-2">
-                          <Checkbox
-                            id={`person-${person.id}-dialog`}
-                            checked={assignments.has(person.id)}
-                            onCheckedChange={(checked) => {
-                              const newAssignments = new Map(assignments);
-                              if (checked) {
-                                newAssignments.set(person.id, 0);
-                              } else {
-                                newAssignments.delete(person.id);
-                              }
-                              setAssignments(newAssignments);
-                            }}
-                          />
-                          <Label htmlFor={`person-${person.id}-dialog`}>
-                            {person.name}
-                          </Label>
-                        </div>
-                        <div className="flex items-center">
-                          <Input
-                            id={`person-${person.id}-${splitMode}`}
-                            type="text"
-                            inputMode="decimal"
-                            value={getDisplayValue(person.id)}
-                            onChange={(e) =>
-                              handleChange(person.id, e.target.value)
-                            }
-                            onBlur={() => {
-                              const newRawInputs = new Map(rawInputs);
-                              newRawInputs.delete(person.id);
-                              setRawInputs(newRawInputs);
-                            }}
-                            className="w-20 text-right"
-                          />
-                          <span className="ml-2">
-                            {splitMode === "percent" ? "%" : ""}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-
-                    <div className="flex items-center justify-between pt-2">
-                      <span className="font-medium">Total:</span>
-                      <span
-                        className={
-                          isValid
-                            ? "text-green-500 font-medium"
-                            : "text-destructive font-medium"
-                        }
-                      >
-                        {splitMode === "amount"
-                          ? `${formatCurrency(dollarSum.toNumber(), receipt.currency)} / ${formatCurrency(itemTotal.toNumber(), receipt.currency)}`
-                          : `${totalPct}%`}
-                      </span>
-                    </div>
-                  </div>
-
-                  <DialogFooter className="flex flex-col sm:flex-row gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={splitEqually}
-                      className="w-full sm:w-auto"
-                    >
-                      Split Equally
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={saveAssignment}
-                      className="w-full sm:w-auto"
-                      disabled={!isValid}
-                    >
-                      Save Assignment
-                    </Button>
-                  </DialogFooter>
-                </>
-              );
-            })()}
-          </DialogContent>
-        </Dialog>
-
-        {/* New item edit dialog */}
-        <Dialog open={editItemDialogOpen} onOpenChange={setEditItemDialogOpen}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                Edit Item:{" "}
-                {currentEditItemIndex !== null
-                  ? receipt.items[currentEditItemIndex]?.name
-                  : ""}
-              </DialogTitle>
-            </DialogHeader>
-
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                saveItemEdit();
-              }}
-            >
-              <div className="grid gap-4 py-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="item-price">Item Price</Label>
-                  <Input
-                    id="item-price"
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={editedItem?.price || ""}
-                    onChange={(e) =>
-                      setEditedItem({
-                        ...editedItem!,
-                        price: parseFloat(e.target.value) || 0,
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="item-quantity">Quantity</Label>
-                  <Input
-                    id="item-quantity"
-                    type="number"
-                    min="1"
-                    step="1"
-                    value={editedItem?.quantity || ""}
-                    onChange={(e) =>
-                      setEditedItem({
-                        ...editedItem!,
-                        quantity: parseInt(e.target.value) || 1,
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <span className="font-medium">Total:</span>
-                  <span>
-                    {editedItem
-                      ? formatCurrency(editedItem.price * editedItem.quantity)
-                      : ""}
-                  </span>
-                </div>
-              </div>
-
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setEditItemDialogOpen(false)}
-                  type="button"
-                >
-                  Cancel
-                </Button>
-                <Button type="submit">Save Changes</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-
-        {/* Add new item dialog */}
-        <Dialog open={addItemDialogOpen} onOpenChange={setAddItemDialogOpen}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Add New Item</DialogTitle>
-            </DialogHeader>
-
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                saveNewItem();
-              }}
-            >
-              <div className="grid gap-4 py-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="new-item-name">Item Name</Label>
-                  <Input
-                    id="new-item-name"
-                    type="text"
-                    value={newItem.name}
-                    onChange={(e) =>
-                      setNewItem({
-                        ...newItem,
-                        name: e.target.value,
-                      })
-                    }
-                    placeholder="e.g., Burger, Pizza, Salad"
-                    autoFocus
-                  />
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="new-item-price">Price</Label>
-                  <Input
-                    id="new-item-price"
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={newItem.price}
-                    onChange={(e) =>
-                      setNewItem({
-                        ...newItem,
-                        price: parseFloat(e.target.value) || 0,
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="new-item-quantity">Quantity</Label>
-                  <Input
-                    id="new-item-quantity"
-                    type="number"
-                    min="1"
-                    step="1"
-                    value={newItem.quantity}
-                    onChange={(e) =>
-                      setNewItem({
-                        ...newItem,
-                        quantity: parseInt(e.target.value) || 1,
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <span className="font-medium">Total:</span>
-                  <span>{formatCurrency(newItem.price * newItem.quantity)}</span>
-                </div>
-              </div>
-
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setAddItemDialogOpen(false)}
-                  type="button"
-                >
-                  Cancel
-                </Button>
-                <Button type="submit">Add Item</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+        <AddItemDialog
+          open={addItemDialogOpen}
+          onOpenChange={setAddItemDialogOpen}
+          onSave={(name, price, quantity) =>
+            saveNewItem(name, price, quantity)
+          }
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/item-assignment.tsx
+++ b/src/components/item-assignment.tsx
@@ -723,17 +723,15 @@ export function ItemAssignment({
               ? receipt.items[currentEditItemIndex]?.quantity ?? 1
               : 1
           }
-          onSave={(price, quantity) =>
-            saveItemEdit(price, quantity)
-          }
+          currency={receipt.currency}
+          onSave={saveItemEdit}
         />
 
         <AddItemDialog
           open={addItemDialogOpen}
           onOpenChange={setAddItemDialogOpen}
-          onSave={(name, price, quantity) =>
-            saveNewItem(name, price, quantity)
-          }
+          currency={receipt.currency}
+          onSave={saveNewItem}
         />
       </CardContent>
     </Card>

--- a/src/components/item-assignment.tsx
+++ b/src/components/item-assignment.tsx
@@ -679,7 +679,7 @@ export function ItemAssignment({
         <EditSplitDialog
           open={open}
           onOpenChange={setOpen}
-          itemIndex={currentItemIndex ?? 0}
+          itemIndex={currentItemIndex}
           itemName={
             currentItemIndex !== null
               ? receipt.items[currentItemIndex]?.name
@@ -700,6 +700,11 @@ export function ItemAssignment({
           existingAssignments={
             currentItemIndex !== null
               ? assignedItems.get(currentItemIndex) || []
+              : []
+          }
+          selectedPersonIds={
+            currentItemIndex !== null
+              ? Array.from(selectedPeople.get(currentItemIndex) || [])
               : []
           }
           onSave={handleSaveSplit}

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -7,6 +7,7 @@ import {
   AmountValidationError,
   calculateSubtotal,
   remapAssignmentsAfterDelete,
+  distributeEqualShares,
 } from "./receipt-utils";
 import { mockPeople, mockReceipt, mockAssignedItems } from "@/test/test-utils";
 import { type PersonItemAssignment, type Receipt, type Person } from "@/types";
@@ -43,6 +44,24 @@ describe("receipt-utils", () => {
       [0, [{ personId: "a", sharePercentage: 50 }]],
     ]);
     expect(getUnassignedItems(mockReceipt, incomplete)).toContain(0);
+  });
+
+  it("distributes equal shares with the remainder on the last person", () => {
+    expect(distributeEqualShares(["a", "b", "c"])).toEqual([
+      { personId: "a", sharePercentage: 33.33 },
+      { personId: "b", sharePercentage: 33.33 },
+      { personId: "c", sharePercentage: 33.34 },
+    ]);
+    expect(distributeEqualShares(["a", "b", "c", "d", "e", "f", "g"]))
+      .toEqual([
+        { personId: "a", sharePercentage: 14.29 },
+        { personId: "b", sharePercentage: 14.29 },
+        { personId: "c", sharePercentage: 14.29 },
+        { personId: "d", sharePercentage: 14.29 },
+        { personId: "e", sharePercentage: 14.29 },
+        { personId: "f", sharePercentage: 14.29 },
+        { personId: "g", sharePercentage: 14.26 },
+      ]);
   });
 });
 

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -63,6 +63,31 @@ export function fixMultiQuantityPrices(
 }
 
 /**
+ * Distributes equal percentage shares among a list of people.
+ * Uses a running sum approach so the last person receives the remainder,
+ * ensuring the total is exactly 100%.
+ */
+export function distributeEqualShares(personIds: string[]): PersonItemAssignment[] {
+  if (personIds.length === 0) return [];
+
+  const equalShare = +(100 / personIds.length).toFixed(2);
+  const assignments: PersonItemAssignment[] = [];
+  let runningSum = 0;
+
+  personIds.forEach((personId, index) => {
+    if (index === personIds.length - 1) {
+      const lastShare = +(100 - runningSum).toFixed(2);
+      assignments.push({ personId, sharePercentage: lastShare });
+    } else {
+      assignments.push({ personId, sharePercentage: equalShare });
+      runningSum += equalShare;
+    }
+  });
+
+  return assignments;
+}
+
+/**
  * Calculates the proportion of tax and tip each person should pay based on their items
  */
 export function calculatePersonTotals(


### PR DESCRIPTION
Closes #122.

## What

Refactored `item-assignment.tsx` (1,171 → 741 lines) by:

1. Extracting `distributeEqualShares(personIds)` into `receipt-utils.ts`, replacing the duplicated equal-share distribution loops.
2. Splitting out three independently testable dialogs:
   - `EditSplitDialog` — percentage/dollar split editor, equal-split action, and validation
   - `EditItemDialog` — edit price and quantity
   - `AddItemDialog` — add a new item
3. Removing the obsolete inline render IIFE and preserving the original Edit Split dialog label, layout, and title.
4. Keeping Add/Edit item total previews in the receipt currency.
5. Restoring Add Item form reset behavior between uses.
6. Preserving selected row-level people when existing assignments are temporarily missing.
7. Adding direct coverage for the extracted share-distribution helper, dialog fallback, and Add Item reset behavior.

## Why

- Removes duplicated equal-share logic.
- Makes the main assignment component easier to read and maintain.
- Preserves existing assignment and dialog behavior while keeping currency displays correct.
- Keeps the extracted logic independently verifiable.

## Testing

- 443 tests pass across 24 suites.
- Lint passes with one pre-existing warning in `src/components/receipt-details.tsx`.
- GitHub CI, Claude review, and Vercel checks all pass.

---

Ready for human review.