### PR TITLE
e2e tests: Split All Evenly flow + fix to only split unassigned items (#131)

### DIFF
--- a/e2e/split-evenly.spec.ts
+++ b/e2e/split-evenly.spec.ts
@@ -197,7 +197,7 @@ test.describe("Split All Evenly flow", () => {
     await test.step("click Split All Evenly — toast confirms", async () => {
       await page.getByRole("button", { name: /split all evenly/i }).click();
       // Wait for toast to appear
-      await expect(page.getByText("All items split evenly among everyone!")).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
     });
 
     await test.step("progress shows 100% after split", async () => {
@@ -209,15 +209,11 @@ test.describe("Split All Evenly flow", () => {
       const resultsTab = page.getByRole("tab", { name: /results/i });
       await resultsTab.click();
 
-      // Each person's Total column renders with $5.00
-      // Scope assertion to the Total column cell (span.font-bold) to avoid
-      // picking up hidden mobile-only subtotal elements.
-      const totals = page.locator("span.font-bold");
-      // After sorting by finalTotal (highest first), both are $5.00 so order is unstable.
-      // Just verify at least one $5.00 total exists per person row.
-      await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
-      await expect(page.getByRole("cell", { name: "Bob" })).toBeVisible();
-      await expect(totals.filter({ hasText: "$5.00" }).first()).toBeVisible();
+      // Verify the total on each person's result row.
+      const aliceRow = page.getByRole("row").filter({ hasText: "Alice" });
+      const bobRow = page.getByRole("row").filter({ hasText: "Bob" });
+      await expect(aliceRow).toContainText("$5.00");
+      await expect(bobRow).toContainText("$5.00");
     });
   });
 
@@ -244,7 +240,7 @@ test.describe("Split All Evenly flow", () => {
 
     await test.step("click Split All Evenly", async () => {
       await page.getByRole("button", { name: /split all evenly/i }).click();
-      await expect(page.getByText("All items split evenly among everyone!")).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
     });
 
     await test.step("progress shows 100%", async () => {
@@ -254,11 +250,12 @@ test.describe("Split All Evenly flow", () => {
     await test.step("Results tab — all three people show $4.00 total", async () => {
       await page.getByRole("tab", { name: /results/i }).click();
 
-      const totals = page.locator("span.font-bold");
-      await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
-      await expect(page.getByRole("cell", { name: "Bob" })).toBeVisible();
-      await expect(page.getByRole("cell", { name: "Charlie" })).toBeVisible();
-      await expect(totals.filter({ hasText: "$4.00" }).first()).toBeVisible();
+      const aliceRow = page.getByRole("row").filter({ hasText: "Alice" });
+      const bobRow = page.getByRole("row").filter({ hasText: "Bob" });
+      const charlieRow = page.getByRole("row").filter({ hasText: "Charlie" });
+      await expect(aliceRow).toContainText("$4.00");
+      await expect(bobRow).toContainText("$4.00");
+      await expect(charlieRow).toContainText("$4.00");
     });
   });
 
@@ -333,7 +330,7 @@ test.describe("Split All Evenly flow", () => {
 
     await test.step("click Split All Evenly", async () => {
       await page.getByRole("button", { name: /split all evenly/i }).click();
-      await expect(page.getByText("All items split evenly among everyone!")).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
     });
 
     await test.step("progress shows 100% after split", async () => {
@@ -343,13 +340,10 @@ test.describe("Split All Evenly flow", () => {
     await test.step("Results tab — Alice $7.50, Bob $2.50", async () => {
       await page.getByRole("tab", { name: /results/i }).click();
 
-      const totals = page.locator("span.font-bold");
-      await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
-      await expect(page.getByRole("cell", { name: "Bob" })).toBeVisible();
       // Alice: $5.00 (item 0) + $2.50 (half of item 1) = $7.50
-      await expect(totals.filter({ hasText: "$7.50" }).first()).toBeVisible();
+      await expect(page.getByRole("row").filter({ hasText: "Alice" })).toContainText("$7.50");
       // Bob: $2.50 (half of item 1)
-      await expect(totals.filter({ hasText: "$2.50" }).first()).toBeVisible();
+      await expect(page.getByRole("row").filter({ hasText: "Bob" })).toContainText("$2.50");
     });
   });
 });

--- a/e2e/split-evenly.spec.ts
+++ b/e2e/split-evenly.spec.ts
@@ -1,0 +1,355 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// =============================================================================
+// Helper: preload session via localStorage
+// =============================================================================
+async function preloadSession(
+  page: Page,
+  state: Record<string, unknown>,
+  activeTab = "upload",
+) {
+  const session = { state, activeTab };
+  await page.addInitScript((data) => {
+    window.localStorage.setItem(
+      "receiptSplitterSession",
+      JSON.stringify(data),
+    );
+  }, session);
+}
+
+// =============================================================================
+// Test 1 — 2 people, 2 items, $10 total → each gets $5
+// =============================================================================
+
+const RECEIPT_2P_2I = {
+  restaurant: "Even Diner",
+  date: "2024-01-15",
+  subtotal: 10.0,
+  tax: 0,
+  tip: 0,
+  total: 10.0,
+  currency: "USD",
+  items: [
+    { name: "Burger", price: 5.0, quantity: 1 },
+    { name: "Fries", price: 5.0, quantity: 1 },
+  ],
+};
+
+const PEOPLE_2P_2I = [
+  {
+    id: "p1",
+    name: "Alice",
+    items: [],
+    totalBeforeTax: 0,
+    tax: 0,
+    tip: 0,
+    finalTotal: 0,
+  },
+  {
+    id: "p2",
+    name: "Bob",
+    items: [],
+    totalBeforeTax: 0,
+    tax: 0,
+    tip: 0,
+    finalTotal: 0,
+  },
+];
+
+const ASSIGNED_2P_2I: unknown[] = [];
+const UNASSIGNED_2P_2I = [0, 1];
+
+// =============================================================================
+// Test 2 — 3 people, 2 items, $12 total → each gets $4
+// =============================================================================
+
+function buildThreePersonData() {
+  const receipt = {
+    restaurant: "Trio Cafe",
+    date: "2024-03-01",
+    subtotal: 12.0,
+    tax: 0,
+    tip: 0,
+    total: 12.0,
+    currency: "USD",
+    items: [
+      { name: "Pizza", price: 6.0, quantity: 1 },
+      { name: "Salad", price: 6.0, quantity: 1 },
+    ],
+  };
+
+  const people = [
+    { id: "p1", name: "Alice", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+    { id: "p2", name: "Bob", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+    { id: "p3", name: "Charlie", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+  ];
+
+  return {
+    state: {
+      originalReceipt: receipt,
+      people,
+      assignedItems: [] as unknown[],
+      unassignedItems: [0, 1],
+      groups: [] as unknown[],
+      isLoading: false,
+      error: null,
+    },
+  };
+}
+
+// =============================================================================
+// Test 3 — Empty receipt (no items) → graceful no-op
+// =============================================================================
+
+const RECEIPT_EMPTY = {
+  restaurant: "Empty Cafe",
+  date: "2024-04-01",
+  subtotal: 0,
+  tax: 0,
+  tip: 0,
+  total: 0,
+  currency: "USD",
+  items: [] as { name: string; price: number; quantity: number }[],
+};
+
+const PEOPLE_EMPTY = [
+  { id: "p1", name: "Alice", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+  { id: "p2", name: "Bob", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
+];
+
+// =============================================================================
+// Test 4 — Some items already assigned → only unassigned items split
+// =============================================================================
+
+const RECEIPT_PRE_ASSIGNED = {
+  restaurant: "PreSplit Grill",
+  date: "2024-05-01",
+  subtotal: 10.0,
+  tax: 0,
+  tip: 0,
+  total: 10.0,
+  currency: "USD",
+  items: [
+    { name: "Steak", price: 5.0, quantity: 1 },
+    { name: "Wine", price: 5.0, quantity: 1 },
+  ],
+};
+
+const PEOPLE_PRE_ASSIGNED = [
+  {
+    id: "p1",
+    name: "Alice",
+    items: [
+      { itemId: 0, itemName: "Steak", originalPrice: 5.0, quantity: 1, sharePercentage: 100, amount: 5.0 },
+    ],
+    totalBeforeTax: 5.0,
+    tax: 0,
+    tip: 0,
+    finalTotal: 5.0,
+  },
+  {
+    id: "p2",
+    name: "Bob",
+    items: [],
+    totalBeforeTax: 0,
+    tax: 0,
+    tip: 0,
+    finalTotal: 0,
+  },
+];
+
+// Item 0 already assigned to Alice, Item 1 unassigned
+const ASSIGNED_PRE = [[0, [{ personId: "p1", sharePercentage: 100 }]]];
+const UNASSIGNED_PRE = [1];
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test.describe("Split All Evenly flow", () => {
+  // ---------------------------------------------------------------------------
+  // 2 people, 2 items, $10 total → each gets $5
+  // ---------------------------------------------------------------------------
+  test("splits 2 items evenly between 2 people — $5 each", async ({
+    page,
+  }) => {
+    await test.step("preload session with 2 items, $10 total, 2 people", async () => {
+      await preloadSession(page, {
+        originalReceipt: RECEIPT_2P_2I,
+        people: PEOPLE_2P_2I,
+        assignedItems: ASSIGNED_2P_2I,
+        unassignedItems: UNASSIGNED_2P_2I,
+        groups: [],
+        isLoading: false,
+        error: null,
+      }, "assign");
+    });
+
+    await test.step("Assign tab — Split All Evenly button visible and enabled", async () => {
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+
+      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      await expect(splitBtn).toBeVisible({ timeout: 10000 });
+      await expect(splitBtn).toBeEnabled();
+    });
+
+    await test.step("click Split All Evenly — toast confirms", async () => {
+      await page.getByRole("button", { name: /split all evenly/i }).click();
+      // Wait for toast to appear
+      await expect(page.getByText("All items split evenly among everyone!")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("progress shows 100% after split", async () => {
+      await expect(page.getByText("100%")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("navigate to Results tab — both people show $5.00 total", async () => {
+      // Click the Results tab trigger
+      const resultsTab = page.getByRole("tab", { name: /results/i });
+      await resultsTab.click();
+
+      // Each person's Total column renders with $5.00
+      // Scope assertion to the Total column cell (span.font-bold) to avoid
+      // picking up hidden mobile-only subtotal elements.
+      const totals = page.locator("span.font-bold");
+      // After sorting by finalTotal (highest first), both are $5.00 so order is unstable.
+      // Just verify at least one $5.00 total exists per person row.
+      await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+      await expect(page.getByRole("cell", { name: "Bob" })).toBeVisible();
+      await expect(totals.filter({ hasText: "$5.00" }).first()).toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3 people, 2 items, $12 total → each gets $4 (rounding test)
+  // ---------------------------------------------------------------------------
+  test("splits 2 items evenly among 3 people — $4 each with rounding", async ({
+    page,
+  }) => {
+    const threePersonData = buildThreePersonData();
+
+    await test.step("preload session with 2 items, $12 total, 3 people", async () => {
+      await preloadSession(page, threePersonData.state, "assign");
+    });
+
+    await test.step("Assign tab — Split All Evenly button visible", async () => {
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+
+      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      await expect(splitBtn).toBeVisible({ timeout: 10000 });
+      await expect(splitBtn).toBeEnabled();
+    });
+
+    await test.step("click Split All Evenly", async () => {
+      await page.getByRole("button", { name: /split all evenly/i }).click();
+      await expect(page.getByText("All items split evenly among everyone!")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("progress shows 100%", async () => {
+      await expect(page.getByText("100%")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("Results tab — all three people show $4.00 total", async () => {
+      await page.getByRole("tab", { name: /results/i }).click();
+
+      const totals = page.locator("span.font-bold");
+      await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+      await expect(page.getByRole("cell", { name: "Bob" })).toBeVisible();
+      await expect(page.getByRole("cell", { name: "Charlie" })).toBeVisible();
+      await expect(totals.filter({ hasText: "$4.00" }).first()).toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty receipt (no items) → graceful no-op
+  // ---------------------------------------------------------------------------
+  test("empty receipt — Split All Evenly is a no-op", async ({
+    page,
+  }) => {
+    await test.step("preload session with empty receipt (0 items), 2 people", async () => {
+      await preloadSession(page, {
+        originalReceipt: RECEIPT_EMPTY,
+        people: PEOPLE_EMPTY,
+        assignedItems: [],
+        unassignedItems: [],
+        groups: [],
+        isLoading: false,
+        error: null,
+      }, "assign");
+    });
+
+    await test.step("Assign tab — Split All Evenly button visible and enabled", async () => {
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+
+      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      await expect(splitBtn).toBeVisible({ timeout: 10000 });
+      await expect(splitBtn).toBeEnabled();
+    });
+
+    await test.step("click Split All Evenly — info toast says no unassigned items", async () => {
+      await page.getByRole("button", { name: /split all evenly/i }).click();
+      // With 0 items, progress is already 100% and there are no unassigned items
+      await expect(page.getByText("No unassigned items to split evenly!")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("progress stays at 100% (empty receipt rounds to 100%)", async () => {
+      await expect(page.getByText("100%")).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Some items already assigned → only unassigned items split
+  // ---------------------------------------------------------------------------
+  test("with pre-assigned items — only unassigned items split evenly", async ({
+    page,
+  }) => {
+    await test.step("preload session with Item 0 assigned to Alice, Item 1 unassigned", async () => {
+      await preloadSession(page, {
+        originalReceipt: RECEIPT_PRE_ASSIGNED,
+        people: PEOPLE_PRE_ASSIGNED,
+        assignedItems: ASSIGNED_PRE,
+        unassignedItems: UNASSIGNED_PRE,
+        groups: [],
+        isLoading: false,
+        error: null,
+      }, "assign");
+    });
+
+    await test.step("Assign tab — button visible", async () => {
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+
+      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      await expect(splitBtn).toBeVisible({ timeout: 10000 });
+      await expect(splitBtn).toBeEnabled();
+    });
+
+    await test.step("verify progress shows 50% (1 of 2 items assigned)", async () => {
+      await expect(page.getByText("50%")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("click Split All Evenly", async () => {
+      await page.getByRole("button", { name: /split all evenly/i }).click();
+      await expect(page.getByText("All items split evenly among everyone!")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("progress shows 100% after split", async () => {
+      await expect(page.getByText("100%")).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step("Results tab — Alice $7.50, Bob $2.50", async () => {
+      await page.getByRole("tab", { name: /results/i }).click();
+
+      const totals = page.locator("span.font-bold");
+      await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+      await expect(page.getByRole("cell", { name: "Bob" })).toBeVisible();
+      // Alice: $5.00 (item 0) + $2.50 (half of item 1) = $7.50
+      await expect(totals.filter({ hasText: "$7.50" }).first()).toBeVisible();
+      // Bob: $2.50 (half of item 1)
+      await expect(totals.filter({ hasText: "$2.50" }).first()).toBeVisible();
+    });
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -410,21 +410,27 @@ export default function Home() {
     }
   };
 
-  // Split all items evenly among all people
+  // Split all unassigned items evenly among all people
   const splitAllItemsEvenly = () => {
     if (!state.originalReceipt || state.people.length === 0) return;
 
     setState((prevState) => {
       if (!prevState.originalReceipt) return prevState;
 
-      // Create new assignments map
-      const newAssignedItems = new Map();
+      // No unassigned items — nothing to do
+      if (prevState.unassignedItems.length === 0) {
+        toast.info("No unassigned items to split evenly!");
+        return prevState;
+      }
+
+      // Start from existing assignments
+      const newAssignedItems = new Map(prevState.assignedItems);
 
       // Calculate equal share percentage with 2 decimal places
       const equalShare = +(100 / prevState.people.length).toFixed(2);
 
-      // For each item in the receipt
-      prevState.originalReceipt.items.forEach((_, itemIndex) => {
+      // Only split unassigned items, preserving existing assignments
+      prevState.unassignedItems.forEach((itemIndex) => {
         // Create assignments for all people
         const assignments: PersonItemAssignment[] = [];
 
@@ -452,7 +458,7 @@ export default function Home() {
         newAssignedItems.set(itemIndex, assignments);
       });
 
-      // No unassigned items since all are assigned
+      // No unassigned items since all are now assigned
       const unassignedItems: number[] = [];
 
       // Recalculate people totals


### PR DESCRIPTION
Closes #131.

## What
Two changes in this PR:

### 1. Fix `splitAllItemsEvenly()` behavior
Previously, `splitAllItemsEvenly()` reassigned **all** items evenly among all people, overwriting any existing individual assignments. Now it only splits **unassigned** items, preserving items that have already been assigned to specific people. This matches the feature's intended behavior where the button divides "remaining unassigned items equally among selected people."

Changes in `src/app/page.tsx`:
- Start from existing `prevState.assignedItems` Map instead of creating a fresh empty one
- Iterate over `prevState.unassignedItems` instead of `prevState.originalReceipt.items`
- Added early return with info toast when there are no unassigned items (empty receipt / all items assigned)

### 2. E2e tests for Split All Evenly
New file `e2e/split-evenly.spec.ts` with 4 test scenarios:

| Test | Scenario | What it verifies |
|------|----------|-----------------|
| 1 | 2 people, 2 items, $10 total | Each person gets $5.00 |
| 2 | 3 people, 2 items, $12 total | Each person gets $4.00 (rounding works) |
| 3 | Empty receipt (0 items) | Button shows info toast, progress stays 100% |
| 4 | Pre-assigned + unassigned items | Already-assigned item preserved, only unassigned split |

Each test preloads a session (skipping Upload -> People -> Assign navigation for speed), verifies the button is visible/enabled, performs the split, checks progress updates, and navigates to the Results tab to verify per-person totals.

## Testing
- All 440 existing unit tests pass unchanged
- E2e tests could not be run in this environment (Playwright browser binaries unavailable) - they follow the same patterns as existing specs in e2e/ and should pass when run on a machine with browsers installed

---

Draft by Hermes - review required, will not auto-merge.
