### PR TITLE
feat: [4/5] per-receipt results and aggregate share note

### DIFF
--- a/e2e/capture-screenshots.spec.ts
+++ b/e2e/capture-screenshots.spec.ts
@@ -1,95 +1,148 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * v1 of this harness waited for "Split Validation Issues" on a single-receipt
+ * session with incomplete assignments. After multi-receipt Results gating, that
+ * copy never appears: unassigned items bounce off Results, and a complete
+ * 2-receipt day shows Day total / By receipt instead.
+ */
+const MOCK_COFFEE_ID = "receipt-coffee";
+const MOCK_LUNCH_ID = "receipt-lunch";
 
 const MOCK_STATE = {
+  version: 2,
   state: {
-    originalReceipt: {
-      id: "receipt-123",
-      restaurant: "Screenshot Cafe",
-      date: "2025-12-25",
-      subtotal: 50.00,
-      tax: 5.00,
-      tip: 10.00,
-      total: 65.00,
-      items: [
-        { name: "Burger", price: 15.00, quantity: 1 },
-        { name: "Fries", price: -5.00, quantity: 1 }, // Negative price error
-        { name: "Soda", price: 3.00, quantity: 2 },
-        { name: "Salad", price: 12.00, quantity: 1 }
-      ]
-    },
+    receipts: [
+      {
+        id: MOCK_COFFEE_ID,
+        receipt: {
+          restaurant: "Coffee",
+          date: "2024-01-15",
+          subtotal: 10.0,
+          tax: 1.0,
+          tip: 2.0,
+          total: 13.0,
+          currency: "USD",
+          items: [
+            { name: "Latte", price: 5.0, quantity: 1 },
+            { name: "Muffin", price: 5.0, quantity: 1 },
+          ],
+        },
+      },
+      {
+        id: MOCK_LUNCH_ID,
+        receipt: {
+          restaurant: "Lunch",
+          date: "2024-01-15",
+          subtotal: 20.0,
+          tax: 2.0,
+          tip: 4.0,
+          total: 26.0,
+          currency: "USD",
+          items: [
+            { name: "Burger", price: 10.0, quantity: 1 },
+            { name: "Fries", price: 10.0, quantity: 1 },
+          ],
+        },
+      },
+    ],
     people: [
-      { id: "p1", name: "Alice", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 },
-      { id: "p2", name: "Bob", items: [], totalBeforeTax: 0, tax: 0, tip: 0, finalTotal: 0 }
+      {
+        id: "p1",
+        name: "Alice",
+        items: [],
+        totalBeforeTax: 15,
+        tax: 1.5,
+        tip: 3,
+        finalTotal: 19.5,
+      },
+      {
+        id: "p2",
+        name: "Bob",
+        items: [],
+        totalBeforeTax: 15,
+        tax: 1.5,
+        tip: 3,
+        finalTotal: 19.5,
+      },
     ],
-    // Mismatched assignments: Sum of splits won't match item price for Burger
     assignedItems: [
-        [0, [{ personId: "p1", sharePercentage: 50 }]], // Only 50% assigned (Mismatch)
-        [1, [{ personId: "p2", sharePercentage: 100 }]],
-        [2, [{ personId: "p1", sharePercentage: 100 }]],
-        [3, [{ personId: "p2", sharePercentage: 100 }]]
+      [
+        MOCK_COFFEE_ID,
+        [
+          [0, [{ personId: "p1", sharePercentage: 100 }]],
+          [1, [{ personId: "p2", sharePercentage: 100 }]],
+        ],
+      ],
+      [
+        MOCK_LUNCH_ID,
+        [
+          [0, [{ personId: "p1", sharePercentage: 100 }]],
+          [1, [{ personId: "p2", sharePercentage: 100 }]],
+        ],
+      ],
     ],
-    unassignedItems: [],
     groups: [],
     isLoading: false,
     error: null,
   },
-  activeTab: "results"
+  activeTab: "results",
 };
 
-test('Capture validation screenshots', async ({ page }) => {
-  // 1. Set up local storage with the invalid state
+async function seedResultsSession(page: Page) {
   await page.addInitScript((value) => {
-    window.localStorage.setItem('receiptSplitterSession', JSON.stringify(value));
+    window.localStorage.setItem(
+      "receiptSplitterSession",
+      JSON.stringify(value),
+    );
   }, MOCK_STATE);
+}
 
-  // 2. Go to the page (it should load directly into the results tab due to activeTab: "results")
-  await page.goto('/');
+async function expectGatedMultiReceiptResults(page: Page) {
+  await expect(page.getByRole("tab", { name: /results/i })).toHaveAttribute(
+    "data-state",
+    "active",
+    { timeout: 10000 },
+  );
+  await expect(page.getByRole("heading", { name: "Day total" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "By receipt" })).toBeVisible();
+}
 
-  // Wait for content to load
-  await page.waitForSelector('text=Split Validation Issues');
+test("Capture validation screenshots", async ({ page }) => {
+  await seedResultsSession(page);
+  await page.goto("/");
+  await expectGatedMultiReceiptResults(page);
 
-  // --- Screenshot 1: Validation Errors Component (Desktop) ---
-  const errorCard = page.locator('[class*="border-yellow-500/50"]');
-  await errorCard.screenshot({ path: 'screenshots/validation-errors-desktop.png' });
+  const dayTotal = page.getByTestId("day-total");
+  await dayTotal.screenshot({ path: "screenshots/validation-errors-desktop.png" });
 
-  // --- Screenshot 2: Full Results View (Desktop) ---
-  await page.screenshot({ path: 'screenshots/full-results-desktop.png', fullPage: true });
+  await page.screenshot({ path: "screenshots/full-results-desktop.png", fullPage: true });
 
-  // --- Screenshot 3: Disabled Share Button / Warning ---
-  // We need to scroll to the share button or capture that specific area
-  // The share button is in the ResultsSummary component
-  const shareSection = page.locator('text=Your Phone Number').locator('..').locator('..');
-  // Optional: Click it to trigger toast if possible, but static screenshot of disabled state is good.
-  // In the current code, the button isn't disabled via attribute but shows an error on click if invalid.
-  // Actually, looking at the code: disabled={!canShareSplit ...} 
-  // and canShareSplit checks validationResult.isValid. So it SHOULD be disabled.
-  // Let's check if it is disabled.
-  const shareButton = page.getByRole('button', { name: 'Share Split' });
+  const shareSection = page
+    .locator("text=Your Phone Number")
+    .locator("..")
+    .locator("..");
+  // Share Split stays disabled until a 10-digit Venmo phone is entered.
+  const shareButton = page.getByRole("button", { name: "Share Split" });
   await expect(shareButton).toBeDisabled();
-  await shareSection.screenshot({ path: 'screenshots/share-section-disabled.png' });
+  await shareSection.screenshot({ path: "screenshots/share-section-disabled.png" });
 
-  // --- Screenshot 4: Dark Mode ---
-  // Toggle dark mode. Since I don't see a clear toggle in the snippets, I'll emulate media.
-  await page.emulateMedia({ colorScheme: 'dark' });
-  await page.reload(); // Reload to ensure theme applies if it's JS based, or just wait.
-  // If the app uses 'next-themes' system preference might be enough.
-  await page.waitForTimeout(1000); 
-  await errorCard.screenshot({ path: 'screenshots/validation-errors-dark.png' });
-
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.reload();
+  await expectGatedMultiReceiptResults(page);
+  await page.getByTestId("day-total").screenshot({
+    path: "screenshots/validation-errors-dark.png",
+  });
 });
 
-test('Capture mobile screenshots', async ({ page }) => {
-  // Set viewport to mobile
+test("Capture mobile screenshots", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 667 });
 
-  await page.addInitScript((value) => {
-    window.localStorage.setItem('receiptSplitterSession', JSON.stringify(value));
-  }, MOCK_STATE);
+  await seedResultsSession(page);
+  await page.goto("/");
+  await expectGatedMultiReceiptResults(page);
 
-  await page.goto('/');
-  await page.waitForSelector('text=Split Validation Issues');
-
-  // --- Screenshot 5: Validation Errors (Mobile) ---
-  const errorCard = page.locator('[class*="border-yellow-500/50"]');
-  await errorCard.screenshot({ path: 'screenshots/validation-errors-mobile.png' });
+  await page.getByTestId("day-total").screenshot({
+    path: "screenshots/validation-errors-mobile.png",
+  });
 });

--- a/e2e/capture-screenshots.spec.ts
+++ b/e2e/capture-screenshots.spec.ts
@@ -99,12 +99,11 @@ async function seedResultsSession(page: Page) {
 }
 
 async function expectGatedMultiReceiptResults(page: Page) {
-  await expect(page.getByRole("tab", { name: /results/i })).toHaveAttribute(
-    "data-state",
-    "active",
-    { timeout: 10000 },
-  );
-  await expect(page.getByRole("heading", { name: "Day total" })).toBeVisible();
+  // On narrow viewports the Results tab label is icon-only, so assert on the
+  // copy that only renders after a fully assigned multi-receipt restore.
+  await expect(page.getByRole("heading", { name: "Day total" })).toBeVisible({
+    timeout: 10000,
+  });
   await expect(page.getByRole("heading", { name: "By receipt" })).toBeVisible();
 }
 

--- a/e2e/empty-states.spec.ts
+++ b/e2e/empty-states.spec.ts
@@ -60,7 +60,8 @@ test.describe("empty states", () => {
     await expect(page.getByText("100%")).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Next", exact: true }),
-    ).toBeDisabled();
+    ).toBeEnabled();
+    await expect(page.getByRole("tab", { name: /results/i })).toBeEnabled();
   });
 
   test("Next stays disabled until all items are assigned", async ({ page }) => {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -717,4 +717,57 @@ describe("Home Page", () => {
       expect(toast.info).not.toHaveBeenCalled();
     });
   });
+
+  describe("multi-receipt results tab", () => {
+    it("shows per-receipt restaurant names and amounts plus a day total", () => {
+      const receiptA = createMockReceipt({
+        restaurant: "Coffee Shop",
+        date: "2024-06-01",
+        items: [{ name: "Latte", price: 20, quantity: 1 }],
+        subtotal: 20,
+        tax: 0,
+        tip: 0,
+        total: 20,
+      });
+      const receiptB = createMockReceipt({
+        restaurant: "Lunch Place",
+        date: "2024-06-01",
+        items: [{ name: "Burger", price: 30, quantity: 1 }],
+        subtotal: 30,
+        tax: 0,
+        tip: 0,
+        total: 30,
+      });
+
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [
+              { id: "r1", receipt: receiptA },
+              { id: "r2", receipt: receiptB },
+            ],
+            people: mockPeople,
+            assignedItems: [
+              ["r1", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+              ["r2", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+            ],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "results",
+        })
+      );
+
+      render(<Home />);
+
+      expect(screen.getByTestId("receipt-breakdown")).toBeInTheDocument();
+      expect(screen.getByText("Coffee Shop")).toBeInTheDocument();
+      expect(screen.getByText("Lunch Place")).toBeInTheDocument();
+      expect(screen.getByText("$20.00")).toBeInTheDocument();
+      expect(screen.getByText("$30.00")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -800,7 +800,7 @@ describe("Home Page", () => {
       expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
     });
 
-    it("shows an incomplete banner if Results is restored with unassigned items", () => {
+    it("keeps Results disabled and leaves Assign when restored with unassigned items", async () => {
       loadResultsSession([
         ["r1", []],
         ["r2", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
@@ -808,16 +808,56 @@ describe("Home Page", () => {
 
       render(<Home />);
 
-      expect(screen.getByRole("tab", { name: /results/i })).toHaveAttribute(
-        "data-state",
-        "active"
-      );
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: /assign items/i })).toHaveAttribute(
+          "data-state",
+          "active"
+        );
+      });
       expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
-      expect(screen.getByTestId("incomplete-assignment-banner")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /share text/i })).not.toBeInTheDocument();
       expect(
-        screen.getByText("Coffee Shop still has 1 unassigned item.")
-      ).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /share text/i })).toBeDisabled();
+        screen.queryByTestId("incomplete-assignment-banner")
+      ).not.toBeInTheDocument();
+    });
+
+    it("treats a 0-item receipt as complete so Results is not trapped", () => {
+      const emptyReceipt = createMockReceipt({
+        restaurant: "Empty Place",
+        date: "2024-06-01",
+        items: [],
+        subtotal: 0,
+        tax: 0,
+        tip: 0,
+        total: 0,
+      });
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [
+              { id: "r1", receipt: receiptA },
+              { id: "r2", receipt: emptyReceipt },
+            ],
+            people: mockPeople,
+            assignedItems: [
+              ["r1", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+              ["r2", []],
+            ],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "assign",
+        })
+      );
+
+      render(<Home />);
+
+      expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /results/i })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /next/i })).toBeEnabled();
     });
   });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -65,6 +65,7 @@ describe("Home Page", () => {
       expect(screen.getByRole("tab", { name: /add people/i })).toHaveAttribute("data-state", "active");
       expect(screen.getByRole("tab", { name: /add people/i })).toBeEnabled();
       expect(screen.getByRole("tab", { name: /assign items/i })).toBeEnabled();
+      expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
     });
 
     it("falls back to empty state on corrupted localStorage", () => {
@@ -145,6 +146,7 @@ describe("Home Page", () => {
       expect(screen.getByRole("tab", { name: /add people/i })).toHaveAttribute("data-state", "active");
       expect(screen.getByRole("tab", { name: /add people/i })).toBeEnabled();
       expect(screen.getByRole("tab", { name: /assign items/i })).toBeEnabled();
+      expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
     });
   });
 
@@ -207,6 +209,7 @@ describe("Home Page", () => {
       });
       render(<Home />);
       expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /results/i })).toBeEnabled();
     });
   });
 
@@ -228,6 +231,7 @@ describe("Home Page", () => {
       );
       expect(toast.info).not.toHaveBeenCalled();
       expect(screen.getByText("100%")).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /results/i })).toBeEnabled();
     });
 
     it("uses Untitled receipt in the toast when the restaurant has no name", () => {
@@ -719,26 +723,26 @@ describe("Home Page", () => {
   });
 
   describe("multi-receipt results tab", () => {
-    it("shows per-receipt restaurant names and amounts plus a day total", () => {
-      const receiptA = createMockReceipt({
-        restaurant: "Coffee Shop",
-        date: "2024-06-01",
-        items: [{ name: "Latte", price: 20, quantity: 1 }],
-        subtotal: 20,
-        tax: 0,
-        tip: 0,
-        total: 20,
-      });
-      const receiptB = createMockReceipt({
-        restaurant: "Lunch Place",
-        date: "2024-06-01",
-        items: [{ name: "Burger", price: 30, quantity: 1 }],
-        subtotal: 30,
-        tax: 0,
-        tip: 0,
-        total: 30,
-      });
+    const receiptA = createMockReceipt({
+      restaurant: "Coffee Shop",
+      date: "2024-06-01",
+      items: [{ name: "Latte", price: 20, quantity: 1 }],
+      subtotal: 20,
+      tax: 0,
+      tip: 0,
+      total: 20,
+    });
+    const receiptB = createMockReceipt({
+      restaurant: "Lunch Place",
+      date: "2024-06-01",
+      items: [{ name: "Burger", price: 30, quantity: 1 }],
+      subtotal: 30,
+      tax: 0,
+      tip: 0,
+      total: 30,
+    });
 
+    function loadResultsSession(assignedItems: unknown, activeTab = "results") {
       localStorage.setItem(
         "receiptSplitterSession",
         JSON.stringify({
@@ -749,25 +753,71 @@ describe("Home Page", () => {
               { id: "r2", receipt: receiptB },
             ],
             people: mockPeople,
-            assignedItems: [
-              ["r1", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
-              ["r2", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
-            ],
+            assignedItems,
             groups: [],
             isLoading: false,
             error: null,
           },
-          activeTab: "results",
+          activeTab,
         })
       );
+    }
+
+    it("shows Day total first, then By receipt with restaurant and date", () => {
+      loadResultsSession([
+        ["r1", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+        ["r2", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+      ]);
 
       render(<Home />);
 
-      expect(screen.getByTestId("receipt-breakdown")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Day total" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "By receipt" })).toBeInTheDocument();
+      expect(
+        screen.getByTestId("day-total").compareDocumentPosition(
+          screen.getByTestId("receipt-breakdown")
+        ) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(screen.getByText("Coffee Shop")).toBeInTheDocument();
       expect(screen.getByText("Lunch Place")).toBeInTheDocument();
       expect(screen.getByText("$20.00")).toBeInTheDocument();
       expect(screen.getByText("$30.00")).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /results/i })).toBeEnabled();
+    });
+
+    it("disables Results until every receipt is assigned", () => {
+      loadResultsSession(
+        [
+          ["r1", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+          ["r2", []],
+        ],
+        "assign"
+      );
+
+      render(<Home />);
+
+      expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+    });
+
+    it("shows an incomplete banner if Results is restored with unassigned items", () => {
+      loadResultsSession([
+        ["r1", []],
+        ["r2", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+      ]);
+
+      render(<Home />);
+
+      expect(screen.getByRole("tab", { name: /results/i })).toHaveAttribute(
+        "data-state",
+        "active"
+      );
+      expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
+      expect(screen.getByTestId("incomplete-assignment-banner")).toBeInTheDocument();
+      expect(
+        screen.getByText("Coffee Shop still has 1 unassigned item.")
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /share text/i })).toBeDisabled();
     });
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,7 @@ import {
 import {
   getUnassignedItems,
   getSessionUnassigned,
+  getUnassignedReceiptSummaries,
   calculateSessionPersonTotals,
   calculatePerReceiptPersonTotals,
   sessionShareNote,
@@ -200,6 +201,11 @@ export default function Home() {
         people,
       })),
     [state.receipts, state.people, state.assignedItems]
+  );
+
+  const unassignedReceipts = useMemo(
+    () => getUnassignedReceiptSummaries(state.receipts, state.assignedItems),
+    [state.receipts, state.assignedItems]
   );
 
   // Restore session from localStorage on mount
@@ -568,6 +574,8 @@ export default function Home() {
   };
 
   const hasReceipt = state.receipts.length > 0;
+  const canViewResults =
+    hasReceipt && state.people.length > 0 && allItemsAssigned;
 
   return (
     <main className="container mx-auto px-4 py-8 max-w-4xl">
@@ -645,7 +653,7 @@ export default function Home() {
             </TabsTrigger>
             <TabsTrigger
               value="results"
-              disabled={!hasReceipt || state.people.length === 0}
+              disabled={!canViewResults}
               className="gap-1.5 sm:gap-2"
             >
               <DollarSign className="h-4 w-4 flex-shrink-0" />
@@ -743,6 +751,7 @@ export default function Home() {
             currencyCode={sessionCurrency(state.receipts)}
             validationResult={validationResult}
             receiptBreakdown={receiptBreakdown}
+            unassignedReceipts={unassignedReceipts}
           />
 
           <PersonItems people={state.people} currencyCode={sessionCurrency(state.receipts)} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,6 @@ import {
 import {
   getUnassignedItems,
   getSessionUnassigned,
-  getUnassignedReceiptSummaries,
   calculateSessionPersonTotals,
   calculatePerReceiptPersonTotals,
   sessionShareNote,
@@ -203,11 +202,6 @@ export default function Home() {
     [state.receipts, state.people, state.assignedItems]
   );
 
-  const unassignedReceipts = useMemo(
-    () => getUnassignedReceiptSummaries(state.receipts, state.assignedItems),
-    [state.receipts, state.assignedItems]
-  );
-
   // Restore session from localStorage on mount
   useEffect(() => {
     const session = safeGetItem(SESSION_STORAGE_KEY);
@@ -215,7 +209,18 @@ export default function Home() {
       const restored = deserializeSession(session);
       if (restored) {
         setState(restored.state);
-        setActiveTab(restored.activeTab || "upload");
+        const restoredTab = restored.activeTab || "upload";
+        const restoredAssigned = validateSessionAssignments(
+          restored.state.receipts,
+          restored.state.assignedItems
+        );
+        if (restoredTab === "results" && !restoredAssigned) {
+          setActiveTab(
+            restored.state.people.length > 0 ? "assign" : "people"
+          );
+        } else {
+          setActiveTab(restoredTab);
+        }
         setHasSession(!isDefaultSession(restored.state, restored.activeTab || "upload"));
       } else {
         setHasSession(false);
@@ -264,6 +269,17 @@ export default function Home() {
     state.receipts,
     state.assignedItems
   );
+
+  useEffect(() => {
+    if (activeTab !== "results" || allItemsAssigned) return;
+    if (state.people.length > 0) {
+      setActiveTab("assign");
+    } else if (state.receipts.length > 0) {
+      setActiveTab("people");
+    } else {
+      setActiveTab("upload");
+    }
+  }, [activeTab, allItemsAssigned, state.people.length, state.receipts.length]);
 
   // Calculate progress across every receipt in the session
   const calculateProgress = (): number => {
@@ -751,7 +767,6 @@ export default function Home() {
             currencyCode={sessionCurrency(state.receipts)}
             validationResult={validationResult}
             receiptBreakdown={receiptBreakdown}
-            unassignedReceipts={unassignedReceipts}
           />
 
           <PersonItems people={state.people} currencyCode={sessionCurrency(state.receipts)} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,9 @@ import {
   getUnassignedItems,
   getSessionUnassigned,
   calculateSessionPersonTotals,
+  calculatePerReceiptPersonTotals,
+  sessionShareNote,
+  sessionShareDate,
   validateSessionAssignments,
   validateSessionInvariants,
   sessionCurrency,
@@ -184,6 +187,20 @@ export default function Home() {
       state.people
     );
   }, [state.receipts, state.assignedItems, state.people]);
+
+  const receiptBreakdown = useMemo(
+    () =>
+      calculatePerReceiptPersonTotals(
+        state.receipts,
+        state.people,
+        state.assignedItems
+      ).map(({ stored, people }) => ({
+        name: stored.receipt.restaurant || "Untitled receipt",
+        date: stored.receipt.date,
+        people,
+      })),
+    [state.receipts, state.people, state.assignedItems]
+  );
 
   // Restore session from localStorage on mount
   useEffect(() => {
@@ -721,13 +738,14 @@ export default function Home() {
 
           <ResultsSummary
             people={state.people}
-            receiptName={activeReceipt?.restaurant || null}
-            receiptDate={activeReceipt?.date || null}
-            currencyCode={activeReceipt?.currency}
+            receiptName={sessionShareNote(state.receipts)}
+            receiptDate={sessionShareDate(state.receipts)}
+            currencyCode={sessionCurrency(state.receipts)}
             validationResult={validationResult}
+            receiptBreakdown={receiptBreakdown}
           />
 
-          <PersonItems people={state.people} currencyCode={activeReceipt?.currency} />
+          <PersonItems people={state.people} currencyCode={sessionCurrency(state.receipts)} />
         </TabsContent>
       </Tabs>
 

--- a/src/components/person-items.test.tsx
+++ b/src/components/person-items.test.tsx
@@ -1,11 +1,87 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { PersonItems } from "./person-items";
 import { mockPeople } from "@/test/test-utils";
+import { type Person, type PersonItem } from "@/types";
+
+function personWithItems(items: PersonItem[], overrides: Partial<Person> = {}): Person {
+  return {
+    ...mockPeople[0],
+    items,
+    totalBeforeTax: items.reduce((sum, item) => sum + item.amount, 0),
+    tax: 1,
+    tip: 2,
+    finalTotal: 20,
+    ...overrides,
+  };
+}
 
 describe("PersonItems", () => {
   it("renders person names", () => {
     render(<PersonItems people={mockPeople} />);
     expect(screen.getByText(/Alice/)).toBeInTheDocument();
     expect(screen.getByText(/Bob/)).toBeInTheDocument();
+  });
+
+  it("groups expanded items by receipt", () => {
+    const people = [
+      personWithItems([
+        {
+          itemId: 0,
+          itemName: "Latte",
+          originalPrice: 5,
+          quantity: 1,
+          sharePercentage: 100,
+          amount: 5,
+          receiptId: "r1",
+          receiptName: "Coffee Shop",
+        },
+        {
+          itemId: 0,
+          itemName: "Burger",
+          originalPrice: 12,
+          quantity: 1,
+          sharePercentage: 100,
+          amount: 12,
+          receiptId: "r2",
+          receiptName: "Lunch Place",
+        },
+      ]),
+    ];
+
+    render(<PersonItems people={people} />);
+    fireEvent.click(screen.getByText("Alice"));
+
+    const headings = screen.getAllByTestId("receipt-group-heading");
+    expect(headings.map((el) => el.textContent)).toEqual([
+      "Coffee Shop",
+      "Lunch Place",
+    ]);
+    expect(screen.getByText("Latte")).toBeInTheDocument();
+    expect(screen.getByText("Burger")).toBeInTheDocument();
+    expect(screen.getByText("Tax")).toBeInTheDocument();
+    expect(screen.getByText("Tip")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
+  });
+
+  it("keeps an ungrouped table when items have no receiptId", () => {
+    const people = [
+      personWithItems([
+        {
+          itemId: 0,
+          itemName: "Burger",
+          originalPrice: 50,
+          quantity: 1,
+          sharePercentage: 100,
+          amount: 50,
+        },
+      ]),
+    ];
+
+    render(<PersonItems people={people} />);
+    fireEvent.click(screen.getByText("Alice"));
+
+    expect(screen.getByText("Burger")).toBeInTheDocument();
+    expect(screen.queryByTestId("receipt-group-heading")).not.toBeInTheDocument();
+    expect(screen.queryByText("Receipt")).not.toBeInTheDocument();
   });
 });

--- a/src/components/person-items.tsx
+++ b/src/components/person-items.tsx
@@ -10,12 +10,51 @@ import {
   TableHead, 
   TableCell 
 } from '@/components/ui/table';
-import { type Person } from '@/types';
+import { type Person, type PersonItem } from '@/types';
 import { formatCurrency } from '@/lib/receipt-utils';
 
 interface PersonItemsProps {
   people: Person[];
   currencyCode?: string;
+}
+
+interface ReceiptItemGroup {
+  id: string;
+  name: string;
+  items: PersonItem[];
+}
+
+function groupItemsByReceipt(items: PersonItem[]): ReceiptItemGroup[] {
+  const groups: ReceiptItemGroup[] = [];
+  const indexById = new Map<string, number>();
+
+  for (const item of items) {
+    const id = item.receiptId ?? item.receiptName ?? "Receipt";
+    const name = item.receiptName || "Receipt";
+    const existing = indexById.get(id);
+    if (existing === undefined) {
+      indexById.set(id, groups.length);
+      groups.push({ id, name, items: [item] });
+    } else {
+      groups[existing].items.push(item);
+    }
+  }
+
+  return groups;
+}
+
+function hasReceiptGrouping(items: PersonItem[]): boolean {
+  return items.some((item) => Boolean(item.receiptId));
+}
+
+function renderItemRows(items: PersonItem[], currencyCode?: string, keyPrefix = "") {
+  return items.map((item, index) => (
+    <TableRow key={`${keyPrefix}${index}`}>
+      <TableCell>{item.itemName}</TableCell>
+      <TableCell className="text-right">{item.sharePercentage}%</TableCell>
+      <TableCell className="text-right">{formatCurrency(item.amount, currencyCode)}</TableCell>
+    </TableRow>
+  ));
 }
 
 export function PersonItems({ people, currencyCode }: PersonItemsProps) {
@@ -41,8 +80,12 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
       </CardHeader>
       
       <CardContent>
-        <div className="space-y-4">
-          {people.map(person => (
+        <div className="flex flex-col gap-4">
+          {people.map(person => {
+            const grouped = hasReceiptGrouping(person.items);
+            const groups = grouped ? groupItemsByReceipt(person.items) : [];
+
+            return (
             <div key={person.id} className="border rounded-md">
               <div 
                 className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted"
@@ -83,13 +126,20 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {person.items.map((item, index) => (
-                          <TableRow key={index}>
-                            <TableCell>{item.itemName}</TableCell>
-                            <TableCell className="text-right">{item.sharePercentage}%</TableCell>
-                            <TableCell className="text-right">{formatCurrency(item.amount, currencyCode)}</TableCell>
-                          </TableRow>
-                        ))}
+                        {grouped
+                          ? groups.flatMap((group) => [
+                              <TableRow key={`${group.id}-heading`}>
+                                <TableCell
+                                  colSpan={3}
+                                  data-testid="receipt-group-heading"
+                                  className="font-medium bg-muted/50"
+                                >
+                                  {group.name}
+                                </TableCell>
+                              </TableRow>,
+                              ...renderItemRows(group.items, currencyCode, `${group.id}-`),
+                            ])
+                          : renderItemRows(person.items, currencyCode)}
                         <TableRow>
                           <TableCell colSpan={2} className="font-medium">Subtotal</TableCell>
                           <TableCell className="text-right">{formatCurrency(person.totalBeforeTax, currencyCode)}</TableCell>
@@ -112,7 +162,8 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
                 </div>
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       </CardContent>
     </Card>

--- a/src/components/results-summary.test.tsx
+++ b/src/components/results-summary.test.tsx
@@ -601,4 +601,88 @@ describe("ResultsSummary", () => {
       expect(rows).toHaveLength(11); // Header + 10 people
     });
   });
+
+  describe("Per-receipt breakdown", () => {
+    const alice = {
+      ...mockPeople[0],
+      name: "Alice",
+      finalTotal: 60,
+    };
+    const coffeePeople = [
+      { ...mockPeople[0], name: "Alice", finalTotal: 25 },
+    ];
+    const lunchPeople = [
+      { ...mockPeople[0], name: "Alice", finalTotal: 35 },
+    ];
+    const twoReceiptBreakdown = [
+      { name: "Coffee Shop", date: "2024-01-01", people: coffeePeople },
+      { name: "Lunch Place", date: "2024-01-01", people: lunchPeople },
+    ];
+
+    it("shows both restaurant names and per-receipt amounts for two receipts", () => {
+      render(
+        <ResultsSummary
+          people={[alice]}
+          receiptName="Coffee Shop, Lunch Place"
+          receiptDate="2024-01-01"
+          receiptBreakdown={twoReceiptBreakdown}
+        />
+      );
+
+      expect(screen.getByTestId("receipt-breakdown")).toBeInTheDocument();
+      expect(screen.getByText("Coffee Shop")).toBeInTheDocument();
+      expect(screen.getByText("Lunch Place")).toBeInTheDocument();
+      expect(screen.getByText("$25.00")).toBeInTheDocument();
+      expect(screen.getByText("$35.00")).toBeInTheDocument();
+      expect(screen.getByText("$60.00")).toBeInTheDocument();
+    });
+
+    it("does not show a per-receipt section for a single receipt", () => {
+      render(
+        <ResultsSummary
+          people={[alice]}
+          receiptName="Coffee Shop"
+          receiptDate="2024-01-01"
+          receiptBreakdown={[twoReceiptBreakdown[0]]}
+        />
+      );
+
+      expect(screen.queryByTestId("receipt-breakdown")).not.toBeInTheDocument();
+      expect(screen.queryByText("Coffee Shop")).not.toBeInTheDocument();
+    });
+
+    it("titles share text with Receipts for when multiple receipts are present", async () => {
+      const originalShare = navigator.share;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (navigator as any).share;
+
+      try {
+        render(
+          <ResultsSummary
+            people={[alice]}
+            receiptName="Coffee Shop, Lunch Place"
+            receiptDate="2024-01-01"
+            receiptBreakdown={twoReceiptBreakdown}
+          />
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: /share text/i }));
+
+        await waitFor(() => {
+          const clipboardContent = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0];
+          expect(clipboardContent).toContain("Receipts for Coffee Shop, Lunch Place");
+          expect(clipboardContent).toContain("Alice:");
+          expect(clipboardContent).toContain("$60.00");
+          expect(clipboardContent).toContain("Coffee Shop:");
+          expect(clipboardContent).toContain("Lunch Place:");
+        });
+      } finally {
+        Object.defineProperty(navigator, "share", {
+          value: originalShare,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+  });
 });

--- a/src/components/results-summary.test.tsx
+++ b/src/components/results-summary.test.tsx
@@ -619,7 +619,7 @@ describe("ResultsSummary", () => {
       { name: "Lunch Place", date: "2024-01-01", people: lunchPeople },
     ];
 
-    it("shows both restaurant names and per-receipt amounts for two receipts", () => {
+    it("shows Day total first, then By receipt with restaurant and date", () => {
       render(
         <ResultsSummary
           people={[alice]}
@@ -629,9 +629,23 @@ describe("ResultsSummary", () => {
         />
       );
 
+      expect(screen.getByRole("heading", { name: "Day total" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "By receipt" })).toBeInTheDocument();
+      expect(screen.getByTestId("day-total")).toBeInTheDocument();
       expect(screen.getByTestId("receipt-breakdown")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("day-total").compareDocumentPosition(
+          screen.getByTestId("receipt-breakdown")
+        ) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(screen.getByText("Coffee Shop")).toBeInTheDocument();
       expect(screen.getByText("Lunch Place")).toBeInTheDocument();
+      expect(screen.getByText("Coffee Shop").parentElement).toHaveTextContent(
+        "Coffee Shop · 2024-01-01"
+      );
+      expect(screen.getByText("Lunch Place").parentElement).toHaveTextContent(
+        "Lunch Place · 2024-01-01"
+      );
       expect(screen.getByText("$25.00")).toBeInTheDocument();
       expect(screen.getByText("$35.00")).toBeInTheDocument();
       expect(screen.getByText("$60.00")).toBeInTheDocument();
@@ -648,6 +662,8 @@ describe("ResultsSummary", () => {
       );
 
       expect(screen.queryByTestId("receipt-breakdown")).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "Day total" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "By receipt" })).not.toBeInTheDocument();
       expect(screen.queryByText("Coffee Shop")).not.toBeInTheDocument();
     });
 
@@ -670,11 +686,13 @@ describe("ResultsSummary", () => {
 
         await waitFor(() => {
           const clipboardContent = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0];
+          expect(clipboardContent).toContain("Day total");
           expect(clipboardContent).toContain("Receipts for Coffee Shop, Lunch Place");
           expect(clipboardContent).toContain("Alice:");
           expect(clipboardContent).toContain("$60.00");
-          expect(clipboardContent).toContain("Coffee Shop:");
-          expect(clipboardContent).toContain("Lunch Place:");
+          expect(clipboardContent).toContain("By receipt");
+          expect(clipboardContent).toContain("Coffee Shop · 2024-01-01:");
+          expect(clipboardContent).toContain("Lunch Place · 2024-01-01:");
         });
       } finally {
         Object.defineProperty(navigator, "share", {
@@ -683,6 +701,66 @@ describe("ResultsSummary", () => {
           configurable: true,
         });
       }
+    });
+  });
+
+  describe("Incomplete assignment", () => {
+    const alice = {
+      ...mockPeople[0],
+      name: "Alice",
+      finalTotal: 35,
+    };
+    const unassignedReceipts = [{ name: "Coffee Shop", count: 4 }];
+
+    it("shows a banner naming receipts that still have unassigned items", () => {
+      render(
+        <ResultsSummary
+          people={[alice]}
+          receiptName="Coffee Shop, Lunch Place"
+          receiptDate="2024-01-01"
+          unassignedReceipts={unassignedReceipts}
+        />
+      );
+
+      expect(screen.getByTestId("incomplete-assignment-banner")).toBeInTheDocument();
+      expect(
+        screen.getByText("Coffee Shop still has 4 unassigned items.")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/this day total is incomplete/i)
+      ).toBeInTheDocument();
+    });
+
+    it("disables Share Text and Share Split so a partial total cannot be copied", () => {
+      render(
+        <ResultsSummary
+          people={[alice]}
+          receiptName="Coffee Shop, Lunch Place"
+          receiptDate="2024-01-01"
+          unassignedReceipts={unassignedReceipts}
+        />
+      );
+
+      const phoneInput = screen.getByPlaceholderText("e.g. 555-123-4567");
+      fireEvent.change(phoneInput, { target: { value: "5551234567" } });
+
+      expect(screen.getByRole("button", { name: /share text/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /share split/i })).toBeDisabled();
+    });
+
+    it("does not show the banner when every receipt is assigned", () => {
+      render(
+        <ResultsSummary
+          people={[alice]}
+          receiptName="Lunch Place"
+          receiptDate="2024-01-01"
+        />
+      );
+
+      expect(
+        screen.queryByTestId("incomplete-assignment-banner")
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /share text/i })).toBeEnabled();
     });
   });
 });

--- a/src/components/results-summary.test.tsx
+++ b/src/components/results-summary.test.tsx
@@ -667,7 +667,7 @@ describe("ResultsSummary", () => {
       expect(screen.queryByText("Coffee Shop")).not.toBeInTheDocument();
     });
 
-    it("titles share text with Receipts for when multiple receipts are present", async () => {
+    it("puts Day total amounts before By receipt in share text", async () => {
       const originalShare = navigator.share;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (navigator as any).share;
@@ -687,12 +687,19 @@ describe("ResultsSummary", () => {
         await waitFor(() => {
           const clipboardContent = (navigator.clipboard.writeText as jest.Mock).mock.calls[0][0];
           expect(clipboardContent).toContain("Day total");
-          expect(clipboardContent).toContain("Receipts for Coffee Shop, Lunch Place");
           expect(clipboardContent).toContain("Alice:");
           expect(clipboardContent).toContain("$60.00");
+          expect(clipboardContent.indexOf("Day total")).toBeLessThan(
+            clipboardContent.indexOf("By receipt")
+          );
+          expect(clipboardContent.indexOf("$60.00")).toBeLessThan(
+            clipboardContent.indexOf("By receipt")
+          );
           expect(clipboardContent).toContain("By receipt");
           expect(clipboardContent).toContain("Coffee Shop · 2024-01-01:");
           expect(clipboardContent).toContain("Lunch Place · 2024-01-01:");
+          expect(clipboardContent).not.toContain("Receipts for");
+          expect(clipboardContent).not.toContain("Amount owed by each person:");
         });
       } finally {
         Object.defineProperty(navigator, "share", {
@@ -701,66 +708,6 @@ describe("ResultsSummary", () => {
           configurable: true,
         });
       }
-    });
-  });
-
-  describe("Incomplete assignment", () => {
-    const alice = {
-      ...mockPeople[0],
-      name: "Alice",
-      finalTotal: 35,
-    };
-    const unassignedReceipts = [{ name: "Coffee Shop", count: 4 }];
-
-    it("shows a banner naming receipts that still have unassigned items", () => {
-      render(
-        <ResultsSummary
-          people={[alice]}
-          receiptName="Coffee Shop, Lunch Place"
-          receiptDate="2024-01-01"
-          unassignedReceipts={unassignedReceipts}
-        />
-      );
-
-      expect(screen.getByTestId("incomplete-assignment-banner")).toBeInTheDocument();
-      expect(
-        screen.getByText("Coffee Shop still has 4 unassigned items.")
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/this day total is incomplete/i)
-      ).toBeInTheDocument();
-    });
-
-    it("disables Share Text and Share Split so a partial total cannot be copied", () => {
-      render(
-        <ResultsSummary
-          people={[alice]}
-          receiptName="Coffee Shop, Lunch Place"
-          receiptDate="2024-01-01"
-          unassignedReceipts={unassignedReceipts}
-        />
-      );
-
-      const phoneInput = screen.getByPlaceholderText("e.g. 555-123-4567");
-      fireEvent.change(phoneInput, { target: { value: "5551234567" } });
-
-      expect(screen.getByRole("button", { name: /share text/i })).toBeDisabled();
-      expect(screen.getByRole("button", { name: /share split/i })).toBeDisabled();
-    });
-
-    it("does not show the banner when every receipt is assigned", () => {
-      render(
-        <ResultsSummary
-          people={[alice]}
-          receiptName="Lunch Place"
-          receiptDate="2024-01-01"
-        />
-      );
-
-      expect(
-        screen.queryByTestId("incomplete-assignment-banner")
-      ).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /share text/i })).toBeEnabled();
     });
   });
 });

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -1,4 +1,4 @@
-import { Share, Link2, Check, AlertTriangle } from "lucide-react";
+import { Share, Link2, Check } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,12 +11,7 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { type Person } from "@/types";
-import {
-  formatCurrency,
-  formatUnassignedReceiptMessage,
-  type ReceiptValidationResult,
-  type UnassignedReceiptSummary,
-} from "@/lib/receipt-utils";
+import { formatCurrency, type ReceiptValidationResult } from "@/lib/receipt-utils";
 import {
   generateShareableUrl,
   validateSerializationInput,
@@ -37,7 +32,6 @@ interface ResultsSummaryProps {
   currencyCode?: string;
   validationResult?: ReceiptValidationResult;
   receiptBreakdown?: ReceiptBreakdown[];
-  unassignedReceipts?: UnassignedReceiptSummary[];
 }
 
 function receiptLabel(receipt: ReceiptBreakdown): string {
@@ -51,7 +45,6 @@ export function ResultsSummary({
   currencyCode,
   validationResult,
   receiptBreakdown,
-  unassignedReceipts = [],
 }: ResultsSummaryProps) {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [shareStatus, setShareStatus] = useState<
@@ -60,21 +53,35 @@ export function ResultsSummary({
   // Sort people by final total (highest first)
   const sortedPeople = [...people].sort((a, b) => b.finalTotal - a.finalTotal);
   const showBreakdown = (receiptBreakdown?.length ?? 0) > 1;
-  const assignmentComplete = unassignedReceipts.length === 0;
 
-  // Create a shareable text summary
+  // Create a shareable text summary matching on-screen order:
+  // Day total (people amounts), then By receipt (restaurant + date).
   const createShareText = (): string => {
     let text = "";
 
     if (showBreakdown) {
       text += "Day total\n";
+      sortedPeople.forEach((person) => {
+        text += `${person.name}: ${formatCurrency(person.finalTotal, currencyCode)}\n`;
+      });
+
+      if (receiptBreakdown) {
+        text += "\nBy receipt\n";
+        receiptBreakdown.forEach((receipt) => {
+          text += `${receiptLabel(receipt)}:\n`;
+          [...receipt.people]
+            .sort((a, b) => b.finalTotal - a.finalTotal)
+            .forEach((person) => {
+              text += `  ${person.name}: ${formatCurrency(person.finalTotal, currencyCode)}\n`;
+            });
+        });
+      }
+
+      return text;
     }
 
-    // Add receipt info
     if (receiptName) {
-      text += showBreakdown
-        ? `Receipts for ${receiptName}\n`
-        : `Receipt for ${receiptName}\n`;
+      text += `Receipt for ${receiptName}\n`;
     }
 
     if (receiptDate) {
@@ -83,22 +90,9 @@ export function ResultsSummary({
 
     text += "\nAmount owed by each person:\n";
 
-    // Add each person's total
     sortedPeople.forEach((person) => {
       text += `${person.name}: ${formatCurrency(person.finalTotal, currencyCode)}\n`;
     });
-
-    if (showBreakdown && receiptBreakdown) {
-      text += "\nBy receipt\n";
-      receiptBreakdown.forEach((receipt) => {
-        text += `${receiptLabel(receipt)}:\n`;
-        [...receipt.people]
-          .sort((a, b) => b.finalTotal - a.finalTotal)
-          .forEach((person) => {
-            text += `  ${person.name}: ${formatCurrency(person.finalTotal, currencyCode)}\n`;
-          });
-      });
-    }
 
     return text;
   };
@@ -205,7 +199,6 @@ export function ResultsSummary({
 
   // Check if split is ready to share
   const canShareSplit =
-    assignmentComplete &&
     people.length > 0 &&
     people.every((person) => person.finalTotal > 0) &&
     phoneNumber.replace(/\D/g, "").length >= 10 &&
@@ -217,27 +210,6 @@ export function ResultsSummary({
 
   return (
     <div className="w-full flex flex-col gap-4">
-      {unassignedReceipts.length > 0 ? (
-        <div
-          data-testid="incomplete-assignment-banner"
-          className="rounded-lg border border-yellow-500/50 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:bg-yellow-900/10 dark:text-yellow-300"
-          role="alert"
-          aria-live="polite"
-        >
-          <div className="flex items-start gap-2 font-medium">
-            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
-            <div className="flex flex-col gap-1">
-              <span>This day total is incomplete. Assign remaining items before sharing.</span>
-              {unassignedReceipts.map((summary, index) => (
-                <span key={`${summary.name}-${index}`}>
-                  {formatUnassignedReceiptMessage(summary)}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      ) : null}
-
       <div className="flex flex-col gap-3">
         <label
           htmlFor="venmo-phone"
@@ -292,7 +264,6 @@ export function ResultsSummary({
               variant="outline"
               className="flex items-center justify-center gap-2 text-base sm:text-sm font-medium transition-all duration-200 hover:bg-muted active:scale-95"
               onClick={shareResults}
-              disabled={!assignmentComplete}
             >
               <Share className="h-5 w-5 sm:h-4 sm:w-4" />
               <span>Share Text</span>

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -19,12 +19,19 @@ import {
 
 import { useState } from "react";
 
+export interface ReceiptBreakdown {
+  name: string;
+  date: string | null;
+  people: Person[];
+}
+
 interface ResultsSummaryProps {
   people: Person[];
   receiptName: string | null;
   receiptDate: string | null;
   currencyCode?: string;
   validationResult?: ReceiptValidationResult;
+  receiptBreakdown?: ReceiptBreakdown[];
 }
 
 export function ResultsSummary({
@@ -33,6 +40,7 @@ export function ResultsSummary({
   receiptDate,
   currencyCode,
   validationResult,
+  receiptBreakdown,
 }: ResultsSummaryProps) {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [shareStatus, setShareStatus] = useState<
@@ -40,6 +48,7 @@ export function ResultsSummary({
   >("idle");
   // Sort people by final total (highest first)
   const sortedPeople = [...people].sort((a, b) => b.finalTotal - a.finalTotal);
+  const showBreakdown = (receiptBreakdown?.length ?? 0) > 1;
 
   // Create a shareable text summary
   const createShareText = (): string => {
@@ -47,7 +56,9 @@ export function ResultsSummary({
 
     // Add receipt info
     if (receiptName) {
-      text += `Receipt for ${receiptName}\n`;
+      text += showBreakdown
+        ? `Receipts for ${receiptName}\n`
+        : `Receipt for ${receiptName}\n`;
     }
 
     if (receiptDate) {
@@ -60,6 +71,18 @@ export function ResultsSummary({
     sortedPeople.forEach((person) => {
       text += `${person.name}: ${formatCurrency(person.finalTotal, currencyCode)}\n`;
     });
+
+    if (showBreakdown && receiptBreakdown) {
+      text += "\n";
+      receiptBreakdown.forEach((receipt) => {
+        text += `${receipt.name}:\n`;
+        [...receipt.people]
+          .sort((a, b) => b.finalTotal - a.finalTotal)
+          .forEach((person) => {
+            text += `  ${person.name}: ${formatCurrency(person.finalTotal, currencyCode)}\n`;
+          });
+      });
+    }
 
     return text;
   };
@@ -238,6 +261,51 @@ export function ResultsSummary({
           </div>
         </CardHeader>
         <CardContent className="p-6">
+          <div className="flex flex-col gap-6">
+          {showBreakdown && receiptBreakdown ? (
+            <div
+              data-testid="receipt-breakdown"
+              className="flex flex-col gap-4"
+            >
+              {receiptBreakdown.map((receipt, index) => {
+                const sortedReceiptPeople = [...receipt.people].sort(
+                  (a, b) => b.finalTotal - a.finalTotal
+                );
+                return (
+                  <div key={`${receipt.name}-${receipt.date ?? "no-date"}-${index}`} className="flex flex-col gap-2">
+                    <div className="font-medium text-sm sm:text-base">
+                      {receipt.name}
+                    </div>
+                    <div className="overflow-x-auto">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="min-w-[100px]">Person</TableHead>
+                            <TableHead className="text-right min-w-[80px] font-semibold">
+                              Total
+                            </TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {sortedReceiptPeople.map((person) => (
+                            <TableRow key={person.id}>
+                              <TableCell className="font-medium py-2">
+                                {person.name}
+                              </TableCell>
+                              <TableCell className="text-right py-2">
+                                {formatCurrency(person.finalTotal, currencyCode)}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
           {/* Mobile-friendly responsive table */}
           <div className="overflow-x-auto">
             <Table>
@@ -293,6 +361,7 @@ export function ResultsSummary({
                 ))}
               </TableBody>
             </Table>
+          </div>
           </div>
         </CardContent>
       </Card>

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -1,4 +1,4 @@
-import { Share, Link2, Check } from "lucide-react";
+import { Share, Link2, Check, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,7 +11,12 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { type Person } from "@/types";
-import { formatCurrency, type ReceiptValidationResult } from "@/lib/receipt-utils";
+import {
+  formatCurrency,
+  formatUnassignedReceiptMessage,
+  type ReceiptValidationResult,
+  type UnassignedReceiptSummary,
+} from "@/lib/receipt-utils";
 import {
   generateShareableUrl,
   validateSerializationInput,
@@ -32,6 +37,11 @@ interface ResultsSummaryProps {
   currencyCode?: string;
   validationResult?: ReceiptValidationResult;
   receiptBreakdown?: ReceiptBreakdown[];
+  unassignedReceipts?: UnassignedReceiptSummary[];
+}
+
+function receiptLabel(receipt: ReceiptBreakdown): string {
+  return receipt.date ? `${receipt.name} · ${receipt.date}` : receipt.name;
 }
 
 export function ResultsSummary({
@@ -41,6 +51,7 @@ export function ResultsSummary({
   currencyCode,
   validationResult,
   receiptBreakdown,
+  unassignedReceipts = [],
 }: ResultsSummaryProps) {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [shareStatus, setShareStatus] = useState<
@@ -49,10 +60,15 @@ export function ResultsSummary({
   // Sort people by final total (highest first)
   const sortedPeople = [...people].sort((a, b) => b.finalTotal - a.finalTotal);
   const showBreakdown = (receiptBreakdown?.length ?? 0) > 1;
+  const assignmentComplete = unassignedReceipts.length === 0;
 
   // Create a shareable text summary
   const createShareText = (): string => {
     let text = "";
+
+    if (showBreakdown) {
+      text += "Day total\n";
+    }
 
     // Add receipt info
     if (receiptName) {
@@ -73,9 +89,9 @@ export function ResultsSummary({
     });
 
     if (showBreakdown && receiptBreakdown) {
-      text += "\n";
+      text += "\nBy receipt\n";
       receiptBreakdown.forEach((receipt) => {
-        text += `${receipt.name}:\n`;
+        text += `${receiptLabel(receipt)}:\n`;
         [...receipt.people]
           .sort((a, b) => b.finalTotal - a.finalTotal)
           .forEach((person) => {
@@ -189,6 +205,7 @@ export function ResultsSummary({
 
   // Check if split is ready to share
   const canShareSplit =
+    assignmentComplete &&
     people.length > 0 &&
     people.every((person) => person.finalTotal > 0) &&
     phoneNumber.replace(/\D/g, "").length >= 10 &&
@@ -200,6 +217,27 @@ export function ResultsSummary({
 
   return (
     <div className="w-full flex flex-col gap-4">
+      {unassignedReceipts.length > 0 ? (
+        <div
+          data-testid="incomplete-assignment-banner"
+          className="rounded-lg border border-yellow-500/50 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:bg-yellow-900/10 dark:text-yellow-300"
+          role="alert"
+          aria-live="polite"
+        >
+          <div className="flex items-start gap-2 font-medium">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div className="flex flex-col gap-1">
+              <span>This day total is incomplete. Assign remaining items before sharing.</span>
+              {unassignedReceipts.map((summary, index) => (
+                <span key={`${summary.name}-${index}`}>
+                  {formatUnassignedReceiptMessage(summary)}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <div className="flex flex-col gap-3">
         <label
           htmlFor="venmo-phone"
@@ -254,6 +292,7 @@ export function ResultsSummary({
               variant="outline"
               className="flex items-center justify-center gap-2 text-base sm:text-sm font-medium transition-all duration-200 hover:bg-muted active:scale-95"
               onClick={shareResults}
+              disabled={!assignmentComplete}
             >
               <Share className="h-5 w-5 sm:h-4 sm:w-4" />
               <span>Share Text</span>
@@ -262,49 +301,13 @@ export function ResultsSummary({
         </CardHeader>
         <CardContent className="p-6">
           <div className="flex flex-col gap-6">
-          {showBreakdown && receiptBreakdown ? (
-            <div
-              data-testid="receipt-breakdown"
-              className="flex flex-col gap-4"
-            >
-              {receiptBreakdown.map((receipt, index) => {
-                const sortedReceiptPeople = [...receipt.people].sort(
-                  (a, b) => b.finalTotal - a.finalTotal
-                );
-                return (
-                  <div key={`${receipt.name}-${receipt.date ?? "no-date"}-${index}`} className="flex flex-col gap-2">
-                    <div className="font-medium text-sm sm:text-base">
-                      {receipt.name}
-                    </div>
-                    <div className="overflow-x-auto">
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead className="min-w-[100px]">Person</TableHead>
-                            <TableHead className="text-right min-w-[80px] font-semibold">
-                              Total
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {sortedReceiptPeople.map((person) => (
-                            <TableRow key={person.id}>
-                              <TableCell className="font-medium py-2">
-                                {person.name}
-                              </TableCell>
-                              <TableCell className="text-right py-2">
-                                {formatCurrency(person.finalTotal, currencyCode)}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : null}
+          <div
+            data-testid={showBreakdown ? "day-total" : undefined}
+            className="flex flex-col gap-2"
+          >
+            {showBreakdown ? (
+              <h2 className="font-semibold text-base sm:text-lg">Day total</h2>
+            ) : null}
 
           {/* Mobile-friendly responsive table */}
           <div className="overflow-x-auto">
@@ -362,6 +365,57 @@ export function ResultsSummary({
               </TableBody>
             </Table>
           </div>
+          </div>
+
+          {showBreakdown && receiptBreakdown ? (
+            <div
+              data-testid="receipt-breakdown"
+              className="flex flex-col gap-4"
+            >
+              <h2 className="font-semibold text-base sm:text-lg">By receipt</h2>
+              {receiptBreakdown.map((receipt, index) => {
+                const sortedReceiptPeople = [...receipt.people].sort(
+                  (a, b) => b.finalTotal - a.finalTotal
+                );
+                return (
+                  <div key={`${receipt.name}-${receipt.date ?? "no-date"}-${index}`} className="flex flex-col gap-2">
+                    <div className="font-medium text-sm sm:text-base">
+                      <span>{receipt.name}</span>
+                      {receipt.date ? (
+                        <span className="text-muted-foreground font-normal">
+                          {` · ${receipt.date}`}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="overflow-x-auto">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="min-w-[100px]">Person</TableHead>
+                            <TableHead className="text-right min-w-[80px] font-semibold">
+                              Total
+                            </TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {sortedReceiptPeople.map((person) => (
+                            <TableRow key={person.id}>
+                              <TableCell className="font-medium py-2">
+                                {person.name}
+                              </TableCell>
+                              <TableCell className="text-right py-2">
+                                {formatCurrency(person.finalTotal, currencyCode)}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
           </div>
         </CardContent>
       </Card>

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -16,8 +16,6 @@ import {
   sessionShareDate,
   validateSessionAssignments,
   getSessionUnassigned,
-  getUnassignedReceiptSummaries,
-  formatUnassignedReceiptMessage,
   validateSessionInvariants,
 } from "./receipt-utils";
 import { mockPeople, mockReceipt, mockAssignedItems } from "@/test/test-utils";
@@ -44,6 +42,12 @@ describe("receipt-utils", () => {
       [0, [{ personId: "a", sharePercentage: 50 }]],
     ]);
     expect(validateItemAssignments(mockReceipt, incomplete)).toBe(false);
+  });
+
+  it("validateItemAssignments is true for a receipt with no items", () => {
+    expect(
+      validateItemAssignments({ ...mockReceipt, items: [] }, new Map())
+    ).toBe(true);
   });
 
   it("formatCurrency formats USD", () => {
@@ -867,32 +871,18 @@ describe("session-level receipt helpers", () => {
     ]);
   });
 
-  it("getUnassignedReceiptSummaries names receipts that still have items", () => {
-    const incompleteB = new Map<string, ItemAssignments>([
+  it("validateSessionAssignments treats a 0-item receipt as complete", () => {
+    const emptyStored: StoredReceipt = {
+      id: "empty",
+      receipt: { ...receiptA, restaurant: "Empty Place", items: [] },
+    };
+    const assigned = new Map<string, ItemAssignments>([
       ["rec-a", innerA],
-      ["rec-b", new Map()],
+      ["empty", new Map()],
     ]);
-    expect(getUnassignedReceiptSummaries([storedA, storedB], bothAssigned)).toEqual(
-      []
+    expect(validateSessionAssignments([storedA, emptyStored], assigned)).toBe(
+      true
     );
-    expect(
-      getUnassignedReceiptSummaries([storedA, storedB], incompleteB)
-    ).toEqual([{ name: "Cafe B", count: 1 }]);
-    expect(
-      getUnassignedReceiptSummaries(
-        [{ id: "x", receipt: { ...receiptA, restaurant: null } }],
-        new Map()
-      )
-    ).toEqual([{ name: "Untitled receipt", count: 1 }]);
-  });
-
-  it("formatUnassignedReceiptMessage uses singular and plural item wording", () => {
-    expect(
-      formatUnassignedReceiptMessage({ name: "Coffee Shop", count: 4 })
-    ).toBe("Coffee Shop still has 4 unassigned items.");
-    expect(
-      formatUnassignedReceiptMessage({ name: "Coffee Shop", count: 1 })
-    ).toBe("Coffee Shop still has 1 unassigned item.");
   });
 
   it("calculatePerReceiptPersonTotals Alice totals sum to the session total", () => {

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -11,6 +11,9 @@ import {
   sessionCurrency,
   validateReceiptCurrency,
   calculateSessionPersonTotals,
+  calculatePerReceiptPersonTotals,
+  sessionShareNote,
+  sessionShareDate,
   validateSessionAssignments,
   getSessionUnassigned,
   validateSessionInvariants,
@@ -860,6 +863,71 @@ describe("session-level receipt helpers", () => {
     expect(getSessionUnassigned([storedA, storedB], incompleteB)).toEqual([
       { receiptId: "rec-b", itemIndex: 0 },
     ]);
+  });
+
+  it("calculatePerReceiptPersonTotals Alice totals sum to the session total", () => {
+    const perReceipt = calculatePerReceiptPersonTotals(
+      [storedA, storedB],
+      mockPeople,
+      bothAssigned
+    );
+    const session = calculateSessionPersonTotals(
+      [storedA, storedB],
+      mockPeople,
+      bothAssigned
+    );
+
+    expect(perReceipt).toHaveLength(2);
+    expect(perReceipt[0].stored).toBe(storedA);
+    expect(perReceipt[1].stored).toBe(storedB);
+
+    const aliceSum =
+      perReceipt[0].people[0].finalTotal + perReceipt[1].people[0].finalTotal;
+    expect(session[0].finalTotal).toBe(aliceSum);
+    expect(aliceSum).toBeGreaterThan(0);
+  });
+
+  it("sessionShareNote uses defaults, joins names, and truncates to MAX_NOTE_LENGTH", () => {
+    expect(sessionShareNote([])).toBe("Receipt Split");
+    expect(sessionShareNote([storedA])).toBe("Cafe A");
+    expect(
+      sessionShareNote([{ id: "x", receipt: { ...receiptA, restaurant: null } }])
+    ).toBe("Receipt Split");
+    expect(sessionShareNote([storedA, storedB])).toBe("Cafe A, Cafe B");
+    expect(
+      sessionShareNote([
+        { id: "x", receipt: { ...receiptA, restaurant: null } },
+        storedB,
+      ])
+    ).toBe("Untitled, Cafe B");
+
+    const longA = "A".repeat(60);
+    const longB = "B".repeat(60);
+    const truncated = sessionShareNote([
+      { id: "a", receipt: { ...receiptA, restaurant: longA } },
+      { id: "b", receipt: { ...receiptB, restaurant: longB } },
+    ]);
+    expect(truncated.length).toBe(100);
+    expect(truncated.endsWith("...")).toBe(true);
+    expect(truncated.startsWith("A")).toBe(true);
+  });
+
+  it("sessionShareDate keeps identical dates and returns null when dates disagree", () => {
+    expect(sessionShareDate([])).toBeNull();
+    expect(sessionShareDate([storedA])).toBe("2024-01-01");
+    expect(
+      sessionShareDate([
+        storedA,
+        { id: "rec-c", receipt: { ...receiptB, date: "2024-01-01" } },
+      ])
+    ).toBe("2024-01-01");
+    expect(sessionShareDate([storedA, storedB])).toBeNull();
+    expect(
+      sessionShareDate([
+        { id: "a", receipt: { ...receiptA, date: null } },
+        { id: "b", receipt: { ...receiptB, date: null } },
+      ])
+    ).toBeNull();
   });
 
   it("validateSessionInvariants concatenates per-receipt errors and treats empty as valid", () => {

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -16,6 +16,8 @@ import {
   sessionShareDate,
   validateSessionAssignments,
   getSessionUnassigned,
+  getUnassignedReceiptSummaries,
+  formatUnassignedReceiptMessage,
   validateSessionInvariants,
 } from "./receipt-utils";
 import { mockPeople, mockReceipt, mockAssignedItems } from "@/test/test-utils";
@@ -863,6 +865,34 @@ describe("session-level receipt helpers", () => {
     expect(getSessionUnassigned([storedA, storedB], incompleteB)).toEqual([
       { receiptId: "rec-b", itemIndex: 0 },
     ]);
+  });
+
+  it("getUnassignedReceiptSummaries names receipts that still have items", () => {
+    const incompleteB = new Map<string, ItemAssignments>([
+      ["rec-a", innerA],
+      ["rec-b", new Map()],
+    ]);
+    expect(getUnassignedReceiptSummaries([storedA, storedB], bothAssigned)).toEqual(
+      []
+    );
+    expect(
+      getUnassignedReceiptSummaries([storedA, storedB], incompleteB)
+    ).toEqual([{ name: "Cafe B", count: 1 }]);
+    expect(
+      getUnassignedReceiptSummaries(
+        [{ id: "x", receipt: { ...receiptA, restaurant: null } }],
+        new Map()
+      )
+    ).toEqual([{ name: "Untitled receipt", count: 1 }]);
+  });
+
+  it("formatUnassignedReceiptMessage uses singular and plural item wording", () => {
+    expect(
+      formatUnassignedReceiptMessage({ name: "Coffee Shop", count: 4 })
+    ).toBe("Coffee Shop still has 4 unassigned items.");
+    expect(
+      formatUnassignedReceiptMessage({ name: "Coffee Shop", count: 1 })
+    ).toBe("Coffee Shop still has 1 unassigned item.");
   });
 
   it("calculatePerReceiptPersonTotals Alice totals sum to the session total", () => {

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -708,6 +708,44 @@ export function getSessionUnassigned(
   return unassigned;
 }
 
+export interface UnassignedReceiptSummary {
+  name: string;
+  count: number;
+}
+
+/**
+ * Per-receipt unassigned counts for Results warnings.
+ * Receipts that are fully assigned are omitted.
+ */
+export function getUnassignedReceiptSummaries(
+  receipts: StoredReceipt[],
+  assignedItems: Map<string, ItemAssignments>
+): UnassignedReceiptSummary[] {
+  const summaries: UnassignedReceiptSummary[] = [];
+
+  for (const stored of receipts) {
+    const count = getUnassignedItems(
+      stored.receipt,
+      assignedItems.get(stored.id) ?? new Map()
+    ).length;
+    if (count > 0) {
+      summaries.push({
+        name: stored.receipt.restaurant || "Untitled receipt",
+        count,
+      });
+    }
+  }
+
+  return summaries;
+}
+
+export function formatUnassignedReceiptMessage(
+  summary: UnassignedReceiptSummary
+): string {
+  const itemWord = summary.count === 1 ? "item" : "items";
+  return `${summary.name} still has ${summary.count} unassigned ${itemWord}.`;
+}
+
 /**
  * Runs per-receipt invariant checks and concatenates errors.
  * An empty session is valid.

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -620,6 +620,62 @@ export function calculateSessionPersonTotals(
 }
 
 /**
+ * Per-receipt person totals for the Results breakdown.
+ * Always delegates tax/tip math to calculatePersonTotals.
+ */
+export function calculatePerReceiptPersonTotals(
+  receipts: StoredReceipt[],
+  people: Person[],
+  assignedItems: Map<string, ItemAssignments>
+): { stored: StoredReceipt; people: Person[] }[] {
+  return receipts.map((stored) => ({
+    stored,
+    people: calculatePersonTotals(
+      stored.receipt,
+      people,
+      assignedItems.get(stored.id) ?? new Map(),
+      stored.id
+    ),
+  }));
+}
+
+/**
+ * Share-URL note for a session. Truncated to MAX_NOTE_LENGTH when needed.
+ */
+export function sessionShareNote(receipts: StoredReceipt[]): string {
+  if (receipts.length === 0) {
+    return "Receipt Split";
+  }
+  if (receipts.length === 1) {
+    return receipts[0].receipt.restaurant || "Receipt Split";
+  }
+
+  const joined = receipts
+    .map((stored) => stored.receipt.restaurant || "Untitled")
+    .join(", ");
+
+  if (joined.length <= VALIDATION_LIMITS.MAX_NOTE_LENGTH) {
+    return joined;
+  }
+
+  const ellipsis = "...";
+  return `${joined.slice(0, VALIDATION_LIMITS.MAX_NOTE_LENGTH - ellipsis.length)}${ellipsis}`;
+}
+
+/**
+ * Share-URL date for a session. Omitted when receipts disagree on date.
+ */
+export function sessionShareDate(receipts: StoredReceipt[]): string | null {
+  if (receipts.length === 0) {
+    return null;
+  }
+
+  const firstDate = receipts[0].receipt.date;
+  const allSame = receipts.every((stored) => stored.receipt.date === firstDate);
+  return allSame ? firstDate : null;
+}
+
+/**
  * True when every receipt in the session is fully assigned.
  * Empty sessions are not fully assigned.
  */

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -166,13 +166,15 @@ export function calculatePersonTotals(
 }
 
 /**
- * Validates if all items have been fully assigned (100%)
+ * Validates if all items have been fully assigned (100%).
+ * A receipt with no items is complete — there is nothing left to assign.
  */
 export function validateItemAssignments(
   receipt: Receipt,
   assignedItems: Map<number, PersonItemAssignment[]>
 ): boolean {
-  if (!receipt?.items?.length) return false;
+  if (!receipt) return false;
+  if (!receipt.items?.length) return true;
   
   for (let i = 0; i < receipt.items.length; i++) {
     const assignments = assignedItems.get(i) || [];
@@ -706,44 +708,6 @@ export function getSessionUnassigned(
   }
 
   return unassigned;
-}
-
-export interface UnassignedReceiptSummary {
-  name: string;
-  count: number;
-}
-
-/**
- * Per-receipt unassigned counts for Results warnings.
- * Receipts that are fully assigned are omitted.
- */
-export function getUnassignedReceiptSummaries(
-  receipts: StoredReceipt[],
-  assignedItems: Map<string, ItemAssignments>
-): UnassignedReceiptSummary[] {
-  const summaries: UnassignedReceiptSummary[] = [];
-
-  for (const stored of receipts) {
-    const count = getUnassignedItems(
-      stored.receipt,
-      assignedItems.get(stored.id) ?? new Map()
-    ).length;
-    if (count > 0) {
-      summaries.push({
-        name: stored.receipt.restaurant || "Untitled receipt",
-        count,
-      });
-    }
-  }
-
-  return summaries;
-}
-
-export function formatUnassignedReceiptMessage(
-  summary: UnassignedReceiptSummary
-): string {
-  const itemWord = summary.count === 1 ? "item" : "items";
-  return `${summary.name} still has ${summary.count} unassigned ${itemWord}.`;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #139. Base is now `main` after #152 merged.

## Summary

Results show a per-receipt breakdown plus a day total. Share/Venmo stays aggregate (no URL schema change, `/split` unchanged).

## Behavior

- With 2+ receipts, a compact per-receipt section lists each restaurant and that receipt’s person totals. The grand-total table is unchanged.
- Single-receipt results look like today (no extra section).
- Share note is the restaurant name, or a truncated join of names (`MAX_NOTE_LENGTH` 100). Date is omitted when receipts disagree.
- PersonItems groups line items by receipt; tax/tip/total stay session-level.

## Stack

1. #149 — Data model (merged)
2. #151 — Multi-file upload (merged)
3. #152 — Per-receipt assignment cards (merged)
4. **This PR — Per-receipt results + aggregate share**
5. #154 — Copy and screenshot mocks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

