### PR TITLE
Add Dependabot weekly npm upgrades with patch/minor auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+    groups:
+      next-toolchain:
+        patterns:
+          - next
+          - eslint-config-next
+          - "@next/*"
+
+      radix:
+        patterns:
+          - "@radix-ui/*"
+
+      testing:
+        patterns:
+          - jest
+          - jest-*
+          - "@testing-library/*"
+          - "@types/jest"
+          - ts-jest
+          - "@babel/*"
+          - identity-obj-proxy
+          - "@playwright/test"
+          - playwright

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'narulaskaran/receipt-splitter'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -395,6 +395,8 @@ GitHub Actions workflow runs on every push and pull request to ensure code quali
 - **Test Execution**: Full test suite validation
 - **Quality Gates**: All checks must pass before merging
 
+Dependabot opens weekly grouped npm upgrade PRs. Patch and minor PRs auto-squash-merge once the required CI job (`build-and-test`) is green. Major version upgrades stay manual.
+
 ## Test Coverage
 
 Comprehensive test coverage including:


### PR DESCRIPTION
## Summary
- Add weekly Dependabot npm updates, grouped for Next, Radix, and the testing stack
- Auto-squash-merge patch and minor PRs once the `build-and-test` CI job is green; majors stay manual

## Test plan
- [ ] Confirm CI still runs on this PR
- [ ] After merge, enable GitHub **Allow auto-merge** on the repo (currently off) so Dependabot PRs can queue
- [ ] Confirm a future patch/minor Dependabot PR auto-merges after CI, and that majors stay open
