### PR TITLE
feat: [2/5] multi-file receipt upload with currency lock

### DIFF
--- a/e2e/core-flow.spec.ts
+++ b/e2e/core-flow.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { receiptCardToggle } from "./helpers";
 
 // ---- Mock data --------------------------------------------------------------
 // Validated happy-path receipt: all math correct, all items fully assigned.
@@ -165,11 +166,15 @@ test.describe("core flow", () => {
 
     // ---- Tab 1: Upload ------------------------------------------------------
     // The receipt card should be visible because we preloaded it.
-    await expect(page.getByText("Test Diner")).toBeVisible({ timeout: 10000 });
+    // Role locator: merchant name appears on both the accordion toggle and details.
+    await expect(receiptCardToggle(page, "Test Diner")).toBeVisible({
+      timeout: 10000,
+    });
 
     // Verify receipt financial figures are rendered.
+    // Totals also appear in the accordion meta line and in Receipt Details.
     await expect(page.getByText("$43.00")).toBeVisible();
-    await expect(page.getByText("$55.90")).toBeVisible();
+    await expect(page.getByText("$55.90").first()).toBeVisible();
 
     // "Next" should be enabled (receipt is loaded).
     // Use { exact: true } — the Next.js Dev Tools button also contains "Next".

--- a/e2e/edge-cases.spec.ts
+++ b/e2e/edge-cases.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { receiptCardToggle } from "./helpers";
 
 // =============================================================================
 // Helper: preload session via localStorage
@@ -250,7 +251,9 @@ test.describe("edge-case receipt values", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      await expect(page.getByText("Free Cafe")).toBeVisible({ timeout: 10000 });
+      await expect(receiptCardToggle(page, "Free Cafe")).toBeVisible({
+        timeout: 10000,
+      });
       await expect(page.getByText("$0.00").first()).toBeVisible();
     });
 
@@ -313,11 +316,11 @@ test.describe("edge-case receipt values", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      await expect(page.getByText("Corner Bistro")).toBeVisible({
+      await expect(receiptCardToggle(page, "Corner Bistro")).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByText("$12.50")).toBeVisible();
-      await expect(page.getByText("$16.25")).toBeVisible();
+      await expect(page.getByText("$16.25").first()).toBeVisible();
     });
 
     await test.step("People tab — single person added", async () => {
@@ -369,11 +372,11 @@ test.describe("edge-case receipt values", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      await expect(page.getByText("Large Party Hall")).toBeVisible({
+      await expect(receiptCardToggle(page, "Large Party Hall")).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByText("$250.00")).toBeVisible();
-      await expect(page.getByText("$325.00")).toBeVisible();
+      await expect(page.getByText("$325.00").first()).toBeVisible();
     });
 
     await test.step("People tab — all four people visible", async () => {
@@ -432,7 +435,7 @@ test.describe("edge-case receipt values", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      await expect(page.getByText("London Cafe")).toBeVisible({
+      await expect(receiptCardToggle(page, "London Cafe")).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByText("GBP - British Pound")).toBeVisible();
@@ -483,7 +486,7 @@ test.describe("edge-case receipt values", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      await expect(page.getByText("Paris Bistro")).toBeVisible({
+      await expect(receiptCardToggle(page, "Paris Bistro")).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByText("EUR - Euro")).toBeVisible();
@@ -516,7 +519,7 @@ test.describe("edge-case receipt values", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      await expect(page.getByText("Tokyo Ramen")).toBeVisible({
+      await expect(receiptCardToggle(page, "Tokyo Ramen")).toBeVisible({
         timeout: 10000,
       });
       await expect(page.getByText(/JPY - Japanese Yen/)).toBeVisible();

--- a/e2e/edit-receipt.spec.ts
+++ b/e2e/edit-receipt.spec.ts
@@ -3,6 +3,7 @@ import {
   preloadSession,
   fullyAssignedState,
   parseMoney,
+  receiptCardToggle,
 } from "./helpers";
 
 async function openItemPriceEditor(page: import("@playwright/test").Page, itemName: string) {
@@ -137,7 +138,9 @@ test.describe("edit receipt", () => {
     await preloadSession(page, fullyAssignedState(), "upload");
     await page.goto("/");
 
-    await expect(page.getByText("Test Diner")).toBeVisible({ timeout: 10000 });
+    await expect(receiptCardToggle(page, "Test Diner")).toBeVisible({
+      timeout: 10000,
+    });
     await page.getByRole("button", { name: /^Edit$/ }).click();
     await expect(page.getByText("Edit Receipt Details")).toBeVisible();
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -47,6 +47,16 @@ export async function uploadTinyReceipt(page: Page) {
   });
 }
 
+/**
+ * Accordion toggle for a parsed receipt card.
+ * The restaurant name is the start of the button's accessible name; the
+ * Remove control is "Remove {name}" and must not match this locator.
+ */
+export function receiptCardToggle(page: Page, restaurant: string) {
+  const escaped = restaurant.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return page.getByRole("button", { name: new RegExp(`^${escaped}`) });
+}
+
 export function parseMoney(text: string | null | undefined): number {
   if (!text) return NaN;
   const numeric = text.replace(/[^0-9,.-]/g, "");

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Home from "./page";
 import { toast } from "sonner";
-import { mockReceipt, mockPeople } from "@/test/test-utils";
+import { mockReceipt, mockPeople, createMockReceipt } from "@/test/test-utils";
 import { RECEIPT_IMAGE_STORAGE_KEY } from "@/lib/storage";
 
 type SerializedAssignments = [number, { personId: string; sharePercentage: number }[]][];
@@ -224,6 +225,217 @@ describe("Home Page", () => {
 
       expect(toast.success).toHaveBeenCalledWith("All items split evenly among everyone!");
       expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+  });
+
+  describe("multi-receipt upload", () => {
+    let uuidSeq = 0;
+
+    beforeEach(() => {
+      uuidSeq = 0;
+      (crypto.randomUUID as jest.Mock).mockImplementation(
+        () => `00000000-0000-4000-8000-${String(++uuidSeq).padStart(12, "0")}`
+      );
+    });
+
+    afterEach(() => {
+      (crypto.randomUUID as jest.Mock).mockImplementation(
+        () => "00000000-0000-4000-8000-000000000000"
+      );
+    });
+
+    function loadV2(options: {
+      receipts?: Array<{ id: string; receipt: typeof mockReceipt }>;
+      people?: typeof mockPeople;
+      assignedItems?: unknown;
+      groups?: unknown[];
+      activeTab?: string;
+    } = {}) {
+      const receiptId = options.receipts?.[0]?.id ?? "r1";
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: options.receipts ?? [{ id: receiptId, receipt: mockReceipt }],
+            people: options.people ?? [],
+            assignedItems: options.assignedItems ?? [[receiptId, []]],
+            groups: options.groups ?? [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: options.activeTab ?? "upload",
+        })
+      );
+    }
+
+    async function uploadParsedReceipt(receipt: typeof mockReceipt) {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => receipt,
+      });
+      const input = screen.getByRole("presentation").querySelector("input");
+      expect(input).not.toBeNull();
+      const file = new File(["x"], `${receipt.restaurant ?? "receipt"}.jpg`, {
+        type: "image/jpeg",
+      });
+      await userEvent.upload(input!, file);
+    }
+
+    it("keeps people when a second same-currency receipt is parsed", async () => {
+      loadV2({ people: mockPeople });
+      render(<Home />);
+
+      await uploadParsedReceipt(
+        createMockReceipt({ restaurant: "Second Cafe", currency: "USD" })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Second Cafe")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText(/2 receipts · USD/)).toBeInTheDocument();
+    });
+
+    it("rejects a mismatched currency without adding it or dropping existing people", async () => {
+      loadV2({ people: mockPeople });
+      render(<Home />);
+
+      await uploadParsedReceipt(
+        createMockReceipt({ restaurant: "Paris Bistro", currency: "EUR" })
+      );
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "This receipt is EUR, but this split is in USD."
+        );
+      });
+      expect(screen.queryByText("Paris Bistro")).not.toBeInTheDocument();
+      expect(screen.getByText("Testaurant")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText(/1 receipt · USD/)).toBeInTheDocument();
+    });
+
+    it("keeps people after removing a receipt", async () => {
+      loadV2({
+        people: mockPeople,
+        receipts: [
+          { id: "r1", receipt: mockReceipt },
+          {
+            id: "r2",
+            receipt: createMockReceipt({ restaurant: "Second Cafe" }),
+          },
+        ],
+        assignedItems: [
+          ["r1", []],
+          ["r2", []],
+        ],
+      });
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: /remove second cafe/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Second Cafe")).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+    });
+
+    it("keeps people in the session when the last receipt is removed", async () => {
+      loadV2({ people: mockPeople });
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: /remove testaurant/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+      await waitFor(() => {
+        const raw = localStorage.getItem("receiptSplitterSession");
+        expect(raw).toBeTruthy();
+        const parsed = JSON.parse(raw as string);
+        expect(parsed.state.receipts).toHaveLength(0);
+        expect(parsed.state.people).toHaveLength(mockPeople.length);
+      });
+    });
+
+    it("clears people when the first receipt is parsed in an empty session", async () => {
+      loadV2({
+        receipts: [],
+        people: mockPeople,
+        assignedItems: [],
+      });
+      render(<Home />);
+
+      await uploadParsedReceipt(
+        createMockReceipt({ restaurant: "New Place", currency: "USD" })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("New Place")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+      expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+    });
+
+    it("caps the session at 10 receipts", async () => {
+      const receipts = Array.from({ length: 10 }, (_, i) => ({
+        id: `r${i}`,
+        receipt: createMockReceipt({ restaurant: `Place ${i}` }),
+      }));
+      loadV2({
+        receipts,
+        assignedItems: receipts.map((r) => [r.id, []]),
+      });
+      render(<Home />);
+
+      await uploadParsedReceipt(
+        createMockReceipt({ restaurant: "One Too Many" })
+      );
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          expect.stringMatching(/already has 10 receipts/)
+        );
+      });
+      expect(screen.queryByText("One Too Many")).not.toBeInTheDocument();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("copies a currency edit onto every receipt in the session", async () => {
+      loadV2({
+        receipts: [
+          { id: "r1", receipt: mockReceipt },
+          {
+            id: "r2",
+            receipt: createMockReceipt({ restaurant: "Second Cafe" }),
+          },
+        ],
+        assignedItems: [
+          ["r1", []],
+          ["r2", []],
+        ],
+      });
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+      fireEvent.click(screen.getByRole("combobox", { name: /currency/i }));
+      fireEvent.click(screen.getByRole("option", { name: /EUR - Euro/i }));
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/· EUR$/).length).toBeGreaterThanOrEqual(2);
+      });
     });
   });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -282,6 +282,14 @@ describe("Home Page", () => {
       await userEvent.upload(input!, file);
     }
 
+    function goToPeopleTab() {
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+      expect(screen.getByRole("tab", { name: /add people/i })).toHaveAttribute(
+        "data-state",
+        "active"
+      );
+    }
+
     it("keeps people when a second same-currency receipt is parsed", async () => {
       loadV2({ people: mockPeople });
       render(<Home />);
@@ -291,10 +299,10 @@ describe("Home Page", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Second Cafe")).toBeInTheDocument();
+        expect(screen.getAllByText("Second Cafe").length).toBeGreaterThan(0);
       });
 
-      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      goToPeopleTab();
       expect(screen.getByText("Alice")).toBeInTheDocument();
       expect(screen.getByText("Bob")).toBeInTheDocument();
       expect(screen.getByText(/2 receipts · USD/)).toBeInTheDocument();
@@ -314,9 +322,9 @@ describe("Home Page", () => {
         );
       });
       expect(screen.queryByText("Paris Bistro")).not.toBeInTheDocument();
-      expect(screen.getByText("Testaurant")).toBeInTheDocument();
+      expect(screen.getAllByText("Testaurant").length).toBeGreaterThan(0);
 
-      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      goToPeopleTab();
       expect(screen.getByText("Alice")).toBeInTheDocument();
       expect(screen.getByText("Bob")).toBeInTheDocument();
       expect(screen.getByText(/1 receipt · USD/)).toBeInTheDocument();
@@ -346,7 +354,7 @@ describe("Home Page", () => {
         expect(screen.queryByText("Second Cafe")).not.toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      goToPeopleTab();
       expect(screen.getByText("Alice")).toBeInTheDocument();
       expect(screen.getByText("Bob")).toBeInTheDocument();
     });
@@ -380,10 +388,10 @@ describe("Home Page", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("New Place")).toBeInTheDocument();
+        expect(screen.getAllByText("New Place").length).toBeGreaterThan(0);
       });
 
-      fireEvent.click(screen.getByRole("tab", { name: /add people/i }));
+      goToPeopleTab();
       expect(screen.queryByText("Alice")).not.toBeInTheDocument();
       expect(screen.queryByText("Bob")).not.toBeInTheDocument();
     });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Home from "./page";
 import { toast } from "sonner";
-import { mockReceipt, mockPeople, createMockReceipt } from "@/test/test-utils";
+import { mockReceipt, mockPeople, mockGroups, createMockReceipt } from "@/test/test-utils";
 import { RECEIPT_IMAGE_STORAGE_KEY } from "@/lib/storage";
 
 type SerializedAssignments = [number, { personId: string; sharePercentage: number }[]][];
@@ -375,25 +375,31 @@ describe("Home Page", () => {
       });
     });
 
-    it("clears people when the first receipt is parsed in an empty session", async () => {
-      loadV2({
-        receipts: [],
-        people: mockPeople,
-        assignedItems: [],
-      });
+    it("keeps people and groups after removing every receipt and uploading again", async () => {
+      loadV2({ people: mockPeople, groups: mockGroups });
       render(<Home />);
 
+      fireEvent.click(screen.getByRole("button", { name: /remove testaurant/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Testaurant")).not.toBeInTheDocument();
+      });
+
       await uploadParsedReceipt(
-        createMockReceipt({ restaurant: "New Place", currency: "USD" })
+        createMockReceipt({ restaurant: "Retry Cafe", currency: "USD" })
       );
 
       await waitFor(() => {
-        expect(screen.getAllByText("New Place").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("Retry Cafe").length).toBeGreaterThan(0);
       });
 
       goToPeopleTab();
-      expect(screen.queryByText("Alice")).not.toBeInTheDocument();
-      expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("Team A")).toBeInTheDocument();
+      expect(screen.getByText("Team B")).toBeInTheDocument();
+      expect(screen.getByText(/1 receipt · USD/)).toBeInTheDocument();
     });
 
     it("caps the session at 10 receipts", async () => {
@@ -420,7 +426,7 @@ describe("Home Page", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("copies a currency edit onto every receipt in the session", async () => {
+    it("does not rewrite other receipts when currency is locked", async () => {
       loadV2({
         receipts: [
           { id: "r1", receipt: mockReceipt },
@@ -437,13 +443,34 @@ describe("Home Page", () => {
       render(<Home />);
 
       fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+      const currencySelect = screen.getByRole("combobox", { name: /currency/i });
+      expect(currencySelect).toBeDisabled();
+      expect(
+        screen.getByText(/locked to USD because this split has multiple receipts/i)
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+      expect(screen.getAllByText(/· USD$/).length).toBeGreaterThanOrEqual(2);
+      expect(screen.queryByText(/· EUR$/)).not.toBeInTheDocument();
+    });
+
+    it("allows changing currency when the session has a single receipt", async () => {
+      loadV2();
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: /edit/i }));
       fireEvent.click(screen.getByRole("combobox", { name: /currency/i }));
       fireEvent.click(screen.getByRole("option", { name: /EUR - Euro/i }));
       fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
       await waitFor(() => {
-        expect(screen.getAllByText(/· EUR$/).length).toBeGreaterThanOrEqual(2);
+        expect(screen.getByText(/EUR - Euro/)).toBeInTheDocument();
       });
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -426,7 +426,7 @@ describe("Home Page", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("does not rewrite other receipts when currency is locked", async () => {
+    it("rejects a currency edit on one receipt without rewriting the others", async () => {
       loadV2({
         receipts: [
           { id: "r1", receipt: mockReceipt },
@@ -443,12 +443,17 @@ describe("Home Page", () => {
       render(<Home />);
 
       fireEvent.click(screen.getByRole("button", { name: /edit/i }));
-      const currencySelect = screen.getByRole("combobox", { name: /currency/i });
-      expect(currencySelect).toBeDisabled();
-      expect(
-        screen.getByText(/locked to USD because this split has multiple receipts/i)
-      ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("combobox", { name: /currency/i }));
+      fireEvent.click(screen.getByRole("option", { name: /EUR - Euro/i }));
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "This receipt is EUR, but this split is in USD."
+        );
+      });
+      expect(toast.success).not.toHaveBeenCalledWith("Receipt details updated");
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
 
       await waitFor(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,10 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft, ArrowRight, UploadCloud, Users, ListChecks, DollarSign } from "lucide-react";
 
 import { ReceiptUploader } from "@/components/receipt-uploader";
+import { ParsedReceiptsList } from "@/components/parsed-receipts-list";
 import { PeopleManager } from "@/components/people-manager";
 import { GroupManager } from "@/components/group-manager";
 import { ItemAssignment } from "@/components/item-assignment";
-import { ReceiptDetails } from "@/components/receipt-details";
 import { ResultsSummary } from "@/components/results-summary";
 import { PersonItems } from "@/components/person-items";
 import { KofiButton } from "@/components/kofi-button";
@@ -30,7 +30,10 @@ import {
   calculateSessionPersonTotals,
   validateSessionAssignments,
   validateSessionInvariants,
+  sessionCurrency,
+  validateReceiptCurrency,
 } from "@/lib/receipt-utils";
+import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
 import {
   getUniqueGroupEmoji,
   getRandomGroupEmojiExcluding,
@@ -49,12 +52,122 @@ import {
   isDefaultSession,
 } from "@/lib/session-persistence";
 
+type ParseResult =
+  | { status: "added"; next: ReceiptState }
+  | { status: "capped"; next: ReceiptState }
+  | { status: "mismatch"; next: ReceiptState; pinned: string };
+
+function addParsedReceipt(prev: ReceiptState, receipt: Receipt): ParseResult {
+  if (prev.receipts.length >= MAX_RECEIPTS_PER_SESSION) {
+    return { status: "capped", next: prev };
+  }
+
+  const pinned = sessionCurrency(prev.receipts);
+  if (!validateReceiptCurrency(receipt, pinned)) {
+    return { status: "mismatch", next: prev, pinned: pinned as string };
+  }
+
+  const id = crypto.randomUUID();
+  if (prev.receipts.length === 0) {
+    return {
+      status: "added",
+      next: {
+        receipts: [{ id, receipt }],
+        people: [],
+        groups: [],
+        assignedItems: new Map([[id, new Map()]]),
+        isLoading: prev.isLoading,
+        error: null,
+      },
+    };
+  }
+
+  const nextAssigned = new Map(prev.assignedItems);
+  nextAssigned.set(id, new Map());
+  const nextReceipts = [...prev.receipts, { id, receipt }];
+  return {
+    status: "added",
+    next: {
+      ...prev,
+      receipts: nextReceipts,
+      assignedItems: nextAssigned,
+      people: calculateSessionPersonTotals(
+        nextReceipts,
+        prev.people,
+        nextAssigned
+      ),
+      error: null,
+    },
+  };
+}
+
+function removeReceiptFromState(
+  prev: ReceiptState,
+  receiptId: string
+): ReceiptState {
+  const nextReceipts = prev.receipts.filter((stored) => stored.id !== receiptId);
+  const nextAssigned = new Map(prev.assignedItems);
+  nextAssigned.delete(receiptId);
+  return {
+    ...prev,
+    receipts: nextReceipts,
+    assignedItems: nextAssigned,
+    people: calculateSessionPersonTotals(
+      nextReceipts,
+      prev.people,
+      nextAssigned
+    ),
+  };
+}
+
+function updateReceiptInState(
+  prev: ReceiptState,
+  receiptId: string,
+  updatedReceipt: Receipt,
+  remappedAssignments?: Map<number, PersonItemAssignment[]>
+): ReceiptState {
+  const existing = prev.receipts.find((stored) => stored.id === receiptId);
+  if (!existing) return prev;
+
+  const currencyChanged = existing.receipt.currency !== updatedReceipt.currency;
+  const nextReceipts = prev.receipts.map((stored) => {
+    if (stored.id === receiptId) {
+      return { ...stored, receipt: updatedReceipt };
+    }
+    if (currencyChanged) {
+      return {
+        ...stored,
+        receipt: { ...stored.receipt, currency: updatedReceipt.currency },
+      };
+    }
+    return stored;
+  });
+
+  const nextOuter = new Map(prev.assignedItems);
+  if (remappedAssignments) {
+    nextOuter.set(receiptId, remappedAssignments);
+  }
+
+  return {
+    ...prev,
+    receipts: nextReceipts,
+    assignedItems: nextOuter,
+    people: calculateSessionPersonTotals(
+      nextReceipts,
+      prev.people,
+      nextOuter
+    ),
+  };
+}
+
 export default function Home() {
   const [state, setState] = useState<ReceiptState>(emptyReceiptState);
   const [activeTab, setActiveTab] = useState("upload");
   const [hasSession, setHasSession] = useState(false);
   const isFirstLoad = useRef(true);
   const [resetImageTrigger, setResetImageTrigger] = useState(0);
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   const activeReceipt = state.receipts[0]?.receipt ?? null;
   const activeId = state.receipts[0]?.id;
@@ -116,7 +229,9 @@ export default function Home() {
   const handleNewSplit = () => {
     safeRemoveItem(SESSION_STORAGE_KEY);
     safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
-    setState(emptyReceiptState());
+    const empty = emptyReceiptState();
+    stateRef.current = empty;
+    setState(empty);
     setActiveTab("upload");
     setHasSession(false);
     setResetImageTrigger((v) => v + 1);
@@ -139,21 +254,33 @@ export default function Home() {
     return (assignedItemCount / totalItems) * 100;
   };
 
-  // Handle receipt upload — still replaces a single receipt (append is a later PR)
+  // Handle receipt upload — first receipt starts a new outing; later ones append
   const handleReceiptParsed = (receipt: Receipt) => {
-    const id = crypto.randomUUID();
-    setState({
-      receipts: [{ id, receipt }],
-      people: [],
-      groups: [],
-      assignedItems: new Map([[id, new Map()]]),
-      isLoading: false,
-      error: null,
-    });
-
-    // Don't auto-advance
-    // setActiveTab("people");
+    const result = addParsedReceipt(stateRef.current, receipt);
+    if (result.status === "capped") {
+      toast.error(
+        `This split already has ${MAX_RECEIPTS_PER_SESSION} receipts. Remove one to add another.`
+      );
+      return;
+    }
+    if (result.status === "mismatch") {
+      toast.error(
+        `This receipt is ${receipt.currency}, but this split is in ${result.pinned}.`
+      );
+      return;
+    }
+    stateRef.current = result.next;
+    setState(result.next);
     toast.success("Receipt successfully parsed!");
+  };
+
+  const handleRemoveReceipt = (receiptId: string) => {
+    setState((prevState) => {
+      const next = removeReceiptFromState(prevState, receiptId);
+      stateRef.current = next;
+      return next;
+    });
+    toast.success("Receipt removed");
   };
 
   // Handle people changes
@@ -188,7 +315,7 @@ export default function Home() {
         nextAssigned = nextOuter;
       }
 
-      return {
+      const next = {
         ...prevState,
         people: calculateSessionPersonTotals(
           prevState.receipts,
@@ -197,38 +324,26 @@ export default function Home() {
         ),
         assignedItems: nextAssigned,
       };
+      stateRef.current = next;
+      return next;
     });
   };
 
-  // Handle receipt updates
+  // Handle receipt updates (currency changes are copied onto every receipt)
   const handleReceiptUpdate = (
+    receiptId: string,
     updatedReceipt: Receipt,
     remappedAssignments?: Map<number, PersonItemAssignment[]>
   ) => {
     setState((prevState) => {
-      const receiptId = prevState.receipts[0]?.id;
-      if (!receiptId) return prevState;
-
-      const nextOuter = new Map(prevState.assignedItems);
-      const assignmentsToUse =
-        remappedAssignments ??
-        new Map(nextOuter.get(receiptId) ?? []);
-      nextOuter.set(receiptId, assignmentsToUse);
-
-      const nextReceipts = prevState.receipts.map((stored, index) =>
-        index === 0 ? { ...stored, receipt: updatedReceipt } : stored
+      const next = updateReceiptInState(
+        prevState,
+        receiptId,
+        updatedReceipt,
+        remappedAssignments
       );
-
-      return {
-        ...prevState,
-        receipts: nextReceipts,
-        assignedItems: nextOuter,
-        people: calculateSessionPersonTotals(
-          nextReceipts,
-          prevState.people,
-          nextOuter
-        ),
-      };
+      stateRef.current = next;
+      return next;
     });
   };
 
@@ -265,10 +380,14 @@ export default function Home() {
 
   // Update loading state
   const setIsLoading = (isLoading: boolean) => {
-    setState((prevState) => ({
-      ...prevState,
-      isLoading,
-    }));
+    setState((prevState) => {
+      const next = {
+        ...prevState,
+        isLoading,
+      };
+      stateRef.current = next;
+      return next;
+    });
   };
 
   // Handle group creation
@@ -556,17 +675,25 @@ export default function Home() {
             isLoading={state.isLoading}
             setIsLoading={setIsLoading}
             resetImageTrigger={resetImageTrigger}
+            maxRemaining={MAX_RECEIPTS_PER_SESSION - state.receipts.length}
           />
 
-          {activeReceipt && (
-            <ReceiptDetails
-              receipt={activeReceipt}
-              onReceiptUpdate={(receipt) => handleReceiptUpdate(receipt)}
-            />
-          )}
+          <ParsedReceiptsList
+            receipts={state.receipts}
+            onReceiptUpdate={(id, receipt) => handleReceiptUpdate(id, receipt)}
+            onRemoveReceipt={handleRemoveReceipt}
+          />
         </TabsContent>
 
         <TabsContent value="people" className="space-y-6">
+          {state.receipts.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              {state.receipts.length}{" "}
+              {state.receipts.length === 1 ? "receipt" : "receipts"} ·{" "}
+              {sessionCurrency(state.receipts) ?? "USD"}
+            </p>
+          )}
+
           <PeopleManager
             people={state.people}
             onPeopleChange={handlePeopleChange}
@@ -580,17 +707,10 @@ export default function Home() {
             onGroupDelete={handleGroupDelete}
             onGroupEmojiRegenerate={handleGroupEmojiRegenerate}
           />
-
-          {activeReceipt && (
-            <ReceiptDetails
-              receipt={activeReceipt}
-              onReceiptUpdate={(receipt) => handleReceiptUpdate(receipt)}
-            />
-          )}
         </TabsContent>
 
         <TabsContent value="assign" className="space-y-6">
-          {activeReceipt && (
+          {activeReceipt && activeId && (
             <ItemAssignment
               receipt={activeReceipt}
               people={state.people}
@@ -598,7 +718,9 @@ export default function Home() {
               assignedItems={activeAssignments}
               unassignedItems={unassignedItems}
               onAssignItems={handleAssignItems}
-              onReceiptUpdate={handleReceiptUpdate}
+              onReceiptUpdate={(receipt, remapped) =>
+                handleReceiptUpdate(activeId, receipt, remapped)
+              }
             />
           )}
         </TabsContent>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -331,12 +331,12 @@ export default function Home() {
     });
   };
 
-  // Handle receipt updates. Currency cannot diverge from other receipts.
+  // Handle receipt updates. Currency mismatches are rejected like uploads.
   const handleReceiptUpdate = (
     receiptId: string,
     updatedReceipt: Receipt,
     remappedAssignments?: Map<number, PersonItemAssignment[]>
-  ) => {
+  ): boolean => {
     const pinned = currencyChangeConflict(
       stateRef.current.receipts,
       receiptId,
@@ -344,9 +344,9 @@ export default function Home() {
     );
     if (pinned) {
       toast.error(
-        `This split is in ${pinned}. All receipts must use the same currency.`
+        `This receipt is ${updatedReceipt.currency}, but this split is in ${pinned}.`
       );
-      return;
+      return false;
     }
     setState((prevState) => {
       const next = updateReceiptInState(
@@ -358,6 +358,7 @@ export default function Home() {
       stateRef.current = next;
       return next;
     });
+    return true;
   };
 
   // Handle item assignments

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,23 +68,11 @@ function addParsedReceipt(prev: ReceiptState, receipt: Receipt): ParseResult {
   }
 
   const id = crypto.randomUUID();
-  if (prev.receipts.length === 0) {
-    return {
-      status: "added",
-      next: {
-        receipts: [{ id, receipt }],
-        people: [],
-        groups: [],
-        assignedItems: new Map([[id, new Map()]]),
-        isLoading: prev.isLoading,
-        error: null,
-      },
-    };
-  }
-
   const nextAssigned = new Map(prev.assignedItems);
   nextAssigned.set(id, new Map());
   const nextReceipts = [...prev.receipts, { id, receipt }];
+  // Keep people/groups even when this is the only receipt (retry after a
+  // full clear is the same outing; New Split is what starts a new one).
   return {
     status: "added",
     next: {
@@ -99,6 +87,23 @@ function addParsedReceipt(prev: ReceiptState, receipt: Receipt): ParseResult {
       error: null,
     },
   };
+}
+
+/** Pinned currency from other receipts, when an edit would diverge. */
+function currencyChangeConflict(
+  receipts: ReceiptState["receipts"],
+  receiptId: string,
+  updatedReceipt: Receipt
+): string | undefined {
+  const existing = receipts.find((stored) => stored.id === receiptId);
+  if (!existing || existing.receipt.currency === updatedReceipt.currency) {
+    return undefined;
+  }
+  const pinned = sessionCurrency(receipts.filter((stored) => stored.id !== receiptId));
+  if (pinned && !validateReceiptCurrency(updatedReceipt, pinned)) {
+    return pinned;
+  }
+  return undefined;
 }
 
 function removeReceiptFromState(
@@ -128,20 +133,13 @@ function updateReceiptInState(
 ): ReceiptState {
   const existing = prev.receipts.find((stored) => stored.id === receiptId);
   if (!existing) return prev;
+  if (currencyChangeConflict(prev.receipts, receiptId, updatedReceipt)) {
+    return prev;
+  }
 
-  const currencyChanged = existing.receipt.currency !== updatedReceipt.currency;
-  const nextReceipts = prev.receipts.map((stored) => {
-    if (stored.id === receiptId) {
-      return { ...stored, receipt: updatedReceipt };
-    }
-    if (currencyChanged) {
-      return {
-        ...stored,
-        receipt: { ...stored.receipt, currency: updatedReceipt.currency },
-      };
-    }
-    return stored;
-  });
+  const nextReceipts = prev.receipts.map((stored) =>
+    stored.id === receiptId ? { ...stored, receipt: updatedReceipt } : stored
+  );
 
   const nextOuter = new Map(prev.assignedItems);
   if (remappedAssignments) {
@@ -257,7 +255,7 @@ export default function Home() {
     return (assignedItemCount / totalItems) * 100;
   };
 
-  // Handle receipt upload — first receipt starts a new outing; later ones append
+  // Handle receipt upload — append to the current outing (people/groups stay)
   const handleReceiptParsed = (receipt: Receipt): boolean => {
     const result = addParsedReceipt(stateRef.current, receipt);
     if (result.status === "capped") {
@@ -333,12 +331,23 @@ export default function Home() {
     });
   };
 
-  // Handle receipt updates (currency changes are copied onto every receipt)
+  // Handle receipt updates. Currency cannot diverge from other receipts.
   const handleReceiptUpdate = (
     receiptId: string,
     updatedReceipt: Receipt,
     remappedAssignments?: Map<number, PersonItemAssignment[]>
   ) => {
+    const pinned = currencyChangeConflict(
+      stateRef.current.receipts,
+      receiptId,
+      updatedReceipt
+    );
+    if (pinned) {
+      toast.error(
+        `This split is in ${pinned}. All receipts must use the same currency.`
+      );
+      return;
+    }
     setState((prevState) => {
       const next = updateReceiptInState(
         prevState,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -258,23 +258,24 @@ export default function Home() {
   };
 
   // Handle receipt upload — first receipt starts a new outing; later ones append
-  const handleReceiptParsed = (receipt: Receipt) => {
+  const handleReceiptParsed = (receipt: Receipt): boolean => {
     const result = addParsedReceipt(stateRef.current, receipt);
     if (result.status === "capped") {
       toast.error(
         `This split already has ${MAX_RECEIPTS_PER_SESSION} receipts. Remove one to add another.`
       );
-      return;
+      return false;
     }
     if (result.status === "mismatch") {
       toast.error(
         `This receipt is ${receipt.currency}, but this split is in ${result.pinned}.`
       );
-      return;
+      return false;
     }
     stateRef.current = result.next;
     setState(result.next);
     toast.success("Receipt successfully parsed!");
+    return true;
   };
 
   const handleRemoveReceipt = (receiptId: string) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -167,7 +167,10 @@ export default function Home() {
   const isFirstLoad = useRef(true);
   const [resetImageTrigger, setResetImageTrigger] = useState(0);
   const stateRef = useRef(state);
-  stateRef.current = state;
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
   const activeReceipt = state.receipts[0]?.receipt ?? null;
   const activeId = state.receipts[0]?.id;

--- a/src/components/parsed-receipts-list.test.tsx
+++ b/src/components/parsed-receipts-list.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  ParsedReceiptsList,
+  receiptDisplayName,
+} from "./parsed-receipts-list";
+import { createMockReceipt, createStoredReceipt } from "@/test/test-utils";
+
+describe("receiptDisplayName", () => {
+  it("falls back to Untitled receipt", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: null }),
+      "a"
+    );
+    expect(receiptDisplayName(stored, [stored])).toBe("Untitled receipt");
+  });
+
+  it("uses date to distinguish two receipts with the same name", () => {
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-02" }),
+      "b"
+    );
+    expect(receiptDisplayName(first, [first, second])).toBe(
+      "Starbucks · 2024-01-01"
+    );
+    expect(receiptDisplayName(second, [first, second])).toBe(
+      "Starbucks · 2024-01-02"
+    );
+  });
+
+  it("uses a short index when name and date both collide", () => {
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "b"
+    );
+    expect(receiptDisplayName(first, [first, second])).toBe("Starbucks (1)");
+    expect(receiptDisplayName(second, [first, second])).toBe("Starbucks (2)");
+  });
+});
+
+describe("ParsedReceiptsList", () => {
+  it("renders restaurant, date, item count, total, and currency", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({
+        restaurant: "Cafe",
+        date: "2024-03-15",
+        total: 42,
+        items: [
+          { name: "Coffee", price: 21, quantity: 1 },
+          { name: "Muffin", price: 21, quantity: 1 },
+        ],
+      }),
+      "r1"
+    );
+
+    render(
+      <ParsedReceiptsList
+        receipts={[stored]}
+        onReceiptUpdate={jest.fn()}
+        onRemoveReceipt={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Cafe")).toBeInTheDocument();
+    expect(screen.getByText(/2024-03-15 · 2 items · \$42\.00 · USD/)).toBeInTheDocument();
+    expect(screen.getByText("Receipts (1/10)")).toBeInTheDocument();
+  });
+
+  it("calls onRemoveReceipt after confirmation", async () => {
+    const onRemoveReceipt = jest.fn();
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe" }),
+      "r1"
+    );
+
+    render(
+      <ParsedReceiptsList
+        receipts={[stored]}
+        onReceiptUpdate={jest.fn()}
+        onRemoveReceipt={onRemoveReceipt}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /remove cafe/i }));
+    expect(onRemoveReceipt).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveTextContent(/Remove Cafe from this split/);
+
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() => {
+      expect(onRemoveReceipt).toHaveBeenCalledWith("r1");
+    });
+  });
+
+  it("does not remove when confirmation is cancelled", () => {
+    const onRemoveReceipt = jest.fn();
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe" }),
+      "r1"
+    );
+
+    render(
+      <ParsedReceiptsList
+        receipts={[stored]}
+        onReceiptUpdate={jest.fn()}
+        onRemoveReceipt={onRemoveReceipt}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /remove cafe/i }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onRemoveReceipt).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/parsed-receipts-list.test.tsx
+++ b/src/components/parsed-receipts-list.test.tsx
@@ -68,7 +68,7 @@ describe("ParsedReceiptsList", () => {
       />
     );
 
-    expect(screen.getByText("Cafe")).toBeInTheDocument();
+    expect(screen.getAllByText("Cafe").length).toBeGreaterThan(0);
     expect(screen.getByText(/2024-03-15 · 2 items · \$42\.00 · USD/)).toBeInTheDocument();
     expect(screen.getByText("Receipts (1/10)")).toBeInTheDocument();
   });

--- a/src/components/parsed-receipts-list.tsx
+++ b/src/components/parsed-receipts-list.tsx
@@ -132,6 +132,7 @@ export function ParsedReceiptsList({
                 <div className="border-t p-3">
                   <ReceiptDetails
                     receipt={receipt}
+                    lockCurrency={receipts.length > 1}
                     onReceiptUpdate={(updated) =>
                       onReceiptUpdate(stored.id, updated)
                     }

--- a/src/components/parsed-receipts-list.tsx
+++ b/src/components/parsed-receipts-list.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ReceiptDetails } from "@/components/receipt-details";
+import { formatCurrency } from "@/lib/receipt-utils";
+import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
+import { type Receipt, type StoredReceipt } from "@/types";
+
+interface ParsedReceiptsListProps {
+  receipts: StoredReceipt[];
+  onReceiptUpdate: (receiptId: string, receipt: Receipt) => void;
+  onRemoveReceipt: (receiptId: string) => void;
+}
+
+function untitledName(receipt: StoredReceipt): string {
+  const name = receipt.receipt.restaurant?.trim();
+  return name ? name : "Untitled receipt";
+}
+
+/** Distinguish same-restaurant receipts with date, then a short index. */
+export function receiptDisplayName(
+  stored: StoredReceipt,
+  receipts: StoredReceipt[]
+): string {
+  const name = untitledName(stored);
+  const sameName = receipts.filter((r) => untitledName(r) === name);
+  if (sameName.length <= 1) return name;
+
+  const sameDate = sameName.filter(
+    (r) => r.receipt.date === stored.receipt.date
+  );
+  if (stored.receipt.date && sameDate.length === 1) {
+    return `${name} · ${stored.receipt.date}`;
+  }
+
+  const index = sameName.findIndex((r) => r.id === stored.id) + 1;
+  return `${name} (${index})`;
+}
+
+export function ParsedReceiptsList({
+  receipts,
+  onReceiptUpdate,
+  onRemoveReceipt,
+}: ParsedReceiptsListProps) {
+  const lastId = receipts[receipts.length - 1]?.id ?? null;
+  const [expandedId, setExpandedId] = useState<string | null>(lastId);
+  const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (lastId) {
+      setExpandedId(lastId);
+    } else {
+      setExpandedId(null);
+    }
+  }, [lastId]);
+
+  if (receipts.length === 0) return null;
+
+  const pendingRemove = receipts.find((r) => r.id === pendingRemoveId);
+  const visibleExpandedId =
+    expandedId && receipts.some((r) => r.id === expandedId)
+      ? expandedId
+      : lastId;
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="text-xl">
+          Receipts ({receipts.length}/{MAX_RECEIPTS_PER_SESSION})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {receipts.map((stored) => {
+          const { receipt } = stored;
+          const itemCount = receipt.items.length;
+          const isExpanded = stored.id === visibleExpandedId;
+          const label = receiptDisplayName(stored, receipts);
+          const metaParts = [
+            receipt.date || null,
+            `${itemCount} ${itemCount === 1 ? "item" : "items"}`,
+            formatCurrency(receipt.total, receipt.currency),
+            receipt.currency,
+          ].filter(Boolean);
+
+          return (
+            <div
+              key={stored.id}
+              className="rounded-lg border"
+            >
+              <div className="flex items-start gap-2 p-3">
+                <button
+                  type="button"
+                  className="flex flex-1 items-start gap-2 text-left min-w-0"
+                  onClick={() =>
+                    setExpandedId(isExpanded ? null : stored.id)
+                  }
+                  aria-expanded={isExpanded}
+                >
+                  <ChevronDown
+                    className={`h-4 w-4 mt-1 shrink-0 transition-transform ${
+                      isExpanded ? "rotate-0" : "-rotate-90"
+                    }`}
+                  />
+                  <span className="min-w-0">
+                    <span className="font-medium block truncate">{label}</span>
+                    <span className="text-sm text-muted-foreground block">
+                      {metaParts.join(" · ")}
+                    </span>
+                  </span>
+                </button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPendingRemoveId(stored.id)}
+                  aria-label={`Remove ${label}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Remove
+                </Button>
+              </div>
+              {isExpanded && (
+                <div className="border-t p-3">
+                  <ReceiptDetails
+                    receipt={receipt}
+                    onReceiptUpdate={(updated) =>
+                      onReceiptUpdate(stored.id, updated)
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+
+      <Dialog
+        open={pendingRemoveId !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemoveId(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove receipt?</DialogTitle>
+            <DialogDescription>
+              {pendingRemove
+                ? `Remove ${receiptDisplayName(pendingRemove, receipts)} from this split? People and groups will be kept.`
+                : "Remove this receipt from the split?"}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setPendingRemoveId(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => {
+                if (pendingRemoveId) {
+                  onRemoveReceipt(pendingRemoveId);
+                }
+                setPendingRemoveId(null);
+              }}
+            >
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/components/parsed-receipts-list.tsx
+++ b/src/components/parsed-receipts-list.tsx
@@ -17,7 +17,7 @@ import { type Receipt, type StoredReceipt } from "@/types";
 
 interface ParsedReceiptsListProps {
   receipts: StoredReceipt[];
-  onReceiptUpdate: (receiptId: string, receipt: Receipt) => void;
+  onReceiptUpdate: (receiptId: string, receipt: Receipt) => boolean | void;
   onRemoveReceipt: (receiptId: string) => void;
 }
 
@@ -132,7 +132,6 @@ export function ParsedReceiptsList({
                 <div className="border-t p-3">
                   <ReceiptDetails
                     receipt={receipt}
-                    lockCurrency={receipts.length > 1}
                     onReceiptUpdate={(updated) =>
                       onReceiptUpdate(stored.id, updated)
                     }

--- a/src/components/receipt-details.test.tsx
+++ b/src/components/receipt-details.test.tsx
@@ -318,6 +318,49 @@ describe("ReceiptDetails", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
     });
+
+    it("disables the currency select when lockCurrency is set", () => {
+      render(
+        <ReceiptDetails
+          receipt={mockReceipt}
+          onReceiptUpdate={mockOnReceiptUpdate}
+          lockCurrency
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+      expect(screen.getByRole("combobox", { name: /currency/i })).toBeDisabled();
+      expect(
+        screen.getByText(/locked to USD because this split has multiple receipts/i)
+      ).toBeInTheDocument();
+    });
+
+    it("saves other fields without changing currency when lockCurrency is set", async () => {
+      render(
+        <ReceiptDetails
+          receipt={mockReceipt}
+          onReceiptUpdate={mockOnReceiptUpdate}
+          lockCurrency
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+      fireEvent.change(screen.getByLabelText("Restaurant"), {
+        target: { value: "Locked Cafe" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockOnReceiptUpdate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            restaurant: "Locked Cafe",
+            currency: "USD",
+          })
+        );
+      });
+      expect(toast.error).not.toHaveBeenCalled();
+    });
   });
 
   describe("Validation", () => {

--- a/src/components/receipt-details.test.tsx
+++ b/src/components/receipt-details.test.tsx
@@ -319,47 +319,23 @@ describe("ReceiptDetails", () => {
       });
     });
 
-    it("disables the currency select when lockCurrency is set", () => {
+    it("keeps the dialog open when onReceiptUpdate rejects the edit", async () => {
+      mockOnReceiptUpdate.mockReturnValueOnce(false);
       render(
         <ReceiptDetails
           receipt={mockReceipt}
           onReceiptUpdate={mockOnReceiptUpdate}
-          lockCurrency
         />
       );
 
       fireEvent.click(screen.getByRole("button", { name: /edit/i }));
-
-      expect(screen.getByRole("combobox", { name: /currency/i })).toBeDisabled();
-      expect(
-        screen.getByText(/locked to USD because this split has multiple receipts/i)
-      ).toBeInTheDocument();
-    });
-
-    it("saves other fields without changing currency when lockCurrency is set", async () => {
-      render(
-        <ReceiptDetails
-          receipt={mockReceipt}
-          onReceiptUpdate={mockOnReceiptUpdate}
-          lockCurrency
-        />
-      );
-
-      fireEvent.click(screen.getByRole("button", { name: /edit/i }));
-      fireEvent.change(screen.getByLabelText("Restaurant"), {
-        target: { value: "Locked Cafe" },
-      });
       fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
       await waitFor(() => {
-        expect(mockOnReceiptUpdate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            restaurant: "Locked Cafe",
-            currency: "USD",
-          })
-        );
+        expect(mockOnReceiptUpdate).toHaveBeenCalled();
       });
-      expect(toast.error).not.toHaveBeenCalled();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(toast.success).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/receipt-details.tsx
+++ b/src/components/receipt-details.tsx
@@ -27,11 +27,14 @@ import { getSupportedCurrencies } from "@/lib/currency";
 interface ReceiptDetailsProps {
   receipt: Receipt;
   onReceiptUpdate: (receipt: Receipt) => void;
+  /** When true, currency cannot be changed (session already has other receipts). */
+  lockCurrency?: boolean;
 }
 
 export function ReceiptDetails({
   receipt,
   onReceiptUpdate,
+  lockCurrency = false,
 }: ReceiptDetailsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedReceipt, setEditedReceipt] = useState<Receipt>(receipt);
@@ -84,6 +87,16 @@ export function ReceiptDetails({
       toast.error(
         `Total ($${editedReceipt.total.toFixed(2)}) doesn't match ` +
         `subtotal + tax + tip ($${totalMismatchError.expected?.toFixed(2)})`
+      );
+      return;
+    }
+
+    if (
+      lockCurrency &&
+      editedReceipt.currency !== (receipt.currency || "USD")
+    ) {
+      toast.error(
+        `This split is in ${receipt.currency || "USD"}. All receipts must use the same currency.`
       );
       return;
     }
@@ -199,6 +212,7 @@ export function ReceiptDetails({
               <Label htmlFor="currency">Currency</Label>
               <Select
                 value={editedReceipt.currency || 'USD'}
+                disabled={lockCurrency}
                 onValueChange={(value) =>
                   setEditedReceipt({
                     ...editedReceipt,
@@ -217,6 +231,12 @@ export function ReceiptDetails({
                   ))}
                 </SelectContent>
               </Select>
+              {lockCurrency && (
+                <p className="text-sm text-muted-foreground">
+                  Currency is locked to {receipt.currency || "USD"} because this
+                  split has multiple receipts.
+                </p>
+              )}
             </div>
 
             <div className="grid grid-cols-2 gap-4">

--- a/src/components/receipt-details.tsx
+++ b/src/components/receipt-details.tsx
@@ -26,15 +26,12 @@ import { getSupportedCurrencies } from "@/lib/currency";
 
 interface ReceiptDetailsProps {
   receipt: Receipt;
-  onReceiptUpdate: (receipt: Receipt) => void;
-  /** When true, currency cannot be changed (session already has other receipts). */
-  lockCurrency?: boolean;
+  onReceiptUpdate: (receipt: Receipt) => boolean | void;
 }
 
 export function ReceiptDetails({
   receipt,
   onReceiptUpdate,
-  lockCurrency = false,
 }: ReceiptDetailsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedReceipt, setEditedReceipt] = useState<Receipt>(receipt);
@@ -91,17 +88,8 @@ export function ReceiptDetails({
       return;
     }
 
-    if (
-      lockCurrency &&
-      editedReceipt.currency !== (receipt.currency || "USD")
-    ) {
-      toast.error(
-        `This split is in ${receipt.currency || "USD"}. All receipts must use the same currency.`
-      );
-      return;
-    }
-
-    onReceiptUpdate(editedReceipt);
+    const accepted = onReceiptUpdate(editedReceipt) !== false;
+    if (!accepted) return;
     setIsEditing(false);
     toast.success("Receipt details updated");
   };
@@ -212,7 +200,6 @@ export function ReceiptDetails({
               <Label htmlFor="currency">Currency</Label>
               <Select
                 value={editedReceipt.currency || 'USD'}
-                disabled={lockCurrency}
                 onValueChange={(value) =>
                   setEditedReceipt({
                     ...editedReceipt,
@@ -231,12 +218,6 @@ export function ReceiptDetails({
                   ))}
                 </SelectContent>
               </Select>
-              {lockCurrency && (
-                <p className="text-sm text-muted-foreground">
-                  Currency is locked to {receipt.currency || "USD"} because this
-                  split has multiple receipts.
-                </p>
-              )}
             </div>
 
             <div className="grid grid-cols-2 gap-4">

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -42,7 +42,7 @@ describe("ReceiptUploader", () => {
 
   it("renders upload prompt", () => {
     renderUploader();
-    expect(screen.getByText(/upload your receipt/i)).toBeInTheDocument();
+    expect(screen.getByText(/upload your receipts/i)).toBeInTheDocument();
   });
 
   it("accepts PDF files", async () => {
@@ -207,5 +207,158 @@ describe("ReceiptUploader", () => {
     });
     // No error toast for caching failure
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("dropping two files calls onReceiptParsed twice", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          restaurant: "First",
+          total: 10,
+          items: [],
+          currency: "USD",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          restaurant: "Second",
+          total: 20,
+          items: [],
+          currency: "USD",
+        }),
+      });
+
+    renderUploader();
+
+    const file1 = new File(["a"], "one.jpg", { type: "image/jpeg" });
+    const file2 = new File(["b"], "two.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), [file1, file2]);
+
+    await waitFor(() => {
+      expect(mockOnReceiptParsed).toHaveBeenCalledTimes(2);
+    });
+    expect(mockOnReceiptParsed).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ restaurant: "First" })
+    );
+    expect(mockOnReceiptParsed).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ restaurant: "Second" })
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("parses files sequentially so the second fetch waits on the first", async () => {
+    let resolveFirst: ((value: unknown) => void) | undefined;
+    const firstGate = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(async () => {
+        await firstGate;
+        return {
+          ok: true,
+          json: async () => ({
+            restaurant: "First",
+            total: 10,
+            items: [],
+            currency: "USD",
+          }),
+        };
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          restaurant: "Second",
+          total: 20,
+          items: [],
+          currency: "USD",
+        }),
+      });
+
+    renderUploader();
+
+    const file1 = new File(["a"], "one.jpg", { type: "image/jpeg" });
+    const file2 = new File(["b"], "two.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), [file1, file2]);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+    expect(mockOnReceiptParsed).not.toHaveBeenCalled();
+
+    resolveFirst?.(undefined);
+
+    await waitFor(() => {
+      expect(mockOnReceiptParsed).toHaveBeenCalledTimes(2);
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues parsing remaining files when one parse fails", async () => {
+    (global.fetch as jest.Mock)
+      .mockRejectedValueOnce(new Error("Failed to parse receipt"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          restaurant: "Second",
+          total: 20,
+          items: [],
+          currency: "USD",
+        }),
+      });
+
+    renderUploader();
+
+    const file1 = new File(["a"], "one.jpg", { type: "image/jpeg" });
+    const file2 = new File(["b"], "two.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), [file1, file2]);
+
+    await waitFor(() => {
+      expect(mockOnReceiptParsed).toHaveBeenCalledTimes(1);
+    });
+    expect(mockOnReceiptParsed).toHaveBeenCalledWith(
+      expect.objectContaining({ restaurant: "Second" })
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringMatching(/one\.jpg: Failed to parse receipt/)
+    );
+  });
+
+  it("skips extra files beyond maxRemaining and still parses the rest", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        restaurant: "Only",
+        total: 10,
+        items: [],
+        currency: "USD",
+      }),
+    });
+
+    render(
+      <ReceiptUploader
+        onReceiptParsed={mockOnReceiptParsed}
+        isLoading={false}
+        setIsLoading={mockSetIsLoading}
+        resetImageTrigger={0}
+        maxRemaining={1}
+      />
+    );
+
+    const file1 = new File(["a"], "one.jpg", { type: "image/jpeg" });
+    const file2 = new File(["b"], "two.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), [file1, file2]);
+
+    await waitFor(() => {
+      expect(mockOnReceiptParsed).toHaveBeenCalledTimes(1);
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringMatching(/Only 1 more receipt/)
+    );
   });
 });

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -361,4 +361,97 @@ describe("ReceiptUploader", () => {
       expect.stringMatching(/Only 1 more receipt/)
     );
   });
+
+  it("does not update thumbnail or cached image when onReceiptParsed rejects", async () => {
+    const OriginalFileReader = global.FileReader;
+    class FakeFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null =
+        null;
+      onerror: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null =
+        null;
+      readAsDataURL(file: Blob) {
+        const name = file instanceof File ? file.name : "blob";
+        this.result = `data:${file.type};base64,${btoa(name)}`;
+        queueMicrotask(() => {
+          this.onload?.call(
+            this as unknown as FileReader,
+            {} as ProgressEvent<FileReader>
+          );
+        });
+      }
+    }
+    global.FileReader = FakeFileReader as unknown as typeof FileReader;
+
+    try {
+      mockOnReceiptParsed.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            restaurant: "NY Diner",
+            total: 10,
+            items: [],
+            subtotal: 10,
+            tax: 0,
+            tip: 0,
+            currency: "USD",
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            restaurant: "Paris Bistro",
+            total: 20,
+            items: [],
+            subtotal: 20,
+            tax: 0,
+            tip: 0,
+            currency: "EUR",
+          }),
+        });
+
+      renderUploader();
+
+      const usdFile = new File(["usd-image"], "usd.jpg", { type: "image/jpeg" });
+      await userEvent.upload(getFileInput(), usdFile);
+
+      await waitFor(() => {
+        expect(mockOnReceiptParsed).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(screen.getByAltText("Receipt preview")).toBeInTheDocument();
+      });
+
+      const usdDataUrl = `data:image/jpeg;base64,${btoa("usd.jpg")}`;
+      const previewAfterUsd = screen
+        .getByAltText("Receipt preview")
+        .getAttribute("src");
+      const cachedAfterUsd = localStorage.getItem("receiptSplitterImage");
+      expect(previewAfterUsd).toBe(usdDataUrl);
+      expect(cachedAfterUsd).toBe(usdDataUrl);
+      expect(usdDataUrl).not.toBe(`data:image/jpeg;base64,${btoa("eur.jpg")}`);
+
+      const eurFile = new File(["eur-image-different-bytes"], "eur.jpg", {
+        type: "image/jpeg",
+      });
+      await userEvent.upload(getFileInput(), eurFile);
+
+      await waitFor(() => {
+        expect(mockOnReceiptParsed).toHaveBeenCalledTimes(2);
+      });
+      expect(mockOnReceiptParsed).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ restaurant: "Paris Bistro", currency: "EUR" })
+      );
+
+      expect(screen.getByAltText("Receipt preview").getAttribute("src")).toBe(
+        previewAfterUsd
+      );
+      expect(localStorage.getItem("receiptSplitterImage")).toBe(cachedAfterUsd);
+    } finally {
+      global.FileReader = OriginalFileReader;
+    }
+  });
 });

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -4,7 +4,11 @@ import { UploadCloud, Loader2, FileText } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "sonner";
 import { type Receipt } from "@/types";
-import { MAX_FILE_SIZE_MB, MAX_FILE_SIZE_BYTES } from "@/lib/constants";
+import {
+  MAX_FILE_SIZE_MB,
+  MAX_FILE_SIZE_BYTES,
+  MAX_RECEIPTS_PER_SESSION,
+} from "@/lib/constants";
 import imageCompression from "browser-image-compression";
 import { getSessionId } from "@/lib/session";
 import {
@@ -19,19 +23,139 @@ interface ReceiptUploaderProps {
   isLoading: boolean;
   setIsLoading: (isLoading: boolean) => void;
   resetImageTrigger?: number;
+  /** How many more receipts the session can accept. Defaults to the session cap. */
+  maxRemaining?: number;
 }
 
 const MAX_COMPRESSION_FILE_SIZE_MB = 50;
 const COMPRESSION_TARGET_SIZE_MB = 4;
+
+async function prepareReceiptFile(
+  file: File,
+  setIsCompressing: (value: boolean) => void
+): Promise<File | null> {
+  if (!file.type.startsWith("image/") && file.type !== "application/pdf") {
+    toast.error("Please upload an image or PDF file");
+    return null;
+  }
+
+  const fileSizeMB = file.size / (1024 * 1024);
+
+  // Attempt client-side compression for images that exceed the upload limit
+  if (file.type.startsWith("image/") && file.size > MAX_FILE_SIZE_BYTES) {
+    if (fileSizeMB > MAX_COMPRESSION_FILE_SIZE_MB) {
+      toast.error(
+        `File is too large to compress (${fileSizeMB.toFixed(1)}MB). Maximum is ${MAX_COMPRESSION_FILE_SIZE_MB}MB.`
+      );
+      return null;
+    }
+
+    try {
+      setIsCompressing(true);
+      const compressed = await imageCompression(file, {
+        maxSizeMB: COMPRESSION_TARGET_SIZE_MB,
+        maxWidthOrHeight: 2048,
+        useWebWorker: true,
+      });
+      const originalSize = fileSizeMB.toFixed(1);
+      const newSize = (compressed.size / (1024 * 1024)).toFixed(1);
+      if (compressed.size > MAX_FILE_SIZE_BYTES) {
+        toast.error(
+          `Compressed from ${originalSize}MB to ${newSize}MB, but it's still over the ${MAX_FILE_SIZE_MB}MB limit. Please use a smaller or lower-resolution image.`
+        );
+        return null;
+      }
+      toast.success(`Compressed from ${originalSize}MB to ${newSize}MB`);
+      return compressed;
+    } catch (error) {
+      console.error("Image compression error:", error);
+      toast.error(
+        `File is too large (${fileSizeMB.toFixed(1)}MB). Maximum size is ${MAX_FILE_SIZE_MB}MB. Compression failed — please use a smaller file.`
+      );
+      return null;
+    } finally {
+      setIsCompressing(false);
+    }
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    toast.error(
+      `File is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB. Your file is ${(file.size / (1024 * 1024)).toFixed(1)}MB.`
+    );
+    return null;
+  }
+
+  return file;
+}
+
+async function parseReceiptFile(file: File): Promise<Receipt> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("sessionId", getSessionId());
+
+  const response = await fetch("/api/parse-receipt", {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    if (response.status === 413) {
+      throw new Error(
+        `File is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB. Please compress your image or use a smaller file.`
+      );
+    }
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to parse receipt");
+  }
+
+  return response.json();
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Failed to read file"));
+      }
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read file"));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+async function updatePreview(
+  file: File,
+  setPreviewUrl: (url: string) => void
+): Promise<void> {
+  if (file.type.startsWith("image/")) {
+    const dataUrl = await readFileAsDataUrl(file);
+    safeSetItem(RECEIPT_IMAGE_STORAGE_KEY, dataUrl);
+    setPreviewUrl(dataUrl);
+    return;
+  }
+
+  setPreviewUrl("pdf-placeholder");
+  safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
+}
 
 export function ReceiptUploader({
   onReceiptParsed,
   isLoading,
   setIsLoading,
   resetImageTrigger,
+  maxRemaining = MAX_RECEIPTS_PER_SESSION,
 }: ReceiptUploaderProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isCompressing, setIsCompressing] = useState(false);
+  const [parseProgress, setParseProgress] = useState<{
+    current: number;
+    total: number;
+  } | null>(null);
 
   // Restore preview image from localStorage on mount
   useEffect(() => {
@@ -58,118 +182,57 @@ export function ReceiptUploader({
     async (acceptedFiles: File[]) => {
       if (acceptedFiles.length === 0) return;
 
-      // Get the first file
-      let file = acceptedFiles[0];
-
-      // Check file type
-      if (!file.type.startsWith("image/") && file.type !== "application/pdf") {
-        toast.error("Please upload an image or PDF file");
-        return;
-      }
-
-      const fileSizeMB = file.size / (1024 * 1024);
-
-      // Attempt client-side compression for images that exceed the upload limit
-      if (file.type.startsWith("image/") && file.size > MAX_FILE_SIZE_BYTES) {
-        if (fileSizeMB > MAX_COMPRESSION_FILE_SIZE_MB) {
-          toast.error(
-            `File is too large to compress (${fileSizeMB.toFixed(1)}MB). Maximum is ${MAX_COMPRESSION_FILE_SIZE_MB}MB.`
-          );
-          return;
-        }
-
-        try {
-          setIsCompressing(true);
-          const compressed = await imageCompression(file, {
-            maxSizeMB: COMPRESSION_TARGET_SIZE_MB,
-            maxWidthOrHeight: 2048,
-            useWebWorker: true,
-          });
-          const originalSize = fileSizeMB.toFixed(1);
-          const newSize = (compressed.size / (1024 * 1024)).toFixed(1);
-          if (compressed.size > MAX_FILE_SIZE_BYTES) {
-            toast.error(
-              `Compressed from ${originalSize}MB to ${newSize}MB, but it's still over the ${MAX_FILE_SIZE_MB}MB limit. Please use a smaller or lower-resolution image.`
-            );
-            return;
-          }
-          toast.success(
-            `Compressed from ${originalSize}MB to ${newSize}MB`
-          );
-          file = compressed;
-        } catch (error) {
-          console.error("Image compression error:", error);
-          toast.error(
-            `File is too large (${fileSizeMB.toFixed(1)}MB). Maximum size is ${MAX_FILE_SIZE_MB}MB. Compression failed — please use a smaller file.`
-          );
-          return;
-        } finally {
-          setIsCompressing(false);
-        }
-      }
-
-      // Final size check (after potential compression)
-      if (file.size > MAX_FILE_SIZE_BYTES) {
+      if (maxRemaining <= 0) {
         toast.error(
-          `File is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB. Your file is ${(file.size / (1024 * 1024)).toFixed(1)}MB.`
+          `This split already has ${MAX_RECEIPTS_PER_SESSION} receipts. Remove one to add another.`
         );
         return;
       }
 
-      // Convert image to Base64 and store in localStorage (skip for PDFs)
-      if (file.type.startsWith("image/")) {
-        const reader = new FileReader();
-        reader.onload = () => {
-          if (reader.result) {
-            safeSetItem(RECEIPT_IMAGE_STORAGE_KEY, reader.result as string);
-            setPreviewUrl(reader.result as string);
-          }
-        };
-        reader.readAsDataURL(file);
-      } else {
-        // For PDFs, just set a placeholder preview
-        setPreviewUrl("pdf-placeholder");
-        safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
+      if (acceptedFiles.length > maxRemaining) {
+        toast.error(
+          `Only ${maxRemaining} more receipt${maxRemaining === 1 ? "" : "s"} can be added (maximum ${MAX_RECEIPTS_PER_SESSION} per split). Extra files were skipped.`
+        );
       }
 
-      // Parse receipt
+      const filesToProcess = acceptedFiles.slice(0, maxRemaining);
+
+      setIsLoading(true);
       try {
-        setIsLoading(true);
+        for (let i = 0; i < filesToProcess.length; i++) {
+          const file = filesToProcess[i];
+          setParseProgress({
+            current: i + 1,
+            total: filesToProcess.length,
+          });
+          try {
+            const prepared = await prepareReceiptFile(file, setIsCompressing);
+            if (!prepared) continue;
 
-        const formData = new FormData();
-        formData.append("file", file);
-        formData.append("sessionId", getSessionId());
-
-        const response = await fetch("/api/parse-receipt", {
-          method: "POST",
-          body: formData,
-        });
-
-        if (!response.ok) {
-          // Handle 413 specifically - the server may not return JSON for this error
-          if (response.status === 413) {
-            throw new Error(
-              `File is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB. Please compress your image or use a smaller file.`
-            );
+            const receipt = await parseReceiptFile(prepared);
+            try {
+              await updatePreview(prepared, setPreviewUrl);
+            } catch {
+              // Preview caching is best-effort and must not block a successful parse
+            }
+            onReceiptParsed(receipt);
+          } catch (error) {
+            console.error("Receipt parsing error:", error);
+            const errorMessage =
+              error instanceof Error
+                ? error.message
+                : "Failed to parse receipt. Please try again.";
+            const prefix =
+              filesToProcess.length > 1 ? `${file.name}: ` : "";
+            toast.error(`${prefix}${errorMessage}`);
           }
-          const errorData = await response.json();
-          throw new Error(errorData.error || "Failed to parse receipt");
         }
-
-        const receiptData = await response.json();
-        onReceiptParsed(receiptData);
-      } catch (error) {
-        console.error("Receipt parsing error:", error);
-        const errorMessage =
-          error instanceof Error
-            ? error.message
-            : "Failed to parse receipt. Please try again.";
-        toast.error(errorMessage);
       } finally {
+        setParseProgress(null);
         setIsLoading(false);
       }
     },
-    [onReceiptParsed, setIsLoading]
+    [onReceiptParsed, setIsLoading, maxRemaining]
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -178,11 +241,15 @@ export function ReceiptUploader({
       "image/*": [".jpeg", ".jpg", ".png", ".heif", ".heic", ".webp"],
       "application/pdf": [".pdf"],
     },
-    maxFiles: 1,
+    multiple: true,
     disabled: isLoading || isCompressing,
   });
 
   const isBusy = isLoading || isCompressing;
+  const parsingLabel =
+    parseProgress && parseProgress.total > 1
+      ? `Parsing receipt ${parseProgress.current} of ${parseProgress.total}...`
+      : "Parsing receipt...";
 
   return (
     <Card className="w-full">
@@ -217,19 +284,28 @@ export function ReceiptUploader({
               {isLoading ? (
                 <div className="flex items-center gap-2">
                   <Loader2 className="h-5 w-5 animate-spin" />
-                  <p>Parsing receipt...</p>
+                  <p>{parsingLabel}</p>
                 </div>
               ) : (
-                <p>Click or drag to upload a different receipt</p>
+                <p>Click or drag to add another receipt</p>
               )}
             </div>
           ) : (
             <div className="flex flex-col items-center">
-              <UploadCloud className="h-12 w-12 mb-4 text-muted-foreground" />
-              <p className="mb-1 font-medium">Upload your receipt</p>
-              <p className="text-sm text-muted-foreground">
-                Drag and drop or click to select
-              </p>
+              {isLoading ? (
+                <>
+                  <Loader2 className="h-12 w-12 mb-4 animate-spin text-primary" />
+                  <p className="mb-1 font-medium">{parsingLabel}</p>
+                </>
+              ) : (
+                <>
+                  <UploadCloud className="h-12 w-12 mb-4 text-muted-foreground" />
+                  <p className="mb-1 font-medium">Upload your receipts</p>
+                  <p className="text-sm text-muted-foreground">
+                    Drag and drop or click to select one or more files
+                  </p>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -19,7 +19,11 @@ import {
 } from "@/lib/storage";
 
 interface ReceiptUploaderProps {
-  onReceiptParsed: (receipt: Receipt) => void;
+  /**
+   * Called after a file is parsed. Return `false` to reject the receipt
+   * (currency mismatch, session cap). Preview/cache update only on accept.
+   */
+  onReceiptParsed: (receipt: Receipt) => boolean | void;
   isLoading: boolean;
   setIsLoading: (isLoading: boolean) => void;
   resetImageTrigger?: number;
@@ -210,12 +214,13 @@ export function ReceiptUploader({
             if (!prepared) continue;
 
             const receipt = await parseReceiptFile(prepared);
+            const accepted = onReceiptParsed(receipt) !== false;
+            if (!accepted) continue;
             try {
               await updatePreview(prepared, setPreviewUrl);
             } catch {
               // Preview caching is best-effort and must not block a successful parse
             }
-            onReceiptParsed(receipt);
           } catch (error) {
             console.error("Receipt parsing error:", error);
             const errorMessage =

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,3 +8,6 @@
  */
 export const MAX_FILE_SIZE_MB = 4.5;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
+/** Maximum number of receipts that can be added to a single split session. */
+export const MAX_RECEIPTS_PER_SESSION = 10;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #139. Base is now `main` after #149 merged.

## Summary

Users can upload multiple same-currency receipts for one outing. People/groups persist after the first receipt. A bad parse can be removed without New Split.

## Behavior

- First receipt in an empty session still starts a new outing (clears people/groups).
- Receipt 2+ appends and keeps the party.
- Session currency is pinned to the first receipt. Mismatches toast both codes and do not abort the rest of a batch.
- Cap: 10 receipts.
- Upload tab lists each receipt with edit + remove.
- People tab shows a session summary (`2 receipts · USD`).
- Assign/results still only used `receipts[0]` until PRs 3–4.

## Stack

1. #149 — Data model (merged)
2. **This PR — Multi-file upload + currency lock + remove**
3. #152 — Per-receipt assignment cards
4. #153 — Per-receipt results + aggregate share
5. #154 — Copy and screenshot mocks

Do not merge this to `main` until #153 is ready (or merge 2–5 together bottom-up).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

