### PR TITLE
feat: [3/5] per-receipt assignment cards and split evenly

### DIFF
--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -82,13 +82,13 @@ test.describe("error states", () => {
     await seedSessionViaReload(page, baseState(), "assign");
 
     await expect(
-      page.getByRole("button", { name: /split all evenly/i }),
+      page.getByRole("button", { name: /split evenly/i }),
     ).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("0%")).toBeVisible();
 
     await context.setOffline(true);
 
-    await page.getByRole("button", { name: /split all evenly/i }).click({
+    await page.getByRole("button", { name: /split evenly/i }).click({
       force: true,
     });
     await expect(

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -92,7 +92,7 @@ test.describe("error states", () => {
       force: true,
     });
     await expect(
-      page.getByText("All items split evenly among everyone!").first(),
+      page.getByText("Split remaining items on Test Diner.").first(),
     ).toBeVisible();
     await expect(page.getByText("100%")).toBeVisible();
 

--- a/e2e/split-evenly.spec.ts
+++ b/e2e/split-evenly.spec.ts
@@ -189,13 +189,13 @@ test.describe("Split All Evenly flow", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      const splitBtn = page.getByRole("button", { name: /split evenly/i });
       await expect(splitBtn).toBeVisible({ timeout: 10000 });
       await expect(splitBtn).toBeEnabled();
     });
 
     await test.step("click Split All Evenly — toast confirms", async () => {
-      await page.getByRole("button", { name: /split all evenly/i }).click();
+      await page.getByRole("button", { name: /split evenly/i }).click();
       // Wait for toast to appear
       await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
     });
@@ -233,13 +233,13 @@ test.describe("Split All Evenly flow", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      const splitBtn = page.getByRole("button", { name: /split evenly/i });
       await expect(splitBtn).toBeVisible({ timeout: 10000 });
       await expect(splitBtn).toBeEnabled();
     });
 
     await test.step("click Split All Evenly", async () => {
-      await page.getByRole("button", { name: /split all evenly/i }).click();
+      await page.getByRole("button", { name: /split evenly/i }).click();
       await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
     });
 
@@ -277,19 +277,13 @@ test.describe("Split All Evenly flow", () => {
       }, "assign");
     });
 
-    await test.step("Assign tab — Split All Evenly button visible and enabled", async () => {
+    await test.step("Assign tab — Split evenly button is visible and disabled", async () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      const splitBtn = page.getByRole("button", { name: /split evenly/i });
       await expect(splitBtn).toBeVisible({ timeout: 10000 });
-      await expect(splitBtn).toBeEnabled();
-    });
-
-    await test.step("click Split All Evenly — info toast says no unassigned items", async () => {
-      await page.getByRole("button", { name: /split all evenly/i }).click();
-      // With 0 items, progress is already 100% and there are no unassigned items
-      await expect(page.getByText("No unassigned items to split evenly!")).toBeVisible({ timeout: 5000 });
+      await expect(splitBtn).toBeDisabled();
     });
 
     await test.step("progress stays at 100% (empty receipt rounds to 100%)", async () => {
@@ -319,7 +313,7 @@ test.describe("Split All Evenly flow", () => {
       await page.goto("/");
       await page.waitForLoadState("networkidle");
 
-      const splitBtn = page.getByRole("button", { name: /split all evenly/i });
+      const splitBtn = page.getByRole("button", { name: /split evenly/i });
       await expect(splitBtn).toBeVisible({ timeout: 10000 });
       await expect(splitBtn).toBeEnabled();
     });
@@ -329,7 +323,7 @@ test.describe("Split All Evenly flow", () => {
     });
 
     await test.step("click Split All Evenly", async () => {
-      await page.getByRole("button", { name: /split all evenly/i }).click();
+      await page.getByRole("button", { name: /split evenly/i }).click();
       await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
     });
 

--- a/e2e/split-evenly.spec.ts
+++ b/e2e/split-evenly.spec.ts
@@ -197,7 +197,7 @@ test.describe("Split All Evenly flow", () => {
     await test.step("click Split All Evenly — toast confirms", async () => {
       await page.getByRole("button", { name: /split evenly/i }).click();
       // Wait for toast to appear
-      await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("Split remaining items on Even Diner.").first()).toBeVisible({ timeout: 5000 });
     });
 
     await test.step("progress shows 100% after split", async () => {
@@ -240,7 +240,7 @@ test.describe("Split All Evenly flow", () => {
 
     await test.step("click Split All Evenly", async () => {
       await page.getByRole("button", { name: /split evenly/i }).click();
-      await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("Split remaining items on Trio Cafe.").first()).toBeVisible({ timeout: 5000 });
     });
 
     await test.step("progress shows 100%", async () => {
@@ -324,7 +324,7 @@ test.describe("Split All Evenly flow", () => {
 
     await test.step("click Split All Evenly", async () => {
       await page.getByRole("button", { name: /split evenly/i }).click();
-      await expect(page.getByText("All items split evenly among everyone!").first()).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("Split remaining items on PreSplit Grill.").first()).toBeVisible({ timeout: 5000 });
     });
 
     await test.step("progress shows 100% after split", async () => {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -223,7 +223,9 @@ describe("Home Page", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /split evenly/i }));
 
-      expect(toast.success).toHaveBeenCalledWith("All items split evenly among everyone!");
+      expect(toast.success).toHaveBeenCalledWith(
+        "Split remaining items on Testaurant."
+      );
       expect(screen.getByText("100%")).toBeInTheDocument();
     });
   });
@@ -532,6 +534,8 @@ describe("Home Page", () => {
       render(<Home />);
       expect(screen.getByText("Alpha Grill")).toBeInTheDocument();
       expect(screen.getByText("Beta Cafe")).toBeInTheDocument();
+      expect(screen.getByText("2024-06-01")).toBeInTheDocument();
+      expect(screen.getByText("2024-06-02")).toBeInTheDocument();
     });
 
     it("split evenly on one receipt does not assign items on the other", () => {
@@ -543,7 +547,7 @@ describe("Home Page", () => {
       );
 
       expect(toast.success).toHaveBeenCalledWith(
-        "All items split evenly among everyone!"
+        "Split remaining items on Alpha Grill."
       );
       expect(
         within(cardFor("Alpha Grill")).queryAllByText(/unassigned/i)
@@ -564,6 +568,117 @@ describe("Home Page", () => {
       ]);
       render(<Home />);
       expect(screen.getByText("50%")).toBeInTheDocument();
+    });
+
+    it("always shows the date and adds #n when restaurant names collide", () => {
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [
+              {
+                id: "r1",
+                receipt: createMockReceipt({
+                  restaurant: "Starbucks",
+                  date: "2024-01-01",
+                  items: [{ name: "Latte", price: 5, quantity: 1 }],
+                  subtotal: 5,
+                  tax: 0,
+                  tip: 0,
+                  total: 5,
+                }),
+              },
+              {
+                id: "r2",
+                receipt: createMockReceipt({
+                  restaurant: "Starbucks",
+                  date: "2024-01-01",
+                  items: [{ name: "Mocha", price: 6, quantity: 1 }],
+                  subtotal: 6,
+                  tax: 0,
+                  tip: 0,
+                  total: 6,
+                }),
+              },
+            ],
+            people: mockPeople,
+            assignedItems: [
+              ["r1", []],
+              ["r2", []],
+            ],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "assign",
+        })
+      );
+      render(<Home />);
+
+      expect(screen.getAllByText("Starbucks")).toHaveLength(2);
+      expect(screen.getByText("2024-01-01 · #1")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-01 · #2")).toBeInTheDocument();
+      expect(screen.queryByText("#1", { exact: true })).not.toBeInTheDocument();
+      expect(screen.queryByText("#2", { exact: true })).not.toBeInTheDocument();
+    });
+
+    it("names the receipt in the split evenly toast", () => {
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [
+              {
+                id: "r1",
+                receipt: createMockReceipt({
+                  restaurant: "Starbucks",
+                  date: "2024-01-01",
+                  items: [{ name: "Latte", price: 5, quantity: 1 }],
+                  subtotal: 5,
+                  tax: 0,
+                  tip: 0,
+                  total: 5,
+                }),
+              },
+              {
+                id: "r2",
+                receipt: createMockReceipt({
+                  restaurant: "Starbucks",
+                  date: "2024-01-02",
+                  items: [{ name: "Mocha", price: 6, quantity: 1 }],
+                  subtotal: 6,
+                  tax: 0,
+                  tip: 0,
+                  total: 6,
+                }),
+              },
+            ],
+            people: mockPeople,
+            assignedItems: [
+              ["r1", []],
+              ["r2", []],
+            ],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "assign",
+        })
+      );
+      render(<Home />);
+
+      const morningCard = screen
+        .getByText("2024-01-01 · #1")
+        .closest("[data-slot='card']") as HTMLElement;
+      fireEvent.click(
+        within(morningCard).getByRole("button", { name: /split evenly/i })
+      );
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "Split remaining items on Starbucks · 2024-01-01 · #1."
+      );
     });
   });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Home from "./page";
 import { toast } from "sonner";
@@ -51,10 +51,10 @@ describe("Home Page", () => {
       expect(screen.getByText(/drag and drop or click to select/i)).toBeInTheDocument();
     });
 
-    it("hides the progress bar and Split All Evenly button", () => {
+    it("hides the progress bar and Split evenly button", () => {
       render(<Home />);
       expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /split all evenly/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /split evenly/i })).not.toBeInTheDocument();
     });
   });
 
@@ -210,18 +210,18 @@ describe("Home Page", () => {
     });
   });
 
-  describe("Split All Evenly button", () => {
+  describe("Split evenly button", () => {
     it("is disabled when no people are added", () => {
-      loadSession();
+      loadSession({}, "assign");
       render(<Home />);
-      expect(screen.getByRole("button", { name: /split all evenly/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /split evenly/i })).toBeDisabled();
     });
 
     it("assigns all items and fires success toast when clicked", () => {
-      loadSession({ people: mockPeople });
+      loadSession({ people: mockPeople }, "assign");
       render(<Home />);
 
-      fireEvent.click(screen.getByRole("button", { name: /split all evenly/i }));
+      fireEvent.click(screen.getByRole("button", { name: /split evenly/i }));
 
       expect(toast.success).toHaveBeenCalledWith("All items split evenly among everyone!");
       expect(screen.getByText("100%")).toBeInTheDocument();
@@ -476,6 +476,94 @@ describe("Home Page", () => {
         expect(screen.getByText(/EUR - Euro/)).toBeInTheDocument();
       });
       expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("multi-receipt assign tab", () => {
+    const receiptA = createMockReceipt({
+      restaurant: "Alpha Grill",
+      date: "2024-06-01",
+      items: [{ name: "Steak", price: 20, quantity: 1 }],
+      subtotal: 20,
+      tax: 0,
+      tip: 0,
+      total: 20,
+    });
+    const receiptB = createMockReceipt({
+      restaurant: "Beta Cafe",
+      date: "2024-06-02",
+      items: [{ name: "Latte", price: 5, quantity: 1 }],
+      subtotal: 5,
+      tax: 0,
+      tip: 0,
+      total: 5,
+    });
+
+    function loadTwoReceipts(assignedItems?: unknown) {
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [
+              { id: "r1", receipt: receiptA },
+              { id: "r2", receipt: receiptB },
+            ],
+            people: mockPeople,
+            assignedItems: assignedItems ?? [
+              ["r1", []],
+              ["r2", []],
+            ],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "assign",
+        })
+      );
+    }
+
+    function cardFor(name: string) {
+      return screen.getByText(name).closest("[data-slot='card']") as HTMLElement;
+    }
+
+    it("renders both restaurant names as assignment cards", () => {
+      loadTwoReceipts();
+      render(<Home />);
+      expect(screen.getByText("Alpha Grill")).toBeInTheDocument();
+      expect(screen.getByText("Beta Cafe")).toBeInTheDocument();
+    });
+
+    it("split evenly on one receipt does not assign items on the other", () => {
+      loadTwoReceipts();
+      render(<Home />);
+
+      fireEvent.click(
+        within(cardFor("Alpha Grill")).getByRole("button", { name: /split evenly/i })
+      );
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "All items split evenly among everyone!"
+      );
+      expect(
+        within(cardFor("Alpha Grill")).queryAllByText(/unassigned/i)
+      ).toHaveLength(0);
+      expect(
+        within(cardFor("Beta Cafe")).getAllByText(/unassigned/i).length
+      ).toBeGreaterThan(0);
+      expect(
+        within(cardFor("Beta Cafe")).getByRole("button", { name: /split evenly/i })
+      ).toBeEnabled();
+      expect(screen.getByText("50%")).toBeInTheDocument();
+    });
+
+    it("progress reflects items across both receipts", () => {
+      loadTwoReceipts([
+        ["r1", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+        ["r2", []],
+      ]);
+      render(<Home />);
+      expect(screen.getByText("50%")).toBeInTheDocument();
     });
   });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -226,7 +226,26 @@ describe("Home Page", () => {
       expect(toast.success).toHaveBeenCalledWith(
         "Split remaining items on Testaurant."
       );
+      expect(toast.info).not.toHaveBeenCalled();
       expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    it("uses Untitled receipt in the toast when the restaurant has no name", () => {
+      loadSession(
+        {
+          people: mockPeople,
+          originalReceipt: { ...mockReceipt, restaurant: null },
+        },
+        "assign"
+      );
+      render(<Home />);
+
+      fireEvent.click(screen.getByRole("button", { name: /split evenly/i }));
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "Split remaining items on Untitled receipt."
+      );
+      expect(toast.info).not.toHaveBeenCalled();
     });
   });
 
@@ -570,7 +589,7 @@ describe("Home Page", () => {
       expect(screen.getByText("50%")).toBeInTheDocument();
     });
 
-    it("always shows the date and adds #n when restaurant names collide", () => {
+    it("always shows the date and numbers #n among duplicate titles only", () => {
       localStorage.setItem(
         "receiptSplitterSession",
         JSON.stringify({
@@ -580,7 +599,7 @@ describe("Home Page", () => {
               {
                 id: "r1",
                 receipt: createMockReceipt({
-                  restaurant: "Starbucks",
+                  restaurant: "Coffee",
                   date: "2024-01-01",
                   items: [{ name: "Latte", price: 5, quantity: 1 }],
                   subtotal: 5,
@@ -592,7 +611,19 @@ describe("Home Page", () => {
               {
                 id: "r2",
                 receipt: createMockReceipt({
-                  restaurant: "Starbucks",
+                  restaurant: "Lunch",
+                  date: "2024-01-02",
+                  items: [{ name: "Sandwich", price: 8, quantity: 1 }],
+                  subtotal: 8,
+                  tax: 0,
+                  tip: 0,
+                  total: 8,
+                }),
+              },
+              {
+                id: "r3",
+                receipt: createMockReceipt({
+                  restaurant: "Coffee",
                   date: "2024-01-01",
                   items: [{ name: "Mocha", price: 6, quantity: 1 }],
                   subtotal: 6,
@@ -606,6 +637,7 @@ describe("Home Page", () => {
             assignedItems: [
               ["r1", []],
               ["r2", []],
+              ["r3", []],
             ],
             groups: [],
             isLoading: false,
@@ -616,11 +648,14 @@ describe("Home Page", () => {
       );
       render(<Home />);
 
-      expect(screen.getAllByText("Starbucks")).toHaveLength(2);
+      expect(screen.getAllByText("Coffee")).toHaveLength(2);
+      expect(screen.getByText("Lunch")).toBeInTheDocument();
       expect(screen.getByText("2024-01-01 · #1")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-02")).toBeInTheDocument();
       expect(screen.getByText("2024-01-01 · #2")).toBeInTheDocument();
+      expect(screen.queryByText("2024-01-01 · #3")).not.toBeInTheDocument();
       expect(screen.queryByText("#1", { exact: true })).not.toBeInTheDocument();
-      expect(screen.queryByText("#2", { exact: true })).not.toBeInTheDocument();
+      expect(screen.queryByText("#3", { exact: true })).not.toBeInTheDocument();
     });
 
     it("names the receipt in the split evenly toast", () => {
@@ -677,8 +712,9 @@ describe("Home Page", () => {
       );
 
       expect(toast.success).toHaveBeenCalledWith(
-        "Split remaining items on Starbucks · 2024-01-01 · #1."
+        "Split remaining items on Starbucks."
       );
+      expect(toast.info).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,15 +23,17 @@ import {
   type PersonItemAssignment,
   type ReceiptState,
   type Group,
-  type ItemAssignments,
+  type StoredReceipt,
 } from "@/types";
 import {
   getUnassignedItems,
+  getSessionUnassigned,
   calculateSessionPersonTotals,
   validateSessionAssignments,
   validateSessionInvariants,
   sessionCurrency,
   validateReceiptCurrency,
+  distributeEqualShares,
 } from "@/lib/receipt-utils";
 import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
 import {
@@ -158,6 +160,22 @@ function updateReceiptInState(
   };
 }
 
+function getAssignCardSubtitle(
+  receipts: StoredReceipt[],
+  index: number
+): string | undefined {
+  const stored = receipts[index];
+  const name = stored.receipt.restaurant || "Untitled receipt";
+  const isDuplicate =
+    receipts.filter(
+      (r) => (r.receipt.restaurant || "Untitled receipt") === name
+    ).length > 1;
+  if (isDuplicate) {
+    return `#${index + 1}`;
+  }
+  return stored.receipt.date || undefined;
+}
+
 export default function Home() {
   const [state, setState] = useState<ReceiptState>(emptyReceiptState);
   const [activeTab, setActiveTab] = useState("upload");
@@ -171,13 +189,6 @@ export default function Home() {
   }, [state]);
 
   const activeReceipt = state.receipts[0]?.receipt ?? null;
-  const activeId = state.receipts[0]?.id;
-  const activeAssignments: ItemAssignments = activeId
-    ? (state.assignedItems.get(activeId) ?? new Map())
-    : new Map();
-  const unassignedItems = activeReceipt
-    ? getUnassignedItems(activeReceipt, activeAssignments)
-    : [];
 
   const validationResult = useMemo(() => {
     return validateSessionInvariants(
@@ -244,15 +255,18 @@ export default function Home() {
     state.assignedItems
   );
 
-  // Calculate progress
+  // Calculate progress across every receipt in the session
   const calculateProgress = (): number => {
-    if (!activeReceipt) return 0;
+    if (state.receipts.length === 0) return 0;
 
-    const totalItems = activeReceipt.items.length;
-    if (totalItems === 0) return 100;
-
-    const assignedItemCount = totalItems - unassignedItems.length;
-    return (assignedItemCount / totalItems) * 100;
+    const totalItems = state.receipts.reduce(
+      (n, r) => n + r.receipt.items.length,
+      0
+    );
+    const unassigned = getSessionUnassigned(state.receipts, state.assignedItems);
+    return totalItems === 0
+      ? 100
+      : ((totalItems - unassigned.length) / totalItems) * 100;
   };
 
   // Handle receipt upload — append to the current outing (people/groups stay)
@@ -361,14 +375,16 @@ export default function Home() {
     return true;
   };
 
-  // Handle item assignments
+  // Handle item assignments for a specific receipt
   const handleAssignItems = (
+    receiptId: string,
     itemIndex: number,
     assignments: PersonItemAssignment[]
   ) => {
     setState((prevState) => {
-      const receiptId = prevState.receipts[0]?.id;
-      if (!receiptId) return prevState;
+      if (!prevState.receipts.some((stored) => stored.id === receiptId)) {
+        return prevState;
+      }
 
       const nextOuter = new Map(prevState.assignedItems);
       const inner = new Map(nextOuter.get(receiptId) ?? []);
@@ -380,7 +396,7 @@ export default function Home() {
       }
       nextOuter.set(receiptId, inner);
 
-      return {
+      const next = {
         ...prevState,
         assignedItems: nextOuter,
         people: calculateSessionPersonTotals(
@@ -389,6 +405,8 @@ export default function Home() {
           nextOuter
         ),
       };
+      stateRef.current = next;
+      return next;
     });
   };
 
@@ -503,53 +521,25 @@ export default function Home() {
     }
   };
 
-  // Split all unassigned items evenly among all people
-  const splitAllItemsEvenly = () => {
-    if (state.receipts.length === 0 || state.people.length === 0) return;
-
+  // Split unassigned items on one receipt evenly among all people
+  const splitItemsEvenlyForReceipt = (receiptId: string) => {
     setState((prevState) => {
-      const receiptId = prevState.receipts[0]?.id;
-      const receipt = prevState.receipts[0]?.receipt;
-      if (!receiptId || !receipt) return prevState;
+      const stored = prevState.receipts.find((r) => r.id === receiptId);
+      if (!stored || prevState.people.length === 0) return prevState;
 
       const inner = new Map(prevState.assignedItems.get(receiptId) ?? []);
-      const currentlyUnassigned = getUnassignedItems(receipt, inner);
+      const currentlyUnassigned = getUnassignedItems(stored.receipt, inner);
 
-      // No unassigned items — nothing to do
       if (currentlyUnassigned.length === 0) {
         toast.info("No unassigned items to split evenly!");
         return prevState;
       }
 
-      // Calculate equal share percentage with 2 decimal places
-      const equalShare = +(100 / prevState.people.length).toFixed(2);
-
-      // Only split unassigned items, preserving existing assignments
+      const equalAssignments = distributeEqualShares(
+        prevState.people.map((p) => p.id)
+      );
       currentlyUnassigned.forEach((itemIndex) => {
-        // Create assignments for all people
-        const assignments: PersonItemAssignment[] = [];
-
-        // Calculate the sum to ensure it adds up to exactly 100%
-        let runningSum = 0;
-
-        prevState.people.forEach((person, personIndex) => {
-          // For the last person, ensure the total is exactly 100%
-          if (personIndex === prevState.people.length - 1) {
-            const lastShare = +(100 - runningSum).toFixed(2);
-            assignments.push({
-              personId: person.id,
-              sharePercentage: lastShare,
-            });
-          } else {
-            assignments.push({
-              personId: person.id,
-              sharePercentage: equalShare,
-            });
-            runningSum += equalShare;
-          }
-        });
-
-        inner.set(itemIndex, assignments);
+        inner.set(itemIndex, equalAssignments.map((a) => ({ ...a })));
       });
 
       const nextOuter = new Map(prevState.assignedItems);
@@ -557,7 +547,7 @@ export default function Home() {
 
       toast.success("All items split evenly among everyone!");
 
-      return {
+      const next = {
         ...prevState,
         assignedItems: nextOuter,
         people: calculateSessionPersonTotals(
@@ -566,10 +556,9 @@ export default function Home() {
           nextOuter
         ),
       };
+      stateRef.current = next;
+      return next;
     });
-
-    // Don't automatically move to results tab anymore
-    // setActiveTab("results");
   };
 
   const hasReceipt = state.receipts.length > 0;
@@ -659,26 +648,15 @@ export default function Home() {
             </TabsTrigger>
           </TabsList>
 
-          {activeReceipt && (
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 w-full">
-              <div className="flex items-center gap-2 w-full sm:w-auto">
-                <Progress
-                  value={calculateProgress()}
-                  className="w-full sm:w-48"
-                />
-                <span className="text-sm whitespace-nowrap w-12">
-                  {Math.round(calculateProgress())}%
-                </span>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={splitAllItemsEvenly}
-                disabled={state.people.length === 0}
-                className="whitespace-nowrap w-full sm:w-auto"
-              >
-                Split All Evenly
-              </Button>
+          {hasReceipt && (
+            <div className="flex items-center gap-2 w-full sm:w-auto">
+              <Progress
+                value={calculateProgress()}
+                className="w-full sm:w-48"
+              />
+              <span className="text-sm whitespace-nowrap w-12">
+                {Math.round(calculateProgress())}%
+              </span>
             </div>
           )}
         </div>
@@ -724,19 +702,29 @@ export default function Home() {
         </TabsContent>
 
         <TabsContent value="assign" className="space-y-6">
-          {activeReceipt && activeId && (
-            <ItemAssignment
-              receipt={activeReceipt}
-              people={state.people}
-              groups={state.groups}
-              assignedItems={activeAssignments}
-              unassignedItems={unassignedItems}
-              onAssignItems={handleAssignItems}
-              onReceiptUpdate={(receipt, remapped) =>
-                handleReceiptUpdate(activeId, receipt, remapped)
-              }
-            />
-          )}
+          {state.receipts.map((stored, index) => {
+            const inner = state.assignedItems.get(stored.id) ?? new Map();
+            const unassigned = getUnassignedItems(stored.receipt, inner);
+            return (
+              <ItemAssignment
+                key={stored.id}
+                receipt={stored.receipt}
+                title={stored.receipt.restaurant || "Untitled receipt"}
+                subtitle={getAssignCardSubtitle(state.receipts, index)}
+                people={state.people}
+                groups={state.groups}
+                assignedItems={inner}
+                unassignedItems={unassigned}
+                onAssignItems={(itemIndex, assignments) =>
+                  handleAssignItems(stored.id, itemIndex, assignments)
+                }
+                onReceiptUpdate={(receipt, remapped) =>
+                  handleReceiptUpdate(stored.id, receipt, remapped)
+                }
+                onSplitEvenly={() => splitItemsEvenlyForReceipt(stored.id)}
+              />
+            );
+          })}
         </TabsContent>
 
         <TabsContent value="results" className="space-y-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,6 @@ import {
 } from "@/lib/receipt-utils";
 import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
 import {
-  receiptDisplayName,
   receiptRestaurantName,
   receiptSubtitle,
 } from "@/lib/receipt-labels";
@@ -534,7 +533,7 @@ export default function Home() {
       nextOuter.set(receiptId, inner);
 
       toast.success(
-        `Split remaining items on ${receiptDisplayName(stored, prevState.receipts)}.`
+        `Split remaining items on ${receiptRestaurantName(stored)}.`
       );
 
       const next = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,6 @@ import {
   type PersonItemAssignment,
   type ReceiptState,
   type Group,
-  type StoredReceipt,
 } from "@/types";
 import {
   getUnassignedItems,
@@ -36,6 +35,11 @@ import {
   distributeEqualShares,
 } from "@/lib/receipt-utils";
 import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
+import {
+  receiptDisplayName,
+  receiptRestaurantName,
+  receiptSubtitle,
+} from "@/lib/receipt-labels";
 import {
   getUniqueGroupEmoji,
   getRandomGroupEmojiExcluding,
@@ -158,22 +162,6 @@ function updateReceiptInState(
       nextOuter
     ),
   };
-}
-
-function getAssignCardSubtitle(
-  receipts: StoredReceipt[],
-  index: number
-): string | undefined {
-  const stored = receipts[index];
-  const name = stored.receipt.restaurant || "Untitled receipt";
-  const isDuplicate =
-    receipts.filter(
-      (r) => (r.receipt.restaurant || "Untitled receipt") === name
-    ).length > 1;
-  if (isDuplicate) {
-    return `#${index + 1}`;
-  }
-  return stored.receipt.date || undefined;
 }
 
 export default function Home() {
@@ -545,7 +533,9 @@ export default function Home() {
       const nextOuter = new Map(prevState.assignedItems);
       nextOuter.set(receiptId, inner);
 
-      toast.success("All items split evenly among everyone!");
+      toast.success(
+        `Split remaining items on ${receiptDisplayName(stored, prevState.receipts)}.`
+      );
 
       const next = {
         ...prevState,
@@ -702,15 +692,15 @@ export default function Home() {
         </TabsContent>
 
         <TabsContent value="assign" className="space-y-6">
-          {state.receipts.map((stored, index) => {
+          {state.receipts.map((stored) => {
             const inner = state.assignedItems.get(stored.id) ?? new Map();
             const unassigned = getUnassignedItems(stored.receipt, inner);
             return (
               <ItemAssignment
                 key={stored.id}
                 receipt={stored.receipt}
-                title={stored.receipt.restaurant || "Untitled receipt"}
-                subtitle={getAssignCardSubtitle(state.receipts, index)}
+                title={receiptRestaurantName(stored)}
+                subtitle={receiptSubtitle(stored, state.receipts)}
                 people={state.people}
                 groups={state.groups}
                 assignedItems={inner}

--- a/src/components/item-assignment.test.tsx
+++ b/src/components/item-assignment.test.tsx
@@ -533,4 +533,88 @@ describe("ItemAssignment", () => {
       expect(toast.success).toHaveBeenCalledWith("Item updated successfully");
     });
   });
+
+  describe("Split evenly button", () => {
+    it("is not rendered when onSplitEvenly is omitted", () => {
+      render(
+        <ItemAssignment
+          receipt={mockReceipt}
+          people={mockPeople}
+          assignedItems={new Map()}
+          unassignedItems={[0, 1]}
+          onAssignItems={jest.fn()}
+          onReceiptUpdate={jest.fn()}
+        />
+      );
+      expect(
+        screen.queryByRole("button", { name: /split evenly/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("calls onSplitEvenly when clicked", () => {
+      const onSplitEvenly = jest.fn();
+      render(
+        <ItemAssignment
+          receipt={mockReceipt}
+          people={mockPeople}
+          assignedItems={new Map()}
+          unassignedItems={[0, 1]}
+          onAssignItems={jest.fn()}
+          onReceiptUpdate={jest.fn()}
+          onSplitEvenly={onSplitEvenly}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /split evenly/i }));
+      expect(onSplitEvenly).toHaveBeenCalledTimes(1);
+    });
+
+    it("is disabled when there are no people", () => {
+      render(
+        <ItemAssignment
+          receipt={mockReceipt}
+          people={[]}
+          assignedItems={new Map()}
+          unassignedItems={[0]}
+          onAssignItems={jest.fn()}
+          onReceiptUpdate={jest.fn()}
+          onSplitEvenly={jest.fn()}
+        />
+      );
+      expect(screen.getByRole("button", { name: /split evenly/i })).toBeDisabled();
+    });
+
+    it("is disabled when there are no unassigned items", () => {
+      render(
+        <ItemAssignment
+          receipt={mockReceipt}
+          people={mockPeople}
+          assignedItems={mockAssignedItems}
+          unassignedItems={[]}
+          onAssignItems={jest.fn()}
+          onReceiptUpdate={jest.fn()}
+          onSplitEvenly={jest.fn()}
+        />
+      );
+      expect(screen.getByRole("button", { name: /split evenly/i })).toBeDisabled();
+    });
+
+    it("renders title and subtitle on the card header", () => {
+      render(
+        <ItemAssignment
+          receipt={mockReceipt}
+          people={mockPeople}
+          assignedItems={new Map()}
+          unassignedItems={[0, 1]}
+          title="Starbucks"
+          subtitle="#2"
+          onAssignItems={jest.fn()}
+          onReceiptUpdate={jest.fn()}
+          onSplitEvenly={jest.fn()}
+        />
+      );
+      expect(screen.getByText("Starbucks")).toBeInTheDocument();
+      expect(screen.getByText("#2")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/item-assignment.test.tsx
+++ b/src/components/item-assignment.test.tsx
@@ -607,14 +607,14 @@ describe("ItemAssignment", () => {
           assignedItems={new Map()}
           unassignedItems={[0, 1]}
           title="Starbucks"
-          subtitle="#2"
+          subtitle="2024-01-01 · #2"
           onAssignItems={jest.fn()}
           onReceiptUpdate={jest.fn()}
           onSplitEvenly={jest.fn()}
         />
       );
       expect(screen.getByText("Starbucks")).toBeInTheDocument();
-      expect(screen.getByText("#2")).toBeInTheDocument();
+      expect(screen.getByText("2024-01-01 · #2")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/item-assignment.tsx
+++ b/src/components/item-assignment.tsx
@@ -1,7 +1,13 @@
 import { useState, useEffect } from "react";
 import { Check, AlertCircle, Pencil, Trash2, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Table,
   TableHeader,
@@ -40,6 +46,9 @@ interface ItemAssignmentProps {
   groups?: Group[];
   assignedItems: Map<number, PersonItemAssignment[]>;
   unassignedItems: number[];
+  title?: string;
+  subtitle?: string;
+  onSplitEvenly?: () => void;
   onAssignItems: (
     itemIndex: number,
     assignments: PersonItemAssignment[]
@@ -56,6 +65,9 @@ export function ItemAssignment({
   groups = [],
   assignedItems,
   unassignedItems,
+  title = receipt.restaurant || "Untitled receipt",
+  subtitle,
+  onSplitEvenly,
   onAssignItems,
   onReceiptUpdate,
 }: ItemAssignmentProps) {
@@ -292,12 +304,27 @@ export function ItemAssignment({
 
   return (
     <Card className="w-full">
-      <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle className="text-xl">Assign Items</CardTitle>
-        <Button variant="outline" size="sm" onClick={handleAddItem}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add Item
-        </Button>
+      <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 space-y-1">
+          <CardTitle className="text-xl">{title}</CardTitle>
+          {subtitle ? <CardDescription>{subtitle}</CardDescription> : null}
+        </div>
+        <div className="flex flex-shrink-0 flex-wrap items-center justify-end gap-2">
+          {onSplitEvenly ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onSplitEvenly}
+              disabled={people.length === 0 || unassignedItems.length === 0}
+            >
+              Split evenly
+            </Button>
+          ) : null}
+          <Button variant="outline" size="sm" onClick={handleAddItem}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add Item
+          </Button>
+        </div>
       </CardHeader>
 
       <CardContent>

--- a/src/components/parsed-receipts-list.test.tsx
+++ b/src/components/parsed-receipts-list.test.tsx
@@ -1,49 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import {
-  ParsedReceiptsList,
-  receiptDisplayName,
-} from "./parsed-receipts-list";
+import { ParsedReceiptsList } from "./parsed-receipts-list";
 import { createMockReceipt, createStoredReceipt } from "@/test/test-utils";
-
-describe("receiptDisplayName", () => {
-  it("falls back to Untitled receipt", () => {
-    const stored = createStoredReceipt(
-      createMockReceipt({ restaurant: null }),
-      "a"
-    );
-    expect(receiptDisplayName(stored, [stored])).toBe("Untitled receipt");
-  });
-
-  it("uses date to distinguish two receipts with the same name", () => {
-    const first = createStoredReceipt(
-      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
-      "a"
-    );
-    const second = createStoredReceipt(
-      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-02" }),
-      "b"
-    );
-    expect(receiptDisplayName(first, [first, second])).toBe(
-      "Starbucks · 2024-01-01"
-    );
-    expect(receiptDisplayName(second, [first, second])).toBe(
-      "Starbucks · 2024-01-02"
-    );
-  });
-
-  it("uses a short index when name and date both collide", () => {
-    const first = createStoredReceipt(
-      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
-      "a"
-    );
-    const second = createStoredReceipt(
-      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
-      "b"
-    );
-    expect(receiptDisplayName(first, [first, second])).toBe("Starbucks (1)");
-    expect(receiptDisplayName(second, [first, second])).toBe("Starbucks (2)");
-  });
-});
 
 describe("ParsedReceiptsList", () => {
   it("renders restaurant, date, item count, total, and currency", () => {
@@ -119,5 +76,31 @@ describe("ParsedReceiptsList", () => {
     fireEvent.click(screen.getByRole("button", { name: /remove cafe/i }));
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
     expect(onRemoveReceipt).not.toHaveBeenCalled();
+  });
+
+  it("keeps the date and adds #n when restaurant names collide", () => {
+    const morning = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const evening = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "b"
+    );
+
+    render(
+      <ParsedReceiptsList
+        receipts={[morning, evening]}
+        onReceiptUpdate={jest.fn()}
+        onRemoveReceipt={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText("Starbucks · 2024-01-01 · #1")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Starbucks · 2024-01-01 · #2")
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/parsed-receipts-list.tsx
+++ b/src/components/parsed-receipts-list.tsx
@@ -13,37 +13,13 @@ import {
 import { ReceiptDetails } from "@/components/receipt-details";
 import { formatCurrency } from "@/lib/receipt-utils";
 import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
+import { receiptDisplayName } from "@/lib/receipt-labels";
 import { type Receipt, type StoredReceipt } from "@/types";
 
 interface ParsedReceiptsListProps {
   receipts: StoredReceipt[];
   onReceiptUpdate: (receiptId: string, receipt: Receipt) => boolean | void;
   onRemoveReceipt: (receiptId: string) => void;
-}
-
-function untitledName(receipt: StoredReceipt): string {
-  const name = receipt.receipt.restaurant?.trim();
-  return name ? name : "Untitled receipt";
-}
-
-/** Distinguish same-restaurant receipts with date, then a short index. */
-export function receiptDisplayName(
-  stored: StoredReceipt,
-  receipts: StoredReceipt[]
-): string {
-  const name = untitledName(stored);
-  const sameName = receipts.filter((r) => untitledName(r) === name);
-  if (sameName.length <= 1) return name;
-
-  const sameDate = sameName.filter(
-    (r) => r.receipt.date === stored.receipt.date
-  );
-  if (stored.receipt.date && sameDate.length === 1) {
-    return `${name} · ${stored.receipt.date}`;
-  }
-
-  const index = sameName.findIndex((r) => r.id === stored.id) + 1;
-  return `${name} (${index})`;
 }
 
 export function ParsedReceiptsList({

--- a/src/lib/receipt-labels.test.ts
+++ b/src/lib/receipt-labels.test.ts
@@ -75,23 +75,23 @@ describe("receiptSubtitle", () => {
     expect(receiptSubtitle(second, receipts)).toBe("2024-01-02 · #2");
   });
 
-  it("numbers collisions among same-name receipts, not the full list", () => {
-    const other = createStoredReceipt(
-      createMockReceipt({ restaurant: "Alpha", date: "2024-06-01" }),
-      "x"
-    );
-    const first = createStoredReceipt(
-      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+  it("numbers collisions among duplicate titles, not the full list", () => {
+    const coffee1 = createStoredReceipt(
+      createMockReceipt({ restaurant: "Coffee", date: "2024-01-01" }),
       "a"
     );
-    const second = createStoredReceipt(
-      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+    const lunch = createStoredReceipt(
+      createMockReceipt({ restaurant: "Lunch", date: "2024-01-02" }),
+      "x"
+    );
+    const coffee2 = createStoredReceipt(
+      createMockReceipt({ restaurant: "Coffee", date: "2024-01-01" }),
       "b"
     );
-    const receipts = [other, first, second];
-    expect(receiptSubtitle(other, receipts)).toBe("2024-06-01");
-    expect(receiptSubtitle(first, receipts)).toBe("2024-01-01 · #1");
-    expect(receiptSubtitle(second, receipts)).toBe("2024-01-01 · #2");
+    const receipts = [coffee1, lunch, coffee2];
+    expect(receiptSubtitle(lunch, receipts)).toBe("2024-01-02");
+    expect(receiptSubtitle(coffee1, receipts)).toBe("2024-01-01 · #1");
+    expect(receiptSubtitle(coffee2, receipts)).toBe("2024-01-01 · #2");
   });
 
   it("shows only #n when colliding receipts have no date", () => {

--- a/src/lib/receipt-labels.test.ts
+++ b/src/lib/receipt-labels.test.ts
@@ -1,0 +1,168 @@
+import {
+  receiptCollisionNumber,
+  receiptDisplayName,
+  receiptRestaurantName,
+  receiptSubtitle,
+  UNTITLED_RECEIPT_NAME,
+} from "./receipt-labels";
+import { createMockReceipt, createStoredReceipt } from "@/test/test-utils";
+
+describe("receiptRestaurantName", () => {
+  it("returns the restaurant name", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe" }),
+      "a"
+    );
+    expect(receiptRestaurantName(stored)).toBe("Cafe");
+  });
+
+  it("falls back to Untitled receipt for null or blank names", () => {
+    const missing = createStoredReceipt(
+      createMockReceipt({ restaurant: null }),
+      "a"
+    );
+    const blank = createStoredReceipt(
+      createMockReceipt({ restaurant: "   " }),
+      "b"
+    );
+    expect(receiptRestaurantName(missing)).toBe(UNTITLED_RECEIPT_NAME);
+    expect(receiptRestaurantName(blank)).toBe(UNTITLED_RECEIPT_NAME);
+  });
+});
+
+describe("receiptSubtitle", () => {
+  it("shows the date when the restaurant name is unique", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe", date: "2024-03-15" }),
+      "a"
+    );
+    expect(receiptSubtitle(stored, [stored])).toBe("2024-03-15");
+  });
+
+  it("omits the subtitle when a unique receipt has no date", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe", date: null }),
+      "a"
+    );
+    expect(receiptSubtitle(stored, [stored])).toBeUndefined();
+  });
+
+  it("always keeps the date and adds #n when names collide", () => {
+    const morning = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const evening = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "b"
+    );
+    const receipts = [morning, evening];
+    expect(receiptSubtitle(morning, receipts)).toBe("2024-01-01 · #1");
+    expect(receiptSubtitle(evening, receipts)).toBe("2024-01-01 · #2");
+  });
+
+  it("still shows each receipt's date plus #n when collision dates differ", () => {
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-02" }),
+      "b"
+    );
+    const receipts = [first, second];
+    expect(receiptSubtitle(first, receipts)).toBe("2024-01-01 · #1");
+    expect(receiptSubtitle(second, receipts)).toBe("2024-01-02 · #2");
+  });
+
+  it("numbers collisions among same-name receipts, not the full list", () => {
+    const other = createStoredReceipt(
+      createMockReceipt({ restaurant: "Alpha", date: "2024-06-01" }),
+      "x"
+    );
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "b"
+    );
+    const receipts = [other, first, second];
+    expect(receiptSubtitle(other, receipts)).toBe("2024-06-01");
+    expect(receiptSubtitle(first, receipts)).toBe("2024-01-01 · #1");
+    expect(receiptSubtitle(second, receipts)).toBe("2024-01-01 · #2");
+  });
+
+  it("shows only #n when colliding receipts have no date", () => {
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: null }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: null }),
+      "b"
+    );
+    expect(receiptSubtitle(first, [first, second])).toBe("#1");
+    expect(receiptSubtitle(second, [first, second])).toBe("#2");
+  });
+});
+
+describe("receiptDisplayName", () => {
+  it("falls back to Untitled receipt", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: null }),
+      "a"
+    );
+    expect(receiptDisplayName(stored, [stored])).toBe(UNTITLED_RECEIPT_NAME);
+  });
+
+  it("uses the restaurant name when it is unique", () => {
+    const stored = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe", date: "2024-03-15" }),
+      "a"
+    );
+    expect(receiptDisplayName(stored, [stored])).toBe("Cafe");
+  });
+
+  it("adds date and #n when names collide", () => {
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-02" }),
+      "b"
+    );
+    expect(receiptDisplayName(first, [first, second])).toBe(
+      "Starbucks · 2024-01-01 · #1"
+    );
+    expect(receiptDisplayName(second, [first, second])).toBe(
+      "Starbucks · 2024-01-02 · #2"
+    );
+  });
+
+  it("keeps the date and adds #n when name and date both collide", () => {
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "a"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Starbucks", date: "2024-01-01" }),
+      "b"
+    );
+    expect(receiptDisplayName(first, [first, second])).toBe(
+      "Starbucks · 2024-01-01 · #1"
+    );
+    expect(receiptDisplayName(second, [first, second])).toBe(
+      "Starbucks · 2024-01-01 · #2"
+    );
+  });
+});
+
+describe("receiptCollisionNumber", () => {
+  it("is null when the name is unique", () => {
+    const stored = createStoredReceipt(createMockReceipt(), "a");
+    expect(receiptCollisionNumber(stored, [stored])).toBeNull();
+  });
+});

--- a/src/lib/receipt-labels.ts
+++ b/src/lib/receipt-labels.ts
@@ -1,0 +1,56 @@
+import { type StoredReceipt } from "@/types";
+
+export const UNTITLED_RECEIPT_NAME = "Untitled receipt";
+
+export function receiptRestaurantName(stored: StoredReceipt): string {
+  const name = stored.receipt.restaurant?.trim();
+  return name ? name : UNTITLED_RECEIPT_NAME;
+}
+
+function sameRestaurantReceipts(
+  stored: StoredReceipt,
+  receipts: StoredReceipt[]
+): StoredReceipt[] {
+  const name = receiptRestaurantName(stored);
+  return receipts.filter((r) => receiptRestaurantName(r) === name);
+}
+
+/** 1-based index among same-name receipts, or null when the name is unique. */
+export function receiptCollisionNumber(
+  stored: StoredReceipt,
+  receipts: StoredReceipt[]
+): number | null {
+  const same = sameRestaurantReceipts(stored, receipts);
+  if (same.length <= 1) return null;
+  return same.findIndex((r) => r.id === stored.id) + 1;
+}
+
+/**
+ * Card subtitle: always the date when present; append #n only when names collide.
+ * Examples: "2024-01-01", "#2", "2024-01-01 · #2"
+ */
+export function receiptSubtitle(
+  stored: StoredReceipt,
+  receipts: StoredReceipt[]
+): string | undefined {
+  const parts: string[] = [];
+  if (stored.receipt.date) parts.push(stored.receipt.date);
+  const n = receiptCollisionNumber(stored, receipts);
+  if (n != null) parts.push(`#${n}`);
+  return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
+/**
+ * Combined label for lists, toasts, results, and copy.
+ * Unique names stay as the restaurant. Collisions add date (when present) and #n.
+ * Examples: "Starbucks", "Starbucks · #2", "Starbucks · 2024-01-01 · #2"
+ */
+export function receiptDisplayName(
+  stored: StoredReceipt,
+  receipts: StoredReceipt[]
+): string {
+  const name = receiptRestaurantName(stored);
+  if (receiptCollisionNumber(stored, receipts) == null) return name;
+  const extra = receiptSubtitle(stored, receipts);
+  return extra ? `${name} · ${extra}` : name;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #139. Stacked on #151 (rebased onto `main` after #149 merged).

## Summary

The Assign Items tab renders one card per receipt. Split evenly is per-card. Progress aggregates across the session.

## Behavior

- Each `ItemAssignment` is still a single-receipt card; `page.tsx` maps `state.receipts`.
- Card title is the restaurant (fallback Untitled). Subtitle always shows the date when one exists, and adds `#n` only when titles collide. `#n` is counted among the duplicates (Coffee, Lunch, Coffee → `#1` and `#2`), not the full list index.
- Split evenly on receipt A does not touch receipt B. Success toast: `Split remaining items on {restaurant}.` (Untitled receipt if unnamed). If nothing was unassigned, the existing info toast is kept — not a success.
- Page-level Split All Evenly is removed.
- Results grand-total table was unchanged here; per-receipt results are #153.

## Restaurant labels

Date + `#n` collision logic lives in `src/lib/receipt-labels.ts` (`receiptSubtitle` / `receiptDisplayName`) so later stack PRs (results/copy) inherit the same wording after rebase.

## Stack

1. #149 — Data model (merged)
2. #151 — Multi-file upload
3. **This PR — Per-receipt assignment cards**
4. #153 — Per-receipt results + aggregate share
5. #154 — Copy and screenshot mocks

Fixes #158 and #159.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

