### PR TITLE
test: e2e coverage for errors, empty states, clipboard, and receipt edits

### DIFF
--- a/e2e/edit-receipt.spec.ts
+++ b/e2e/edit-receipt.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import {
+  preloadSession,
+  fullyAssignedState,
+  parseMoney,
+} from "./helpers";
+
+async function openItemPriceEditor(page: import("@playwright/test").Page, itemName: string) {
+  const row = page.getByRole("row").filter({ hasText: itemName });
+  await row.getByTitle(/edit price and quantity/i).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+}
+
+async function saveItemPrice(page: import("@playwright/test").Page, price: string) {
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Item Price").fill(price);
+  await dialog.getByRole("button", { name: /save changes/i }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+}
+
+test.describe("edit receipt", () => {
+  test("changing an item price updates the line total and person total", async ({
+    page,
+  }) => {
+    await preloadSession(page, fullyAssignedState(), "assign");
+    await page.goto("/");
+
+    await openItemPriceEditor(page, "Burger");
+    await saveItemPrice(page, "15");
+
+    const burgerRow = page.getByRole("row").filter({ hasText: "Burger" });
+    await expect(burgerRow.getByTitle(/edit price and quantity/i)).toContainText(
+      "$15.00",
+    );
+
+    await page.getByRole("tab", { name: /results/i }).click();
+    const aliceRow = page.getByRole("row").filter({ hasText: "Alice" });
+    await expect(aliceRow).toContainText("$15.00");
+    const bobRow = page.getByRole("row").filter({ hasText: "Bob" });
+    await expect(bobRow).toContainText("$10.00");
+  });
+
+  test("adding a named item shows that name on the Assign tab", async ({
+    page,
+  }) => {
+    await preloadSession(page, fullyAssignedState(), "assign");
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /add item/i }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Add New Item")).toBeVisible();
+    await dialog.getByLabel("Item Name").fill("Milkshake");
+    await dialog.getByLabel("Price").fill("6");
+    await dialog.getByRole("button", { name: /^Add Item$/i }).click();
+
+    await expect(
+      page.getByRole("row").filter({ hasText: "Milkshake" }),
+    ).toBeVisible();
+    await expect(page.getByText("Milkshake").first()).toBeVisible();
+  });
+
+  test("removing an item updates assignments and results totals", async ({
+    page,
+  }) => {
+    await preloadSession(page, fullyAssignedState(), "assign");
+    await page.goto("/");
+
+    const friesRow = page.getByRole("row").filter({ hasText: "Fries" });
+    await friesRow.getByRole("button", { name: /delete fries/i }).click();
+
+    await expect(page.getByRole("row").filter({ hasText: "Fries" })).toHaveCount(
+      0,
+    );
+    await expect(page.getByRole("row").filter({ hasText: "Burger" })).toBeVisible();
+
+    await page.getByRole("tab", { name: /results/i }).click();
+    await expect(page.getByRole("row").filter({ hasText: "Alice" })).toContainText(
+      "$10.00",
+    );
+    await expect(page.getByRole("row").filter({ hasText: "Bob" })).toContainText(
+      "$0.00",
+    );
+  });
+
+  test("editing two items in sequence keeps both new prices", async ({
+    page,
+  }) => {
+    await preloadSession(page, fullyAssignedState(), "assign");
+    await page.goto("/");
+
+    await openItemPriceEditor(page, "Burger");
+    await saveItemPrice(page, "20");
+
+    await openItemPriceEditor(page, "Fries");
+    await saveItemPrice(page, "8");
+
+    await expect(
+      page.getByRole("row").filter({ hasText: "Burger" }).getByTitle(
+        /edit price and quantity/i,
+      ),
+    ).toContainText("$20.00");
+    await expect(
+      page.getByRole("row").filter({ hasText: "Fries" }).getByTitle(
+        /edit price and quantity/i,
+      ),
+    ).toContainText("$8.00");
+
+    await page.getByRole("tab", { name: /results/i }).click();
+    const aliceTotal = parseMoney(
+      await page
+        .getByRole("row")
+        .filter({ hasText: "Alice" })
+        .getByRole("cell")
+        .last()
+        .textContent(),
+    );
+    const bobTotal = parseMoney(
+      await page
+        .getByRole("row")
+        .filter({ hasText: "Bob" })
+        .getByRole("cell")
+        .last()
+        .textContent(),
+    );
+    expect(aliceTotal).toBeCloseTo(20, 2);
+    expect(bobTotal).toBeCloseTo(8, 2);
+  });
+
+  test("changing currency reformats totals on Upload and Results", async ({
+    page,
+  }) => {
+    await preloadSession(page, fullyAssignedState(), "upload");
+    await page.goto("/");
+
+    await expect(page.getByText("Test Diner")).toBeVisible();
+    await page.getByRole("button", { name: /^Edit$/ }).click();
+    await expect(page.getByText("Edit Receipt Details")).toBeVisible();
+
+    await page.getByLabel("Currency").click();
+    await page.getByRole("option", { name: /EUR - Euro/ }).click();
+    await page.getByRole("button", { name: /save changes/i }).click();
+
+    await expect(page.getByText(/EUR - Euro/)).toBeVisible();
+
+    await page.getByRole("tab", { name: /results/i }).click();
+    await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+    await expect(page.getByText(/€|EUR/).first()).toBeVisible();
+  });
+});

--- a/e2e/edit-receipt.spec.ts
+++ b/e2e/edit-receipt.spec.ts
@@ -18,12 +18,19 @@ async function saveItemPrice(page: import("@playwright/test").Page, price: strin
   await expect(page.getByRole("dialog")).toHaveCount(0);
 }
 
+async function gotoAssignTab(page: import("@playwright/test").Page) {
+  await preloadSession(page, fullyAssignedState(), "assign");
+  await page.goto("/");
+  await expect(page.getByRole("row").filter({ hasText: "Burger" })).toBeVisible({
+    timeout: 10000,
+  });
+}
+
 test.describe("edit receipt", () => {
   test("changing an item price updates the line total and person total", async ({
     page,
   }) => {
-    await preloadSession(page, fullyAssignedState(), "assign");
-    await page.goto("/");
+    await gotoAssignTab(page);
 
     await openItemPriceEditor(page, "Burger");
     await saveItemPrice(page, "15");
@@ -43,8 +50,7 @@ test.describe("edit receipt", () => {
   test("adding a named item shows that name on the Assign tab", async ({
     page,
   }) => {
-    await preloadSession(page, fullyAssignedState(), "assign");
-    await page.goto("/");
+    await gotoAssignTab(page);
 
     await page.getByRole("button", { name: /add item/i }).click();
     const dialog = page.getByRole("dialog");
@@ -53,17 +59,17 @@ test.describe("edit receipt", () => {
     await dialog.getByLabel("Price").fill("6");
     await dialog.getByRole("button", { name: /^Add Item$/i }).click();
 
+    const milkshakeRow = page.getByRole("row").filter({ hasText: "Milkshake" });
+    await expect(milkshakeRow).toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "Milkshake" }),
-    ).toBeVisible();
-    await expect(page.getByText("Milkshake").first()).toBeVisible();
+      milkshakeRow.getByTitle(/edit price and quantity/i),
+    ).toContainText("$6.00");
   });
 
   test("removing an item updates assignments and results totals", async ({
     page,
   }) => {
-    await preloadSession(page, fullyAssignedState(), "assign");
-    await page.goto("/");
+    await gotoAssignTab(page);
 
     const friesRow = page.getByRole("row").filter({ hasText: "Fries" });
     await friesRow.getByRole("button", { name: /delete fries/i }).click();
@@ -85,8 +91,7 @@ test.describe("edit receipt", () => {
   test("editing two items in sequence keeps both new prices", async ({
     page,
   }) => {
-    await preloadSession(page, fullyAssignedState(), "assign");
-    await page.goto("/");
+    await gotoAssignTab(page);
 
     await openItemPriceEditor(page, "Burger");
     await saveItemPrice(page, "20");
@@ -132,18 +137,21 @@ test.describe("edit receipt", () => {
     await preloadSession(page, fullyAssignedState(), "upload");
     await page.goto("/");
 
-    await expect(page.getByText("Test Diner")).toBeVisible();
+    await expect(page.getByText("Test Diner")).toBeVisible({ timeout: 10000 });
     await page.getByRole("button", { name: /^Edit$/ }).click();
     await expect(page.getByText("Edit Receipt Details")).toBeVisible();
 
     await page.getByLabel("Currency").click();
-    await page.getByRole("option", { name: /EUR - Euro/ }).click();
+    const eurOption = page.getByRole("option", { name: /EUR - Euro/ });
+    await expect(eurOption).toBeVisible();
+    await eurOption.click();
     await page.getByRole("button", { name: /save changes/i }).click();
 
     await expect(page.getByText(/EUR - Euro/)).toBeVisible();
 
     await page.getByRole("tab", { name: /results/i }).click();
-    await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
-    await expect(page.getByText(/€|EUR/).first()).toBeVisible();
+    const aliceRow = page.getByRole("row").filter({ hasText: "Alice" });
+    await expect(aliceRow).toBeVisible();
+    await expect(aliceRow.getByRole("cell").last()).toHaveText(/€|EUR/);
   });
 });

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import {
+  preloadSession,
+  baseState,
+  emptyPerson,
+  usdReceipt,
+  fullyAssignedState,
+} from "./helpers";
+
+test.describe("empty states", () => {
+  test("People tab shows empty prompt and Next is disabled with no people", async ({
+    page,
+  }) => {
+    await preloadSession(
+      page,
+      baseState({
+        people: [],
+        assignedItems: [],
+        unassignedItems: [0, 1],
+      }),
+      "people",
+    );
+
+    await page.goto("/");
+
+    await expect(
+      page.getByText("Add people who shared this receipt"),
+    ).toBeVisible();
+    await expect(page.getByText("Groups")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Next", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("tab", { name: /assign items/i }),
+    ).toBeDisabled();
+  });
+
+  test("Assign tab with no items shows an empty list and 100% progress", async ({
+    page,
+  }) => {
+    await preloadSession(
+      page,
+      baseState({
+        originalReceipt: usdReceipt({
+          items: [],
+          subtotal: 0,
+          total: 0,
+        }),
+        unassignedItems: [],
+      }),
+      "assign",
+    );
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("button", { name: /add item/i }),
+    ).toBeVisible();
+    await expect(page.getByRole("row").filter({ hasText: "Burger" })).toHaveCount(
+      0,
+    );
+    await expect(page.getByText("100%")).toBeVisible();
+  });
+
+  test("Next stays disabled until all items are assigned", async ({ page }) => {
+    await preloadSession(
+      page,
+      baseState({
+        assignedItems: [[0, [{ personId: "p1", sharePercentage: 100 }]]],
+        unassignedItems: [1],
+        people: [
+          {
+            ...emptyPerson("p1", "Alice"),
+            items: [
+              {
+                itemId: 0,
+                itemName: "Burger",
+                originalPrice: 10,
+                quantity: 1,
+                sharePercentage: 100,
+                amount: 10,
+              },
+            ],
+            totalBeforeTax: 10,
+            finalTotal: 10,
+          },
+          emptyPerson("p2", "Bob"),
+        ],
+      }),
+      "assign",
+    );
+
+    await page.goto("/");
+
+    await expect(page.getByText("50%")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Next", exact: true }),
+    ).toBeDisabled();
+  });
+
+  test("Next enables once every item is assigned", async ({ page }) => {
+    await preloadSession(page, fullyAssignedState(), "assign");
+
+    await page.goto("/");
+
+    await expect(page.getByText("100%")).toBeVisible();
+    const nextBtn = page.getByRole("button", { name: "Next", exact: true });
+    await expect(nextBtn).toBeEnabled();
+    await nextBtn.click();
+    await expect(page.getByRole("tab", { name: /results/i })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+  });
+
+  test("Groups card shows empty prompt when people exist but no groups", async ({
+    page,
+  }) => {
+    await preloadSession(page, baseState(), "people");
+
+    await page.goto("/");
+
+    await expect(page.getByText("Alice")).toBeVisible();
+    await expect(
+      page.getByText("Create groups to quickly assign items to multiple people"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /create group/i }).first(),
+    ).toBeVisible();
+  });
+});

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -25,7 +25,7 @@ test.describe("empty states", () => {
 
     await expect(
       page.getByText("Add people who shared this receipt"),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Groups")).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: "Next", exact: true }),
@@ -53,13 +53,14 @@ test.describe("empty states", () => {
 
     await page.goto("/");
 
-    await expect(
-      page.getByRole("button", { name: /add item/i }),
-    ).toBeVisible();
-    await expect(page.getByRole("row").filter({ hasText: "Burger" })).toHaveCount(
-      0,
-    );
+    await expect(page.getByRole("button", { name: /add item/i })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole("row")).toHaveCount(1);
     await expect(page.getByText("100%")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Next", exact: true }),
+    ).toBeDisabled();
   });
 
   test("Next stays disabled until all items are assigned", async ({ page }) => {
@@ -92,7 +93,7 @@ test.describe("empty states", () => {
 
     await page.goto("/");
 
-    await expect(page.getByText("50%")).toBeVisible();
+    await expect(page.getByText("50%")).toBeVisible({ timeout: 10000 });
     await expect(
       page.getByRole("button", { name: "Next", exact: true }),
     ).toBeDisabled();
@@ -103,7 +104,7 @@ test.describe("empty states", () => {
 
     await page.goto("/");
 
-    await expect(page.getByText("100%")).toBeVisible();
+    await expect(page.getByText("100%")).toBeVisible({ timeout: 10000 });
     const nextBtn = page.getByRole("button", { name: "Next", exact: true });
     await expect(nextBtn).toBeEnabled();
     await nextBtn.click();
@@ -121,7 +122,7 @@ test.describe("empty states", () => {
 
     await page.goto("/");
 
-    await expect(page.getByText("Alice")).toBeVisible();
+    await expect(page.getByText("Alice")).toBeVisible({ timeout: 10000 });
     await expect(
       page.getByText("Create groups to quickly assign items to multiple people"),
     ).toBeVisible();

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+import {
+  preloadSession,
+  seedSessionViaReload,
+  uploadTinyReceipt,
+  baseState,
+} from "./helpers";
+
+test.describe("error states", () => {
+  test("API 500 on receipt upload shows an error toast and clears loading", async ({
+    page,
+  }) => {
+    await page.route("**/api/parse-receipt", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Failed to parse receipt" }),
+      }),
+    );
+
+    await page.goto("/");
+    await expect(page.getByText("Upload your receipt")).toBeVisible();
+
+    await uploadTinyReceipt(page);
+
+    await expect(page.getByText("Failed to parse receipt").first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Parsing receipt...")).toHaveCount(0);
+    await expect(page.getByText("Test Diner")).toHaveCount(0);
+    await expect(
+      page.getByText("Click or drag to upload a different receipt"),
+    ).toBeVisible();
+  });
+
+  test("API timeout clears loading and leaves the dropzone usable", async ({
+    page,
+  }) => {
+    await page.route("**/api/parse-receipt", (route) =>
+      route.abort("timedout"),
+    );
+
+    await page.goto("/");
+    await expect(page.getByText("Upload your receipt")).toBeVisible();
+
+    await uploadTinyReceipt(page);
+
+    await expect(page.locator("[data-sonner-toast]").first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Parsing receipt...")).toHaveCount(0);
+    await expect(
+      page.getByText("Click or drag to upload a different receipt"),
+    ).toBeVisible();
+  });
+
+  test("corrupted localStorage recovers to the empty upload screen", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("receiptSplitterSession", "invalid json {");
+    });
+
+    await page.goto("/");
+
+    await expect(page.getByText("Upload your receipt")).toBeVisible();
+    await expect(page.getByRole("tab", { name: /add people/i })).toBeDisabled();
+    await expect(
+      page.getByRole("tab", { name: /assign items/i }),
+    ).toBeDisabled();
+    await expect(page.getByRole("tab", { name: /results/i })).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Next", exact: true }),
+    ).toBeDisabled();
+  });
+
+  test("offline assignment is preserved after reconnecting", async ({
+    page,
+    context,
+  }) => {
+    await seedSessionViaReload(page, baseState(), "assign");
+
+    await expect(
+      page.getByRole("button", { name: /split all evenly/i }),
+    ).toBeVisible();
+    await expect(page.getByText("50%").or(page.getByText("0%"))).toBeVisible();
+
+    await context.setOffline(true);
+
+    await page.getByRole("button", { name: /split all evenly/i }).click();
+    await expect(
+      page.getByText("All items split evenly among everyone!").first(),
+    ).toBeVisible();
+    await expect(page.getByText("100%")).toBeVisible();
+
+    await context.setOffline(false);
+    await page.reload();
+
+    await expect(page.getByText("100%")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Next", exact: true }),
+    ).toBeEnabled();
+  });
+});

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import {
-  preloadSession,
   seedSessionViaReload,
   uploadTinyReceipt,
   baseState,
@@ -19,7 +18,9 @@ test.describe("error states", () => {
     );
 
     await page.goto("/");
-    await expect(page.getByText("Upload your receipt")).toBeVisible();
+    await expect(page.getByText("Upload your receipt")).toBeVisible({
+      timeout: 10000,
+    });
 
     await uploadTinyReceipt(page);
 
@@ -28,9 +29,7 @@ test.describe("error states", () => {
     });
     await expect(page.getByText("Parsing receipt...")).toHaveCount(0);
     await expect(page.getByText("Test Diner")).toHaveCount(0);
-    await expect(
-      page.getByText("Click or drag to upload a different receipt"),
-    ).toBeVisible();
+    await expect(page.locator('input[type="file"]')).toBeEnabled();
   });
 
   test("API timeout clears loading and leaves the dropzone usable", async ({
@@ -41,7 +40,9 @@ test.describe("error states", () => {
     );
 
     await page.goto("/");
-    await expect(page.getByText("Upload your receipt")).toBeVisible();
+    await expect(page.getByText("Upload your receipt")).toBeVisible({
+      timeout: 10000,
+    });
 
     await uploadTinyReceipt(page);
 
@@ -49,9 +50,7 @@ test.describe("error states", () => {
       timeout: 10000,
     });
     await expect(page.getByText("Parsing receipt...")).toHaveCount(0);
-    await expect(
-      page.getByText("Click or drag to upload a different receipt"),
-    ).toBeVisible();
+    await expect(page.locator('input[type="file"]')).toBeEnabled();
   });
 
   test("corrupted localStorage recovers to the empty upload screen", async ({
@@ -63,7 +62,9 @@ test.describe("error states", () => {
 
     await page.goto("/");
 
-    await expect(page.getByText("Upload your receipt")).toBeVisible();
+    await expect(page.getByText("Upload your receipt")).toBeVisible({
+      timeout: 10000,
+    });
     await expect(page.getByRole("tab", { name: /add people/i })).toBeDisabled();
     await expect(
       page.getByRole("tab", { name: /assign items/i }),
@@ -82,12 +83,14 @@ test.describe("error states", () => {
 
     await expect(
       page.getByRole("button", { name: /split all evenly/i }),
-    ).toBeVisible();
-    await expect(page.getByText("50%").or(page.getByText("0%"))).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("0%")).toBeVisible();
 
     await context.setOffline(true);
 
-    await page.getByRole("button", { name: /split all evenly/i }).click();
+    await page.getByRole("button", { name: /split all evenly/i }).click({
+      force: true,
+    });
     await expect(
       page.getByText("All items split evenly among everyone!").first(),
     ).toBeVisible();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,156 @@
+import { type Page } from "@playwright/test";
+
+export async function preloadSession(
+  page: Page,
+  state: Record<string, unknown>,
+  activeTab = "upload",
+) {
+  const session = { state, activeTab };
+  await page.addInitScript((data) => {
+    window.localStorage.setItem(
+      "receiptSplitterSession",
+      JSON.stringify(data),
+    );
+  }, session);
+}
+
+/** Seed localStorage after the origin is loaded so later reloads are not overwritten by addInitScript. */
+export async function seedSessionViaReload(
+  page: Page,
+  state: Record<string, unknown>,
+  activeTab = "upload",
+) {
+  await page.goto("/");
+  await page.evaluate(
+    ({ sessionState, tab }) => {
+      window.localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({ state: sessionState, activeTab: tab }),
+      );
+    },
+    { sessionState: state, tab: activeTab },
+  );
+  await page.reload();
+}
+
+/** 1x1 transparent PNG — enough to satisfy the receipt uploader. */
+export const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+export async function uploadTinyReceipt(page: Page) {
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "receipt.png",
+    mimeType: "image/png",
+    buffer: TINY_PNG,
+  });
+}
+
+export function parseMoney(text: string | null | undefined): number {
+  if (!text) return NaN;
+  const numeric = text.replace(/[^0-9,.-]/g, "");
+  if (numeric.includes(",") && numeric.includes(".")) {
+    return parseFloat(numeric.replace(/,/g, ""));
+  }
+  if (numeric.includes(",")) {
+    return parseFloat(numeric.replace(",", "."));
+  }
+  return parseFloat(numeric);
+}
+
+export function emptyPerson(id: string, name: string) {
+  return {
+    id,
+    name,
+    items: [] as unknown[],
+    totalBeforeTax: 0,
+    tax: 0,
+    tip: 0,
+    finalTotal: 0,
+  };
+}
+
+export function usdReceipt(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    restaurant: "Test Diner",
+    date: "2024-01-15",
+    subtotal: 20,
+    tax: 0,
+    tip: 0,
+    total: 20,
+    currency: "USD",
+    items: [
+      { name: "Burger", price: 10, quantity: 1 },
+      { name: "Fries", price: 10, quantity: 1 },
+    ],
+    ...overrides,
+  };
+}
+
+export function baseState(overrides: Record<string, unknown> = {}) {
+  return {
+    originalReceipt: usdReceipt(),
+    people: [emptyPerson("p1", "Alice"), emptyPerson("p2", "Bob")],
+    assignedItems: [] as unknown[],
+    unassignedItems: [0, 1],
+    groups: [] as unknown[],
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+/** Alice owns Burger, Bob owns Fries — $10 each before tax. */
+export function fullyAssignedState(overrides: Record<string, unknown> = {}) {
+  const receipt = usdReceipt();
+  return baseState({
+    originalReceipt: receipt,
+    people: [
+      {
+        id: "p1",
+        name: "Alice",
+        items: [
+          {
+            itemId: 0,
+            itemName: "Burger",
+            originalPrice: 10,
+            quantity: 1,
+            sharePercentage: 100,
+            amount: 10,
+          },
+        ],
+        totalBeforeTax: 10,
+        tax: 0,
+        tip: 0,
+        finalTotal: 10,
+      },
+      {
+        id: "p2",
+        name: "Bob",
+        items: [
+          {
+            itemId: 1,
+            itemName: "Fries",
+            originalPrice: 10,
+            quantity: 1,
+            sharePercentage: 100,
+            amount: 10,
+          },
+        ],
+        totalBeforeTax: 10,
+        tax: 0,
+        tip: 0,
+        finalTotal: 10,
+      },
+    ],
+    assignedItems: [
+      [0, [{ personId: "p1", sharePercentage: 100 }]],
+      [1, [{ personId: "p2", sharePercentage: 100 }]],
+    ],
+    unassignedItems: [],
+    ...overrides,
+  });
+}

--- a/e2e/share-clipboard.spec.ts
+++ b/e2e/share-clipboard.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from "@playwright/test";
+import { preloadSession, fullyAssignedState } from "./helpers";
+
+declare global {
+  interface Window {
+    __copiedTexts?: string[];
+  }
+}
+
+async function disableNativeShare(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+  });
+}
+
+async function stubClipboardCapture(page: Page) {
+  await page.addInitScript(() => {
+    window.__copiedTexts = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          window.__copiedTexts = window.__copiedTexts || [];
+          window.__copiedTexts.push(text);
+        },
+      },
+    });
+  });
+}
+
+async function stubClipboardDenied(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async () => {
+          throw new DOMException("Permission denied", "NotAllowedError");
+        },
+      },
+    });
+  });
+}
+
+async function stubClipboardMissing(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+}
+
+async function openShareReadyResults(page: Page) {
+  await preloadSession(page, fullyAssignedState(), "results");
+  await page.goto("/");
+  await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+  await page.locator("#venmo-phone").fill("5551234567");
+}
+
+test.describe("Share Split clipboard", () => {
+  test("copies a share URL and shows Copied! when clipboard write succeeds", async ({
+    page,
+  }) => {
+    await disableNativeShare(page);
+    await stubClipboardCapture(page);
+    await openShareReadyResults(page);
+
+    const shareBtn = page.getByRole("button", { name: "Share Split" });
+    await expect(shareBtn).toBeEnabled();
+    await shareBtn.click();
+
+    await expect(page.getByText("Copied!")).toBeVisible();
+
+    const copied = await page.evaluate(() => window.__copiedTexts || []);
+    expect(copied.length).toBeGreaterThan(0);
+    expect(copied[0]).toContain("/split?");
+    expect(copied[0]).toContain("names=");
+    expect(copied[0]).toContain("amounts=");
+  });
+
+  test("shows an error toast when clipboard write is denied", async ({
+    page,
+  }) => {
+    await disableNativeShare(page);
+    await stubClipboardDenied(page);
+    await openShareReadyResults(page);
+
+    await page.getByRole("button", { name: "Share Split" }).click();
+
+    await expect(
+      page.getByText("Failed to copy share link. Please try again."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Share Split" }),
+    ).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+  });
+
+  test("shows the same fallback when the Clipboard API is missing", async ({
+    page,
+  }) => {
+    await disableNativeShare(page);
+    await stubClipboardMissing(page);
+    await openShareReadyResults(page);
+
+    await page.getByRole("button", { name: "Share Split" }).click();
+
+    await expect(
+      page.getByText("Failed to copy share link. Please try again."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Share Split" }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/share-clipboard.spec.ts
+++ b/e2e/share-clipboard.spec.ts
@@ -56,7 +56,9 @@ async function stubClipboardMissing(page: Page) {
 async function openShareReadyResults(page: Page) {
   await preloadSession(page, fullyAssignedState(), "results");
   await page.goto("/");
-  await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible({
+    timeout: 10000,
+  });
   await page.locator("#venmo-phone").fill("5551234567");
 }
 
@@ -72,7 +74,7 @@ test.describe("Share Split clipboard", () => {
     await expect(shareBtn).toBeEnabled();
     await shareBtn.click();
 
-    await expect(page.getByText("Copied!")).toBeVisible();
+    await expect(page.getByText("Copied!")).toBeVisible({ timeout: 5000 });
 
     const copied = await page.evaluate(() => window.__copiedTexts || []);
     expect(copied.length).toBeGreaterThan(0);

--- a/src/components/item-assignment.tsx
+++ b/src/components/item-assignment.tsx
@@ -483,6 +483,7 @@ export function ItemAssignment({
                             size="sm"
                             onClick={() => handleDeleteItem(index)}
                             title="Delete item"
+                            aria-label={`Delete ${item.name}`}
                           >
                             <Trash2 className="h-4 w-4" />
                           </Button>
@@ -663,6 +664,7 @@ export function ItemAssignment({
                             size="sm"
                             onClick={() => handleDeleteItem(index)}
                             title="Delete item"
+                            aria-label={`Delete ${item.name}`}
                           >
                             <Trash2 className="h-4 w-4" />
                           </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Playwright e2e tests for issues #132, #133, #134, and #135. Specs follow the existing localStorage-preload pattern and do not call the real parse API.

## Coverage

- **#132 Error states** — API 500 and timeout on upload (toast + loading clears), corrupted session JSON recovers to empty upload, offline assignment survives reconnect/reload.
- **#133 Empty states** — no people prompt + Next disabled, empty items list, Next disabled until 100% assigned, groups empty copy on the People tab.
- **#134 Share Split clipboard** — stubbed clipboard write success (URL captured, Copied!), denied write, and missing Clipboard API all degrade to the existing error toast.
- **#135 Edit receipt** — price change recalculates person totals, add named item, delete item remaps results, sequential edits are not stale, currency switch reformats Upload/Results.

## Notes

- Shared session helpers live in `e2e/helpers.ts`.
- Delete-item buttons now have `aria-label` so locators can use `getByRole`.
- Item rename is not in the UI; the name AC is covered via Add Item.
- Clipboard tests stub `navigator.clipboard` instead of using the OS clipboard (CI-stable).
- Offline test does not reload while offline (Next.js assets would fail to load).

## Verification

- 17/17 new Playwright specs passed locally
- Related Jest suites and `npm run lint` passed
- CI `build-and-test` is green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32049b93-0d0a-4692-be04-42d3d8792385?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32049b93-0d0a-4692-be04-42d3d8792385&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

