### PR TITLE
feat: [1/5] multi-receipt data model and session migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, "add/*", "ci/*", "feature/*"]
+    branches: [main, "add/*", "ci/*", "feature/*", "cursor/*"]
   pull_request:
-    branches: [main, "add/*", "ci/*", "feature/*"]
+    branches: [main, "add/*", "ci/*", "feature/*", "cursor/*"]
 
 jobs:
   build-and-test:

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -122,6 +122,29 @@ describe("Home Page", () => {
       });
       expect(screen.getByRole("tab", { name: /add people/i })).toHaveAttribute("data-state", "active");
     });
+
+    it("restores a v2 session with receipts[]", () => {
+      const receiptId = "00000000-0000-4000-8000-000000000000";
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [{ id: receiptId, receipt: mockReceipt }],
+            people: mockPeople,
+            assignedItems: [[receiptId, []]],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "people",
+        })
+      );
+      render(<Home />);
+      expect(screen.getByRole("tab", { name: /add people/i })).toHaveAttribute("data-state", "active");
+      expect(screen.getByRole("tab", { name: /add people/i })).toBeEnabled();
+      expect(screen.getByRole("tab", { name: /assign items/i })).toBeEnabled();
+    });
   });
 
   describe("New Split button", () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,12 +23,13 @@ import {
   type PersonItemAssignment,
   type ReceiptState,
   type Group,
+  type ItemAssignments,
 } from "@/types";
 import {
-  calculatePersonTotals,
-  validateItemAssignments,
   getUnassignedItems,
-  validateReceiptInvariants,
+  calculateSessionPersonTotals,
+  validateSessionAssignments,
+  validateSessionInvariants,
 } from "@/lib/receipt-utils";
 import {
   getUniqueGroupEmoji,
@@ -40,69 +41,54 @@ import {
   safeRemoveItem,
   safeSetItem,
 } from "@/lib/storage";
+import {
+  SESSION_STORAGE_KEY,
+  emptyReceiptState,
+  serializeSession,
+  deserializeSession,
+  isDefaultSession,
+} from "@/lib/session-persistence";
 
 export default function Home() {
-  const LOCAL_STORAGE_KEY = "receiptSplitterSession";
-  const [state, setState] = useState<ReceiptState>({
-    originalReceipt: null,
-    people: [],
-    assignedItems: new Map(),
-    unassignedItems: [],
-    groups: [],
-    isLoading: false,
-    error: null,
-  });
+  const [state, setState] = useState<ReceiptState>(emptyReceiptState);
   const [activeTab, setActiveTab] = useState("upload");
   const [hasSession, setHasSession] = useState(false);
   const isFirstLoad = useRef(true);
   const [resetImageTrigger, setResetImageTrigger] = useState(0);
-  
+
+  const activeReceipt = state.receipts[0]?.receipt ?? null;
+  const activeId = state.receipts[0]?.id;
+  const activeAssignments: ItemAssignments = activeId
+    ? (state.assignedItems.get(activeId) ?? new Map())
+    : new Map();
+  const unassignedItems = activeReceipt
+    ? getUnassignedItems(activeReceipt, activeAssignments)
+    : [];
+
   const validationResult = useMemo(() => {
-    return validateReceiptInvariants(
-      state.originalReceipt,
+    return validateSessionInvariants(
+      state.receipts,
       state.assignedItems,
       state.people
     );
-  }, [state.originalReceipt, state.assignedItems, state.people]);
-
-  const defaultSession = useMemo(
-    () => ({
-      state: {
-        originalReceipt: null,
-        people: [],
-        assignedItems: [],
-        unassignedItems: [],
-        groups: [],
-        isLoading: false,
-        error: null,
-      },
-      activeTab: "upload",
-    }),
-    []
-  );
+  }, [state.receipts, state.assignedItems, state.people]);
 
   // Restore session from localStorage on mount
   useEffect(() => {
-    const session = safeGetItem(LOCAL_STORAGE_KEY);
+    const session = safeGetItem(SESSION_STORAGE_KEY);
     if (session) {
-      try {
-        const parsed = JSON.parse(session);
-        // Always convert assignedItems to Map if it's an array
-        if (parsed.state && Array.isArray(parsed.state.assignedItems)) {
-          parsed.state.assignedItems = new Map(parsed.state.assignedItems);
-        }
-        setState(parsed.state || parsed);
-        setActiveTab(parsed.activeTab || "upload");
-        const isDefault =
-          JSON.stringify(parsed) === JSON.stringify(defaultSession);
-        setHasSession(!isDefault);
-      } catch (err) {
-        console.log("Failed to restore session from localStorage", err);
+      const restored = deserializeSession(session);
+      if (restored) {
+        setState(restored.state);
+        setActiveTab(restored.activeTab || "upload");
+        setHasSession(!isDefaultSession(restored.state, restored.activeTab || "upload"));
+      } else {
+        setHasSession(false);
       }
     } else {
       setHasSession(false);
     }
-  }, [defaultSession]);
+  }, []);
 
   // Save session to localStorage on state or tab change
   useEffect(() => {
@@ -115,73 +101,52 @@ export default function Home() {
     }
     // Only save if not loading
     if (!state.isLoading) {
-      const toSave = {
-        state: {
-          ...state,
-          // Convert Map to array for serialization
-          assignedItems: Array.from(state.assignedItems.entries()),
-        },
-        activeTab,
-      };
-      const serialized = JSON.stringify(toSave);
-      const ok = safeSetItem(LOCAL_STORAGE_KEY, serialized);
+      const serialized = serializeSession(state, activeTab);
+      const ok = safeSetItem(SESSION_STORAGE_KEY, serialized);
       if (!ok) {
         // Quota exhausted — evict the cached image (largest consumer) and retry once
         safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
-        safeSetItem(LOCAL_STORAGE_KEY, serialized);
+        safeSetItem(SESSION_STORAGE_KEY, serialized);
       }
-      // Check if session is not default
-      const isDefault =
-        serialized === JSON.stringify(defaultSession);
-      setHasSession(!isDefault);
+      setHasSession(!isDefaultSession(state, activeTab));
     }
-  }, [state, activeTab, defaultSession]);
+  }, [state, activeTab]);
 
   // Handler for New Split button
   const handleNewSplit = () => {
-    safeRemoveItem(LOCAL_STORAGE_KEY);
+    safeRemoveItem(SESSION_STORAGE_KEY);
     safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
-    setState({
-      originalReceipt: null,
-      people: [],
-      assignedItems: new Map(),
-      unassignedItems: [],
-      groups: [],
-      isLoading: false,
-      error: null,
-    });
+    setState(emptyReceiptState());
     setActiveTab("upload");
     setHasSession(false);
     setResetImageTrigger((v) => v + 1);
   };
 
   // Check if all items are assigned
-  const allItemsAssigned = state.originalReceipt
-    ? validateItemAssignments(state.originalReceipt, state.assignedItems)
-    : false;
+  const allItemsAssigned = validateSessionAssignments(
+    state.receipts,
+    state.assignedItems
+  );
 
   // Calculate progress
   const calculateProgress = (): number => {
-    if (!state.originalReceipt) return 0;
+    if (!activeReceipt) return 0;
 
-    const totalItems = state.originalReceipt.items.length;
+    const totalItems = activeReceipt.items.length;
     if (totalItems === 0) return 100;
 
-    const assignedItemCount = totalItems - state.unassignedItems.length;
+    const assignedItemCount = totalItems - unassignedItems.length;
     return (assignedItemCount / totalItems) * 100;
   };
 
-  // Handle receipt upload
+  // Handle receipt upload — still replaces a single receipt (append is a later PR)
   const handleReceiptParsed = (receipt: Receipt) => {
+    const id = crypto.randomUUID();
     setState({
-      originalReceipt: receipt,
+      receipts: [{ id, receipt }],
       people: [],
-      assignedItems: new Map(),
-      unassignedItems: Array.from(
-        { length: receipt.items.length },
-        (_, i) => i
-      ),
       groups: [],
+      assignedItems: new Map([[id, new Map()]]),
       isLoading: false,
       error: null,
     });
@@ -194,56 +159,43 @@ export default function Home() {
   // Handle people changes
   const handlePeopleChange = (updatedPeople: Person[]) => {
     setState((prevState) => {
+      let nextAssigned = prevState.assignedItems;
+
       // If we're removing a person, we need to update the assigned items
       if (prevState.people.length > updatedPeople.length) {
-        const removedPeople = prevState.people.filter(
-          (p) => !updatedPeople.some((up) => up.id === p.id)
+        const removedIds = new Set(
+          prevState.people
+            .filter((p) => !updatedPeople.some((up) => up.id === p.id))
+            .map((p) => p.id)
         );
 
-        const newAssignedItems = new Map(prevState.assignedItems);
-
-        // Remove the assignments for the removed people
-        removedPeople.forEach((person) => {
-          newAssignedItems.forEach((assignments, itemIndex) => {
+        // Clone outer map AND each inner map we change (shallow Map clone is not enough)
+        const nextOuter = new Map(prevState.assignedItems);
+        for (const [receiptId, inner] of prevState.assignedItems) {
+          const nextInner = new Map(inner);
+          nextInner.forEach((assignments, itemIndex) => {
             const updatedAssignments = assignments.filter(
-              (a) => a.personId !== person.id
+              (a) => !removedIds.has(a.personId)
             );
-
             if (updatedAssignments.length === 0) {
-              newAssignedItems.delete(itemIndex);
+              nextInner.delete(itemIndex);
             } else {
-              newAssignedItems.set(itemIndex, updatedAssignments);
+              nextInner.set(itemIndex, updatedAssignments);
             }
           });
-        });
-
-        // Recalculate unassigned items
-        const unassignedItems = prevState.originalReceipt
-          ? getUnassignedItems(prevState.originalReceipt, newAssignedItems)
-          : [];
-
-        // Calculate new totals
-        let newPeople = updatedPeople;
-        if (prevState.originalReceipt) {
-          newPeople = calculatePersonTotals(
-            prevState.originalReceipt,
-            updatedPeople,
-            newAssignedItems
-          );
+          nextOuter.set(receiptId, nextInner);
         }
-
-        return {
-          ...prevState,
-          people: newPeople,
-          assignedItems: newAssignedItems,
-          unassignedItems,
-        };
+        nextAssigned = nextOuter;
       }
 
-      // If we're just adding people, no need to update assignments
       return {
         ...prevState,
-        people: updatedPeople,
+        people: calculateSessionPersonTotals(
+          prevState.receipts,
+          updatedPeople,
+          nextAssigned
+        ),
+        assignedItems: nextAssigned,
       };
     });
   };
@@ -254,28 +206,28 @@ export default function Home() {
     remappedAssignments?: Map<number, PersonItemAssignment[]>
   ) => {
     setState((prevState) => {
-      // Use remapped assignments if provided (from delete), else use existing
-      const assignmentsToUse = remappedAssignments || prevState.assignedItems;
+      const receiptId = prevState.receipts[0]?.id;
+      if (!receiptId) return prevState;
 
-      // Recalculate unassigned items (FIXES STALE STATE BUG)
-      const unassignedItems = getUnassignedItems(
-        updatedReceipt,
-        assignmentsToUse
-      );
+      const nextOuter = new Map(prevState.assignedItems);
+      const assignmentsToUse =
+        remappedAssignments ??
+        new Map(nextOuter.get(receiptId) ?? []);
+      nextOuter.set(receiptId, assignmentsToUse);
 
-      // Recalculate people totals
-      const updatedPeople = calculatePersonTotals(
-        updatedReceipt,
-        prevState.people,
-        assignmentsToUse
+      const nextReceipts = prevState.receipts.map((stored, index) =>
+        index === 0 ? { ...stored, receipt: updatedReceipt } : stored
       );
 
       return {
         ...prevState,
-        originalReceipt: updatedReceipt,
-        assignedItems: assignmentsToUse,
-        unassignedItems,
-        people: updatedPeople,
+        receipts: nextReceipts,
+        assignedItems: nextOuter,
+        people: calculateSessionPersonTotals(
+          nextReceipts,
+          prevState.people,
+          nextOuter
+        ),
       };
     });
   };
@@ -286,36 +238,27 @@ export default function Home() {
     assignments: PersonItemAssignment[]
   ) => {
     setState((prevState) => {
-      if (!prevState.originalReceipt) return prevState;
+      const receiptId = prevState.receipts[0]?.id;
+      if (!receiptId) return prevState;
 
-      // Create new assignments map
-      const newAssignedItems = new Map(prevState.assignedItems);
+      const nextOuter = new Map(prevState.assignedItems);
+      const inner = new Map(nextOuter.get(receiptId) ?? []);
 
-      // Update the assignments for this item
       if (assignments.length === 0) {
-        newAssignedItems.delete(itemIndex);
+        inner.delete(itemIndex);
       } else {
-        newAssignedItems.set(itemIndex, assignments);
+        inner.set(itemIndex, assignments);
       }
-
-      // Recalculate unassigned items
-      const unassignedItems = getUnassignedItems(
-        prevState.originalReceipt,
-        newAssignedItems
-      );
-
-      // Recalculate people totals
-      const updatedPeople = calculatePersonTotals(
-        prevState.originalReceipt,
-        prevState.people,
-        newAssignedItems
-      );
+      nextOuter.set(receiptId, inner);
 
       return {
         ...prevState,
-        assignedItems: newAssignedItems,
-        unassignedItems,
-        people: updatedPeople,
+        assignedItems: nextOuter,
+        people: calculateSessionPersonTotals(
+          prevState.receipts,
+          prevState.people,
+          nextOuter
+        ),
       };
     });
   };
@@ -417,7 +360,7 @@ export default function Home() {
   const canGoToNextTab = (): boolean => {
     switch (activeTab) {
       case "upload":
-        return state.originalReceipt !== null;
+        return state.receipts.length > 0;
       case "people":
         return state.people.length > 0;
       case "assign":
@@ -429,25 +372,27 @@ export default function Home() {
 
   // Split all unassigned items evenly among all people
   const splitAllItemsEvenly = () => {
-    if (!state.originalReceipt || state.people.length === 0) return;
+    if (state.receipts.length === 0 || state.people.length === 0) return;
 
     setState((prevState) => {
-      if (!prevState.originalReceipt) return prevState;
+      const receiptId = prevState.receipts[0]?.id;
+      const receipt = prevState.receipts[0]?.receipt;
+      if (!receiptId || !receipt) return prevState;
+
+      const inner = new Map(prevState.assignedItems.get(receiptId) ?? []);
+      const currentlyUnassigned = getUnassignedItems(receipt, inner);
 
       // No unassigned items — nothing to do
-      if (prevState.unassignedItems.length === 0) {
+      if (currentlyUnassigned.length === 0) {
         toast.info("No unassigned items to split evenly!");
         return prevState;
       }
-
-      // Start from existing assignments
-      const newAssignedItems = new Map(prevState.assignedItems);
 
       // Calculate equal share percentage with 2 decimal places
       const equalShare = +(100 / prevState.people.length).toFixed(2);
 
       // Only split unassigned items, preserving existing assignments
-      prevState.unassignedItems.forEach((itemIndex) => {
+      currentlyUnassigned.forEach((itemIndex) => {
         // Create assignments for all people
         const assignments: PersonItemAssignment[] = [];
 
@@ -471,33 +416,30 @@ export default function Home() {
           }
         });
 
-        // Set the assignments for this item
-        newAssignedItems.set(itemIndex, assignments);
+        inner.set(itemIndex, assignments);
       });
 
-      // No unassigned items since all are now assigned
-      const unassignedItems: number[] = [];
-
-      // Recalculate people totals
-      const updatedPeople = calculatePersonTotals(
-        prevState.originalReceipt,
-        prevState.people,
-        newAssignedItems
-      );
+      const nextOuter = new Map(prevState.assignedItems);
+      nextOuter.set(receiptId, inner);
 
       toast.success("All items split evenly among everyone!");
 
       return {
         ...prevState,
-        assignedItems: newAssignedItems,
-        unassignedItems,
-        people: updatedPeople,
+        assignedItems: nextOuter,
+        people: calculateSessionPersonTotals(
+          prevState.receipts,
+          prevState.people,
+          nextOuter
+        ),
       };
     });
 
     // Don't automatically move to results tab anymore
     // setActiveTab("results");
   };
+
+  const hasReceipt = state.receipts.length > 0;
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-4xl">
@@ -559,14 +501,14 @@ export default function Home() {
               <span className="hidden xs:inline sm:hidden">Upload</span>
               <span className="hidden sm:inline">Upload Receipt</span>
             </TabsTrigger>
-            <TabsTrigger value="people" disabled={!state.originalReceipt} className="gap-1.5 sm:gap-2">
+            <TabsTrigger value="people" disabled={!hasReceipt} className="gap-1.5 sm:gap-2">
               <Users className="h-4 w-4 flex-shrink-0" />
               <span className="hidden xs:inline sm:hidden">People</span>
               <span className="hidden sm:inline">Add People</span>
             </TabsTrigger>
             <TabsTrigger
               value="assign"
-              disabled={!state.originalReceipt || state.people.length === 0}
+              disabled={!hasReceipt || state.people.length === 0}
               className="gap-1.5 sm:gap-2"
             >
               <ListChecks className="h-4 w-4 flex-shrink-0" />
@@ -575,7 +517,7 @@ export default function Home() {
             </TabsTrigger>
             <TabsTrigger
               value="results"
-              disabled={!state.originalReceipt || state.people.length === 0}
+              disabled={!hasReceipt || state.people.length === 0}
               className="gap-1.5 sm:gap-2"
             >
               <DollarSign className="h-4 w-4 flex-shrink-0" />
@@ -584,7 +526,7 @@ export default function Home() {
             </TabsTrigger>
           </TabsList>
 
-          {state.originalReceipt && (
+          {activeReceipt && (
             <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 w-full">
               <div className="flex items-center gap-2 w-full sm:w-auto">
                 <Progress
@@ -616,9 +558,9 @@ export default function Home() {
             resetImageTrigger={resetImageTrigger}
           />
 
-          {state.originalReceipt && (
+          {activeReceipt && (
             <ReceiptDetails
-              receipt={state.originalReceipt}
+              receipt={activeReceipt}
               onReceiptUpdate={(receipt) => handleReceiptUpdate(receipt)}
             />
           )}
@@ -639,22 +581,22 @@ export default function Home() {
             onGroupEmojiRegenerate={handleGroupEmojiRegenerate}
           />
 
-          {state.originalReceipt && (
+          {activeReceipt && (
             <ReceiptDetails
-              receipt={state.originalReceipt}
+              receipt={activeReceipt}
               onReceiptUpdate={(receipt) => handleReceiptUpdate(receipt)}
             />
           )}
         </TabsContent>
 
         <TabsContent value="assign" className="space-y-6">
-          {state.originalReceipt && (
+          {activeReceipt && (
             <ItemAssignment
-              receipt={state.originalReceipt}
+              receipt={activeReceipt}
               people={state.people}
               groups={state.groups}
-              assignedItems={state.assignedItems}
-              unassignedItems={state.unassignedItems}
+              assignedItems={activeAssignments}
+              unassignedItems={unassignedItems}
               onAssignItems={handleAssignItems}
               onReceiptUpdate={handleReceiptUpdate}
             />
@@ -662,17 +604,17 @@ export default function Home() {
         </TabsContent>
 
         <TabsContent value="results" className="space-y-6">
-          <ValidationErrors errors={validationResult.errors} currencyCode={state.originalReceipt?.currency} />
+          <ValidationErrors errors={validationResult.errors} currencyCode={activeReceipt?.currency} />
 
           <ResultsSummary
             people={state.people}
-            receiptName={state.originalReceipt?.restaurant || null}
-            receiptDate={state.originalReceipt?.date || null}
-            currencyCode={state.originalReceipt?.currency}
+            receiptName={activeReceipt?.restaurant || null}
+            receiptDate={activeReceipt?.date || null}
+            currencyCode={activeReceipt?.currency}
             validationResult={validationResult}
           />
 
-          <PersonItems people={state.people} currencyCode={state.originalReceipt?.currency} />
+          <PersonItems people={state.people} currencyCode={activeReceipt?.currency} />
         </TabsContent>
       </Tabs>
 

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -8,9 +8,15 @@ import {
   calculateSubtotal,
   remapAssignmentsAfterDelete,
   distributeEqualShares,
+  sessionCurrency,
+  validateReceiptCurrency,
+  calculateSessionPersonTotals,
+  validateSessionAssignments,
+  getSessionUnassigned,
+  validateSessionInvariants,
 } from "./receipt-utils";
 import { mockPeople, mockReceipt, mockAssignedItems } from "@/test/test-utils";
-import { type PersonItemAssignment, type Receipt, type Person } from "@/types";
+import { type PersonItemAssignment, type Receipt, type Person, type StoredReceipt, type ItemAssignments } from "@/types";
 import { formatAmount } from "./utils";
 
 describe("receipt-utils", () => {
@@ -743,5 +749,133 @@ describe("validateReceiptInvariants", () => {
       const result = validateReceiptInvariants(receipt, new Map(), []);
       expect(result.isValid).toBe(true);
     });
+  });
+});
+
+describe("calculatePersonTotals receipt metadata", () => {
+  it("sets receiptName from the restaurant and omits receiptId without a 4th arg", () => {
+    const result = calculatePersonTotals(mockReceipt, mockPeople, mockAssignedItems);
+    expect(result[0].items[0].receiptName).toBe("Testaurant");
+    expect(result[0].items[0].receiptId).toBeUndefined();
+  });
+
+  it("sets receiptId when the optional 4th argument is provided", () => {
+    const result = calculatePersonTotals(
+      mockReceipt,
+      mockPeople,
+      mockAssignedItems,
+      "receipt-1"
+    );
+    expect(result[0].items[0].receiptId).toBe("receipt-1");
+    expect(result[0].items[0].receiptName).toBe("Testaurant");
+  });
+});
+
+describe("session-level receipt helpers", () => {
+  const receiptA: Receipt = {
+    restaurant: "Cafe A",
+    date: "2024-01-01",
+    subtotal: 50,
+    tax: 5,
+    tip: 5,
+    total: 60,
+    currency: "USD",
+    items: [{ name: "Burger", price: 50, quantity: 1 }],
+  };
+  const receiptB: Receipt = {
+    restaurant: "Cafe B",
+    date: "2024-01-02",
+    subtotal: 40,
+    tax: 4,
+    tip: 6,
+    total: 50,
+    currency: "USD",
+    items: [{ name: "Fries", price: 40, quantity: 1 }],
+  };
+  const storedA: StoredReceipt = { id: "rec-a", receipt: receiptA };
+  const storedB: StoredReceipt = { id: "rec-b", receipt: receiptB };
+  const innerA: ItemAssignments = new Map([
+    [0, [{ personId: "a", sharePercentage: 100 }]],
+  ]);
+  const innerB: ItemAssignments = new Map([
+    [0, [{ personId: "a", sharePercentage: 100 }]],
+  ]);
+  const bothAssigned = new Map<string, ItemAssignments>([
+    ["rec-a", innerA],
+    ["rec-b", innerB],
+  ]);
+
+  it("sessionCurrency returns the first receipt's currency", () => {
+    expect(sessionCurrency([storedA, storedB])).toBe("USD");
+    expect(sessionCurrency([])).toBeUndefined();
+  });
+
+  it("validateReceiptCurrency rejects EUR vs USD and accepts a match", () => {
+    const eurReceipt: Receipt = { ...receiptA, currency: "EUR" };
+    expect(validateReceiptCurrency(eurReceipt, "USD")).toBe(false);
+    expect(validateReceiptCurrency(receiptA, "USD")).toBe(true);
+    expect(validateReceiptCurrency(receiptA, " usd ")).toBe(true);
+    expect(validateReceiptCurrency(receiptA, "usd")).toBe(true);
+    expect(validateReceiptCurrency(receiptA, undefined)).toBe(true);
+  });
+
+  it("calculateSessionPersonTotals sums Alice's per-receipt totals", () => {
+    const perA = calculatePersonTotals(receiptA, mockPeople, innerA, "rec-a");
+    const perB = calculatePersonTotals(receiptB, mockPeople, innerB, "rec-b");
+    const session = calculateSessionPersonTotals(
+      [storedA, storedB],
+      mockPeople,
+      bothAssigned
+    );
+
+    const alice = session[0];
+    expect(alice.finalTotal).toBe(perA[0].finalTotal + perB[0].finalTotal);
+    expect(alice.totalBeforeTax).toBe(perA[0].totalBeforeTax + perB[0].totalBeforeTax);
+    expect(alice.tax).toBe(perA[0].tax + perB[0].tax);
+    expect(alice.tip).toBe(perA[0].tip + perB[0].tip);
+    expect(alice.items).toHaveLength(2);
+    expect(alice.items.map((item) => item.receiptId)).toEqual(["rec-a", "rec-b"]);
+    expect(alice.items.map((item) => item.receiptName)).toEqual(["Cafe A", "Cafe B"]);
+
+    // Bob has no assignments across either receipt
+    expect(session[1].finalTotal).toBe(0);
+    expect(session[1].items).toHaveLength(0);
+  });
+
+  it("validateSessionAssignments is false when receipt B is incomplete", () => {
+    const incompleteB = new Map<string, ItemAssignments>([
+      ["rec-a", innerA],
+      ["rec-b", new Map()],
+    ]);
+    expect(validateSessionAssignments([storedA, storedB], bothAssigned)).toBe(true);
+    expect(validateSessionAssignments([storedA, storedB], incompleteB)).toBe(false);
+    expect(validateSessionAssignments([], bothAssigned)).toBe(false);
+  });
+
+  it("getSessionUnassigned lists incomplete items with receipt ids", () => {
+    const incompleteB = new Map<string, ItemAssignments>([
+      ["rec-a", innerA],
+      ["rec-b", new Map()],
+    ]);
+    expect(getSessionUnassigned([storedA, storedB], incompleteB)).toEqual([
+      { receiptId: "rec-b", itemIndex: 0 },
+    ]);
+  });
+
+  it("validateSessionInvariants concatenates per-receipt errors and treats empty as valid", () => {
+    expect(validateSessionInvariants([], new Map(), []).isValid).toBe(true);
+
+    const badB: StoredReceipt = {
+      id: "rec-b",
+      receipt: { ...receiptB, subtotal: -40, total: 10 },
+    };
+    const result = validateSessionInvariants(
+      [storedA, badB],
+      bothAssigned,
+      mockPeople
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.some((e) => e.type === AmountValidationError.NEGATIVE_AMOUNT)).toBe(true);
   });
 });

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -1,5 +1,5 @@
 import Decimal from 'decimal.js';
-import { type Person, type Receipt, type ReceiptItem, type PersonItem, type PersonItemAssignment } from '@/types';
+import { type Person, type Receipt, type ReceiptItem, type PersonItem, type PersonItemAssignment, type StoredReceipt, type ItemAssignments } from '@/types';
 import { VALIDATION_LIMITS } from './split-sharing';
 import { formatCurrency as formatCurrencyNew } from './currency';
 
@@ -93,7 +93,8 @@ export function distributeEqualShares(personIds: string[]): PersonItemAssignment
 export function calculatePersonTotals(
   receipt: Receipt,
   people: Person[],
-  assignedItems: Map<number, PersonItemAssignment[]>
+  assignedItems: Map<number, PersonItemAssignment[]>,
+  receiptId?: string
 ): Person[] {
   // Convert receipt values to Decimal for precision
   const subtotal = new Decimal(receipt.subtotal || 0);
@@ -134,6 +135,8 @@ export function calculatePersonTotals(
         quantity: item.quantity || 1,
         sharePercentage: sharePercentage,
         amount: personShare.toNumber(),
+        receiptName: receipt.restaurant ?? undefined,
+        receiptId,
       });
     });
     
@@ -538,6 +541,136 @@ export function validateReceiptInvariants(
       }
     });
   });
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Session currency is the first receipt's currency. Mixed-currency splits
+ * are not supported; later receipts must match this code.
+ */
+export function sessionCurrency(receipts: StoredReceipt[]): string | undefined {
+  return receipts[0]?.receipt.currency;
+}
+
+/**
+ * True when the session has no currency yet, or the receipt's currency
+ * matches (case-insensitive, trimmed).
+ */
+export function validateReceiptCurrency(
+  receipt: Receipt,
+  currency: string | undefined
+): boolean {
+  if (currency === undefined || currency.trim() === "") {
+    return true;
+  }
+  return receipt.currency.trim().toUpperCase() === currency.trim().toUpperCase();
+}
+
+/**
+ * Aggregates per-receipt person totals across a session.
+ * Always delegates tax/tip math to calculatePersonTotals.
+ */
+export function calculateSessionPersonTotals(
+  receipts: StoredReceipt[],
+  people: Person[],
+  assignedItems: Map<string, ItemAssignments>
+): Person[] {
+  const totals = people.map((person) => ({
+    ...person,
+    items: [] as PersonItem[],
+    totalBeforeTax: new Decimal(0),
+    tax: new Decimal(0),
+    tip: new Decimal(0),
+    finalTotal: new Decimal(0),
+  }));
+
+  const indexById = new Map(people.map((person, index) => [person.id, index]));
+
+  for (const stored of receipts) {
+    const inner = assignedItems.get(stored.id) ?? new Map();
+    const perReceipt = calculatePersonTotals(
+      stored.receipt,
+      people,
+      inner,
+      stored.id
+    );
+
+    for (const person of perReceipt) {
+      const index = indexById.get(person.id);
+      if (index === undefined) continue;
+      totals[index].items = totals[index].items.concat(person.items);
+      totals[index].totalBeforeTax = totals[index].totalBeforeTax.add(person.totalBeforeTax);
+      totals[index].tax = totals[index].tax.add(person.tax);
+      totals[index].tip = totals[index].tip.add(person.tip);
+      totals[index].finalTotal = totals[index].finalTotal.add(person.finalTotal);
+    }
+  }
+
+  return totals.map((person) => ({
+    ...person,
+    totalBeforeTax: person.totalBeforeTax.toNumber(),
+    tax: person.tax.toNumber(),
+    tip: person.tip.toNumber(),
+    finalTotal: person.finalTotal.toNumber(),
+  }));
+}
+
+/**
+ * True when every receipt in the session is fully assigned.
+ * Empty sessions are not fully assigned.
+ */
+export function validateSessionAssignments(
+  receipts: StoredReceipt[],
+  assignedItems: Map<string, ItemAssignments>
+): boolean {
+  if (receipts.length === 0) return false;
+  return receipts.every((stored) =>
+    validateItemAssignments(
+      stored.receipt,
+      assignedItems.get(stored.id) ?? new Map()
+    )
+  );
+}
+
+export function getSessionUnassigned(
+  receipts: StoredReceipt[],
+  assignedItems: Map<string, ItemAssignments>
+): { receiptId: string; itemIndex: number }[] {
+  const unassigned: { receiptId: string; itemIndex: number }[] = [];
+
+  for (const stored of receipts) {
+    const inner = assignedItems.get(stored.id) ?? new Map();
+    for (const itemIndex of getUnassignedItems(stored.receipt, inner)) {
+      unassigned.push({ receiptId: stored.id, itemIndex });
+    }
+  }
+
+  return unassigned;
+}
+
+/**
+ * Runs per-receipt invariant checks and concatenates errors.
+ * An empty session is valid.
+ */
+export function validateSessionInvariants(
+  receipts: StoredReceipt[],
+  assignedItems: Map<string, ItemAssignments>,
+  people: Person[]
+): ReceiptValidationResult {
+  if (receipts.length === 0) {
+    return { isValid: true, errors: [] };
+  }
+
+  const errors: ReceiptValidationError[] = [];
+  for (const stored of receipts) {
+    const inner = assignedItems.get(stored.id) ?? new Map();
+    const result = validateReceiptInvariants(stored.receipt, inner, people);
+    errors.push(...result.errors);
+  }
 
   return {
     isValid: errors.length === 0,

--- a/src/lib/session-persistence.test.ts
+++ b/src/lib/session-persistence.test.ts
@@ -1,0 +1,218 @@
+import {
+  SESSION_STORAGE_KEY,
+  SESSION_VERSION,
+  emptyReceiptState,
+  serializeSession,
+  deserializeSession,
+  migrateSession,
+  serializeAssignedItems,
+  isDefaultSession,
+} from "./session-persistence";
+import { mockReceipt, mockPeople } from "@/test/test-utils";
+import { type ReceiptState, type ItemAssignments } from "@/types";
+
+const V1_ASSIGNMENTS: [number, { personId: string; sharePercentage: number }[]][] = [
+  [0, [{ personId: "a", sharePercentage: 100 }]],
+];
+
+function v1Blob(overrides: Record<string, unknown> = {}) {
+  return {
+    state: {
+      originalReceipt: mockReceipt,
+      people: mockPeople,
+      assignedItems: V1_ASSIGNMENTS,
+      unassignedItems: [1],
+      groups: [],
+      isLoading: false,
+      error: null,
+      ...overrides,
+    },
+    activeTab: "assign",
+  };
+}
+
+describe("session-persistence", () => {
+  it("exports the localStorage key and v2 version", () => {
+    expect(SESSION_STORAGE_KEY).toBe("receiptSplitterSession");
+    expect(SESSION_VERSION).toBe(2);
+  });
+
+  it("emptyReceiptState has no receipts and empty assignment map", () => {
+    const empty = emptyReceiptState();
+    expect(empty.receipts).toEqual([]);
+    expect(empty.people).toEqual([]);
+    expect(empty.groups).toEqual([]);
+    expect(empty.assignedItems).toBeInstanceOf(Map);
+    expect(empty.assignedItems.size).toBe(0);
+    expect(empty.isLoading).toBe(false);
+    expect(empty.error).toBeNull();
+    expect(isDefaultSession(empty, "upload")).toBe(true);
+  });
+
+  describe("v1 migration", () => {
+    it("round-trips a v1 single-receipt blob to receipts[0] + nested map", () => {
+      const migrated = deserializeSession(JSON.stringify(v1Blob()));
+      expect(migrated).not.toBeNull();
+      expect(migrated!.activeTab).toBe("assign");
+      expect(migrated!.state.receipts).toHaveLength(1);
+      expect(migrated!.state.receipts[0].receipt).toEqual(mockReceipt);
+      expect(migrated!.state.receipts[0].id).toBeTruthy();
+      expect(migrated!.state.people).toEqual(mockPeople);
+
+      const receiptId = migrated!.state.receipts[0].id;
+      const inner = migrated!.state.assignedItems.get(receiptId);
+      expect(inner).toBeInstanceOf(Map);
+      expect(inner?.get(0)).toEqual([{ personId: "a", sharePercentage: 100 }]);
+    });
+
+    it("preserves item 0 assignment to person a after migrate", () => {
+      const migrated = migrateSession(v1Blob());
+      expect(migrated).not.toBeNull();
+      const receiptId = migrated!.state.receipts[0].id;
+      const assignment = migrated!.state.assignedItems.get(receiptId)?.get(0);
+      expect(assignment).toEqual([{ personId: "a", sharePercentage: 100 }]);
+    });
+
+    it("migrates empty v1 originalReceipt to an empty session", () => {
+      const migrated = migrateSession({
+        state: {
+          originalReceipt: null,
+          people: [],
+          assignedItems: [],
+          unassignedItems: [],
+          groups: [],
+          isLoading: false,
+          error: null,
+        },
+        activeTab: "upload",
+      });
+      expect(migrated).not.toBeNull();
+      expect(migrated!.state.receipts).toEqual([]);
+      expect(migrated!.state.assignedItems.size).toBe(0);
+      expect(isDefaultSession(migrated!.state, migrated!.activeTab)).toBe(true);
+    });
+
+    it("does not double-migrate assignedItems that are already v2 nested arrays", () => {
+      const receiptId = "already-v2-id";
+      const hybrid = {
+        state: {
+          originalReceipt: mockReceipt,
+          people: mockPeople,
+          assignedItems: [
+            [receiptId, [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+          ],
+          unassignedItems: [1],
+          groups: [],
+          isLoading: false,
+          error: null,
+        },
+        activeTab: "people",
+      };
+
+      const migrated = migrateSession(hybrid);
+      expect(migrated).not.toBeNull();
+      // Nested string-keyed assignedItems is treated as v2 — keep the existing id
+      expect(migrated!.state.assignedItems.get(receiptId)?.get(0)).toEqual([
+        { personId: "a", sharePercentage: 100 },
+      ]);
+      // Must not wrap again as Map([[newId, Map([[receiptId, ...]])]])
+      expect(migrated!.state.assignedItems.get(receiptId)).toBeInstanceOf(Map);
+    });
+  });
+
+  describe("v2 serialize/deserialize", () => {
+    function v2State(): ReceiptState {
+      const receiptId = "receipt-v2";
+      const inner: ItemAssignments = new Map([
+        [0, [{ personId: "a", sharePercentage: 100 }]],
+        [1, [{ personId: "b", sharePercentage: 50 }, { personId: "a", sharePercentage: 50 }]],
+      ]);
+      return {
+        receipts: [{ id: receiptId, receipt: mockReceipt }],
+        people: mockPeople,
+        groups: [],
+        assignedItems: new Map([[receiptId, inner]]),
+        isLoading: false,
+        error: null,
+      };
+    }
+
+    it("serializes assignedItems as nested entry arrays, not {}", () => {
+      const state = v2State();
+      const parsed = JSON.parse(serializeSession(state, "results"));
+      expect(parsed.version).toBe(2);
+      expect(parsed.activeTab).toBe("results");
+      expect(parsed.state.originalReceipt).toBeUndefined();
+      expect(parsed.state.unassignedItems).toBeUndefined();
+      expect(Array.isArray(parsed.state.assignedItems)).toBe(true);
+      expect(parsed.state.assignedItems).toEqual([
+        [
+          "receipt-v2",
+          [
+            [0, [{ personId: "a", sharePercentage: 100 }]],
+            [1, [{ personId: "b", sharePercentage: 50 }, { personId: "a", sharePercentage: 50 }]],
+          ],
+        ],
+      ]);
+      // Guard the Map pitfall: JSON.stringify of a Map is {}
+      expect(parsed.state.assignedItems).not.toEqual({});
+    });
+
+    it("round-trips nested maps through serialize then deserialize", () => {
+      const state = v2State();
+      const restored = deserializeSession(serializeSession(state, "results"));
+      expect(restored).not.toBeNull();
+      expect(restored!.activeTab).toBe("results");
+      expect(restored!.state.receipts).toEqual(state.receipts);
+      expect(restored!.state.people).toEqual(mockPeople);
+
+      const inner = restored!.state.assignedItems.get("receipt-v2");
+      expect(inner).toBeInstanceOf(Map);
+      expect(inner?.get(0)).toEqual([{ personId: "a", sharePercentage: 100 }]);
+      expect(inner?.get(1)).toEqual([
+        { personId: "b", sharePercentage: 50 },
+        { personId: "a", sharePercentage: 50 },
+      ]);
+    });
+
+    it("does not generate a new receipt id when deserializing v2", () => {
+      const state = v2State();
+      const first = deserializeSession(serializeSession(state, "upload"));
+      const second = deserializeSession(serializeSession(first!.state, "upload"));
+      expect(second!.state.receipts[0].id).toBe("receipt-v2");
+      expect(second!.state.assignedItems.has("receipt-v2")).toBe(true);
+    });
+
+    it("serializes an empty Map as []", () => {
+      expect(serializeAssignedItems(new Map())).toEqual([]);
+      const parsed = JSON.parse(serializeSession(emptyReceiptState(), "upload"));
+      expect(parsed.state.assignedItems).toEqual([]);
+    });
+  });
+
+  describe("corrupt and empty input", () => {
+    it("returns null for corrupt JSON", () => {
+      expect(deserializeSession("invalid json {")).toBeNull();
+      expect(deserializeSession("")).toBeNull();
+    });
+
+    it("returns null for unrecognized shapes", () => {
+      expect(deserializeSession("null")).toBeNull();
+      expect(deserializeSession("[]")).toBeNull();
+      expect(deserializeSession("42")).toBeNull();
+      expect(migrateSession({ foo: "bar" })).toBeNull();
+    });
+
+    it("round-trips an empty/default session", () => {
+      const serialized = serializeSession(emptyReceiptState(), "upload");
+      const restored = deserializeSession(serialized);
+      expect(restored).not.toBeNull();
+      expect(restored!.state.receipts).toEqual([]);
+      expect(restored!.state.people).toEqual([]);
+      expect(restored!.state.groups).toEqual([]);
+      expect(restored!.state.assignedItems.size).toBe(0);
+      expect(restored!.activeTab).toBe("upload");
+      expect(isDefaultSession(restored!.state, restored!.activeTab)).toBe(true);
+    });
+  });
+});

--- a/src/lib/session-persistence.ts
+++ b/src/lib/session-persistence.ts
@@ -1,0 +1,294 @@
+import {
+  type Receipt,
+  type ReceiptState,
+  type Person,
+  type Group,
+  type PersonItemAssignment,
+  type StoredReceipt,
+  type ItemAssignments,
+} from "@/types";
+
+export const SESSION_STORAGE_KEY = "receiptSplitterSession";
+export const SESSION_VERSION = 2;
+
+export interface PersistedSession {
+  state: ReceiptState;
+  activeTab: string;
+}
+
+type SerializedInnerAssignments = Array<[number, PersonItemAssignment[]]>;
+type SerializedAssignedItems = Array<[string, SerializedInnerAssignments]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function emptyReceiptState(): ReceiptState {
+  return {
+    receipts: [],
+    people: [],
+    groups: [],
+    assignedItems: new Map(),
+    isLoading: false,
+    error: null,
+  };
+}
+
+export function isDefaultSession(state: ReceiptState, activeTab: string): boolean {
+  return (
+    activeTab === "upload" &&
+    state.receipts.length === 0 &&
+    state.people.length === 0 &&
+    state.groups.length === 0 &&
+    state.assignedItems.size === 0 &&
+    !state.isLoading &&
+    state.error === null
+  );
+}
+
+/**
+ * Serialize nested assignment Maps as arrays of entries.
+ * JSON.stringify(Map) is `{}`, so Maps must never be stringified directly.
+ */
+export function serializeAssignedItems(
+  assignedItems: Map<string, ItemAssignments>
+): SerializedAssignedItems {
+  return Array.from(assignedItems.entries()).map(([rid, inner]) => [
+    rid,
+    Array.from(inner.entries()),
+  ]);
+}
+
+export function serializeSession(state: ReceiptState, activeTab: string): string {
+  return JSON.stringify({
+    version: SESSION_VERSION,
+    state: {
+      receipts: state.receipts,
+      people: state.people,
+      groups: state.groups,
+      assignedItems: serializeAssignedItems(state.assignedItems),
+      isLoading: state.isLoading,
+      error: state.error,
+    },
+    activeTab,
+  });
+}
+
+export function deserializeSession(
+  raw: string
+): PersistedSession | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return migrateSession(parsed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert a parsed localStorage blob (v1 or v2) into runtime ReceiptState.
+ * Returns null for unrecognized or unusable shapes.
+ */
+export function migrateSession(parsed: unknown): PersistedSession | null {
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  const activeTab =
+    typeof parsed.activeTab === "string" ? parsed.activeTab : "upload";
+  const rawState = isRecord(parsed.state) ? parsed.state : parsed;
+
+  const hasReceiptsArray = Array.isArray(rawState.receipts);
+  const hasOriginalReceipt = "originalReceipt" in rawState;
+  const assignedIsV2 = isV2AssignedItems(rawState.assignedItems);
+
+  // v2 wins when versioned or receipts[] is present. v1 originalReceipt is
+  // checked before assignedItems shape so a leftover v1 blob with nested
+  // assignments is not treated as receipts-less v2.
+  if (parsed.version === SESSION_VERSION || hasReceiptsArray) {
+    return migrateV2(rawState, activeTab);
+  }
+
+  if (hasOriginalReceipt) {
+    return migrateV1(rawState, activeTab);
+  }
+
+  if (assignedIsV2) {
+    return migrateV2(rawState, activeTab);
+  }
+
+  return null;
+}
+
+function migrateV2(
+  rawState: Record<string, unknown>,
+  activeTab: string
+): PersistedSession {
+  const receipts = parseStoredReceipts(rawState.receipts);
+  const assignedItems = assignedItemsFromUnknown(rawState.assignedItems, receipts);
+
+  return {
+    state: {
+      receipts,
+      people: parsePeople(rawState.people),
+      groups: parseGroups(rawState.groups),
+      assignedItems,
+      isLoading: Boolean(rawState.isLoading),
+      error: typeof rawState.error === "string" ? rawState.error : null,
+    },
+    activeTab,
+  };
+}
+
+function migrateV1(
+  rawState: Record<string, unknown>,
+  activeTab: string
+): PersistedSession {
+  const originalReceipt = parseReceipt(rawState.originalReceipt);
+  const people = parsePeople(rawState.people);
+  const groups = parseGroups(rawState.groups);
+  const isLoading = Boolean(rawState.isLoading);
+  const error = typeof rawState.error === "string" ? rawState.error : null;
+
+  if (!originalReceipt) {
+    return {
+      state: {
+        receipts: [],
+        people,
+        groups,
+        assignedItems: isV2AssignedItems(rawState.assignedItems)
+          ? deserializeV2AssignedItems(rawState.assignedItems)
+          : new Map(),
+        isLoading,
+        error,
+      },
+      activeTab,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  const receipts: StoredReceipt[] = [{ id, receipt: originalReceipt }];
+
+  // If assignedItems is already nested (string keys), don't wrap again.
+  const assignedItems = isV2AssignedItems(rawState.assignedItems)
+    ? deserializeV2AssignedItems(rawState.assignedItems)
+    : new Map<string, ItemAssignments>([
+        [id, deserializeV1InnerAssignments(rawState.assignedItems)],
+      ]);
+
+  return {
+    state: {
+      receipts,
+      people,
+      groups,
+      assignedItems,
+      isLoading,
+      error,
+    },
+    activeTab,
+  };
+}
+
+function assignedItemsFromUnknown(
+  raw: unknown,
+  receipts: StoredReceipt[]
+): Map<string, ItemAssignments> {
+  if (isV2AssignedItems(raw)) {
+    return deserializeV2AssignedItems(raw);
+  }
+
+  // v1 inner shape stored under a v2 receipts array — attach to first receipt
+  if (receipts[0] && Array.isArray(raw)) {
+    return new Map([
+      [receipts[0].id, deserializeV1InnerAssignments(raw)],
+    ]);
+  }
+
+  return new Map();
+}
+
+function isV2AssignedItems(raw: unknown): boolean {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return false;
+  }
+  const first = raw[0];
+  if (!Array.isArray(first) || first.length < 2) {
+    return false;
+  }
+  return typeof first[0] === "string";
+}
+
+function deserializeV2AssignedItems(raw: unknown): Map<string, ItemAssignments> {
+  const result = new Map<string, ItemAssignments>();
+  if (!Array.isArray(raw)) {
+    return result;
+  }
+
+  for (const entry of raw) {
+    if (!Array.isArray(entry) || entry.length < 2) {
+      continue;
+    }
+    const [receiptId, inner] = entry;
+    if (typeof receiptId !== "string") {
+      continue;
+    }
+    result.set(receiptId, deserializeV1InnerAssignments(inner));
+  }
+
+  return result;
+}
+
+function deserializeV1InnerAssignments(raw: unknown): ItemAssignments {
+  const inner: ItemAssignments = new Map();
+  if (!Array.isArray(raw)) {
+    return inner;
+  }
+
+  for (const entry of raw) {
+    if (!Array.isArray(entry) || entry.length < 2) {
+      continue;
+    }
+    const [itemIndex, assignments] = entry;
+    const index = Number(itemIndex);
+    if (!Number.isInteger(index) || !Array.isArray(assignments)) {
+      continue;
+    }
+    inner.set(index, assignments as PersonItemAssignment[]);
+  }
+
+  return inner;
+}
+
+function parseStoredReceipts(raw: unknown): StoredReceipt[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const receipts: StoredReceipt[] = [];
+  for (const entry of raw) {
+    if (!isRecord(entry) || typeof entry.id !== "string") {
+      continue;
+    }
+    const receipt = parseReceipt(entry.receipt);
+    if (!receipt) {
+      continue;
+    }
+    receipts.push({ id: entry.id, receipt });
+  }
+  return receipts;
+}
+
+function parseReceipt(raw: unknown): Receipt | null {
+  if (!isRecord(raw) || !Array.isArray(raw.items)) {
+    return null;
+  }
+  return raw as unknown as Receipt;
+}
+
+function parsePeople(raw: unknown): Person[] {
+  return Array.isArray(raw) ? (raw as Person[]) : [];
+}
+
+function parseGroups(raw: unknown): Group[] {
+  return Array.isArray(raw) ? (raw as Group[]) : [];
+}

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -7,7 +7,7 @@
  * - Helper functions for setting up specific test conditions
  * - Re-exports of testing-library for convenience
  */
-import { type Person, type Receipt, type PersonItemAssignment, type Group } from "@/types";
+import { type Person, type Receipt, type PersonItemAssignment, type Group, type StoredReceipt, type ItemAssignments } from "@/types";
 
 // =============================================================================
 // Mock Data: People
@@ -101,6 +101,21 @@ export function createMockAssignments(
     map.set(itemIndex, existing);
   }
   return map;
+}
+
+/** Wrap a receipt as a session-level StoredReceipt */
+export function createStoredReceipt(
+  receipt: Receipt = mockReceipt,
+  id = crypto.randomUUID()
+): StoredReceipt {
+  return { id, receipt };
+}
+
+/** Build a session-level assignedItems map (receiptId -> item assignments) */
+export function createSessionAssignments(
+  ...entries: Array<[string, ItemAssignments]>
+): Map<string, ItemAssignments> {
+  return new Map(entries);
 }
 
 // =============================================================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,8 @@ export interface PersonItem {
   quantity: number;
   sharePercentage: number;
   amount: number;
+  receiptId?: string;
+  receiptName?: string;
 }
 
 // Group types
@@ -50,20 +52,26 @@ export interface Group {
   emoji?: string;
 }
 
-// UI State types
-export interface ReceiptState {
-  originalReceipt: Receipt | null;
-  people: Person[];
-  assignedItems: Map<number, PersonItemAssignment[]>;
-  unassignedItems: number[];
-  groups: Group[];
-  isLoading: boolean;
-  error: string | null;
-}
-
 export interface PersonItemAssignment {
   personId: string;
   sharePercentage: number;
+}
+
+// UI State types
+export interface StoredReceipt {
+  id: string; // crypto.randomUUID()
+  receipt: Receipt;
+}
+
+export type ItemAssignments = Map<number, PersonItemAssignment[]>;
+
+export interface ReceiptState {
+  receipts: StoredReceipt[];
+  people: Person[];
+  groups: Group[];
+  assignedItems: Map<string, ItemAssignments>; // receiptId -> itemIndex -> shares
+  isLoading: boolean;
+  error: string | null;
 }
 
 // Util type for keeping track of item assignments


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #139. Stacked PR 1 of 5 — no visible UX change.

## Issue #139 implementation order

Merge **bottom-up**. PR 1 can land alone. **Do not merge PRs 2–4 to `main` until PR 4 is ready.**

### Locked decisions

- Session currency is pinned to the **first** receipt. Later uploads that don't match are rejected with a toast; the rest of a multi-file batch still proceeds.
- **Split evenly** is per-receipt, not global.
- `/split` sharing stays **aggregate-only**.
- People/groups are **session-level** — adding receipt 2+ must not wipe the party.
- Do not persist N full-size images in localStorage.
- Cap at **10 receipts** per session.

### Stack

1. **This PR — Data model foundation**
2. #151 — Multi-file upload + currency lock + remove
3. #152 — Assign Items: one card per receipt
4. #153 — Results: per-receipt + grand total
5. #154 — Copy and screenshot mocks

### Follow-ups (out of scope)

- Itemized `/split` page
- Mixed-currency sessions
- Persisting multiple full receipt images

## This PR

- Replace `ReceiptState.originalReceipt` with `receipts: StoredReceipt[]` and `assignedItems: Map<receiptId, Map<itemIndex, shares>>`
- Derive unassigned items (no longer stored)
- Nested Map serialize/deserialize (never `JSON.stringify` a Map)
- Clone outer **and** inner maps on assignment mutations
- `handleReceiptParsed` still **replaces** a single receipt (append is PR 2)
- Session helpers and CI `cursor/*` bases

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

