### PR TITLE
feat: [5/5] multi-receipt copy and screenshot mocks

### DIFF
--- a/scripts/screenshot-harness.js
+++ b/scripts/screenshot-harness.js
@@ -8,14 +8,17 @@
  *   npm run screenshots                          # Screenshots of / at all viewports
  *   npm run screenshots -- --route /split        # Screenshots of /split route
  *   npm run screenshots -- --params "data=abc"   # With URL params
- *   npm run screenshots -- --mock-data           # Inject data, show results tab
+ *   npm run screenshots -- --mock-data           # Inject v2 session (one receipt), show results tab
  *   npm run screenshots -- --mock-data --tab all # Screenshot all tabs with mock data
  *   npm run screenshots -- --mock-data --tab people # Screenshot just people tab
+ *   npm run screenshots -- --mock-data --multi-receipt --tab all
+ *                                            # Two-receipt v2 session (Coffee + Lunch)
  *
  * Options:
  *   --route <path>      Route to screenshot (default: /)
  *   --params <query>    URL query parameters (without leading ?)
- *   --mock-data         Inject synthetic receipt data into localStorage
+ *   --mock-data         Inject synthetic receipt data into localStorage (v2 session)
+ *   --multi-receipt     With --mock-data, inject two receipts instead of one
  *   --tab <name>        Which tab to show: upload, people, assign, results, or all (default: results)
  *   --output <dir>      Output directory (default: screenshots)
  *
@@ -49,6 +52,7 @@ const MOCK_RECEIPT = {
   tax: 4.50,
   tip: 9.00,
   total: 58.50,
+  currency: "USD",
   items: [
     { name: "Burger", price: 15.00, quantity: 1 },
     { name: "Fries", price: 5.00, quantity: 2 },
@@ -56,6 +60,35 @@ const MOCK_RECEIPT = {
     { name: "Salad", price: 12.00, quantity: 1 },
   ]
 };
+
+const MOCK_RECEIPT_ID = "receipt-1";
+
+const MOCK_COFFEE_ID = "receipt-coffee";
+const MOCK_LUNCH_ID = "receipt-lunch";
+
+const MOCK_COFFEE_RECEIPT = {
+  restaurant: "Coffee",
+  date: "2024-01-15",
+  subtotal: 10.00,
+  tax: 1.00,
+  tip: 2.00,
+  total: 13.00,
+  currency: "USD",
+  items: [
+    { name: "Latte", price: 5.00, quantity: 1 },
+    { name: "Muffin", price: 5.00, quantity: 1 },
+  ],
+};
+
+const MOCK_LUNCH_RECEIPT = {
+  ...MOCK_RECEIPT,
+  restaurant: "Lunch",
+};
+
+const MOCK_COFFEE_ASSIGNED_ITEMS = [
+  [0, [{ personId: "person-1", sharePercentage: 100 }]],
+  [1, [{ personId: "person-2", sharePercentage: 50 }, { personId: "person-3", sharePercentage: 50 }]],
+];
 
 const MOCK_PEOPLE = [
   {
@@ -113,16 +146,39 @@ const MOCK_ASSIGNED_ITEMS = [
 ];
 
 /**
- * Build the session object matching the app's expected localStorage structure
+ * Build a v2 session matching serializeSession() in src/lib/session-persistence.ts.
+ * assignedItems is nested: [[receiptId, [[itemIndex, assignments]]]]
  * @param {string} activeTab - Which tab to show (upload, people, assign, results)
+ * @param {{ multiReceipt?: boolean }} [options]
  */
-function buildMockSession(activeTab = 'results') {
+function buildMockSession(activeTab = 'results', { multiReceipt = false } = {}) {
+  if (multiReceipt) {
+    return {
+      version: 2,
+      state: {
+        receipts: [
+          { id: MOCK_COFFEE_ID, receipt: MOCK_COFFEE_RECEIPT },
+          { id: MOCK_LUNCH_ID, receipt: MOCK_LUNCH_RECEIPT },
+        ],
+        people: MOCK_PEOPLE,
+        assignedItems: [
+          [MOCK_COFFEE_ID, MOCK_COFFEE_ASSIGNED_ITEMS],
+          [MOCK_LUNCH_ID, MOCK_ASSIGNED_ITEMS],
+        ],
+        groups: MOCK_GROUPS,
+        isLoading: false,
+        error: null,
+      },
+      activeTab,
+    };
+  }
+
   return {
+    version: 2,
     state: {
-      originalReceipt: MOCK_RECEIPT,
+      receipts: [{ id: MOCK_RECEIPT_ID, receipt: MOCK_RECEIPT }],
       people: MOCK_PEOPLE,
-      assignedItems: MOCK_ASSIGNED_ITEMS,
-      unassignedItems: [],
+      assignedItems: [[MOCK_RECEIPT_ID, MOCK_ASSIGNED_ITEMS]],
       groups: MOCK_GROUPS,
       isLoading: false,
       error: null,
@@ -157,6 +213,7 @@ function parseArgs() {
     route: '/',
     params: '',
     mockData: false,
+    multiReceipt: false,
     tab: 'results',
     outputDir: 'screenshots',
   };
@@ -171,6 +228,9 @@ function parseArgs() {
         break;
       case '--mock-data':
         options.mockData = true;
+        break;
+      case '--multi-receipt':
+        options.multiReceipt = true;
         break;
       case '--tab':
         options.tab = args[++i] || 'results';
@@ -222,7 +282,7 @@ async function takeScreenshots(options) {
   console.log(`Base URL: ${baseUrl}`);
   console.log(`Route: ${options.route}`);
   console.log(`Params: ${options.params || '(none)'}`);
-  console.log(`Mock Data: ${options.mockData ? 'Yes' : 'No'}`);
+  console.log(`Mock Data: ${options.mockData ? (options.multiReceipt ? 'Yes (two receipts)' : 'Yes (one receipt)') : 'No'}`);
   console.log(`Tabs: ${options.tab === 'all' ? 'all (upload, people, assign, results)' : options.tab}`);
   console.log(`Output: ${outputPath}`);
   console.log(`Viewports: ${VIEWPORTS.length}`);
@@ -254,7 +314,7 @@ async function takeScreenshots(options) {
           } else {
             // For home route, inject localStorage data using addInitScript
             // This runs before any page scripts, ensuring data is available on load
-            const mockSession = buildMockSession(tab);
+            const mockSession = buildMockSession(tab, { multiReceipt: options.multiReceipt });
             await page.addInitScript((data) => {
               window.localStorage.setItem('receiptSplitterSession', JSON.stringify(data));
             }, mockSession);

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -38,6 +38,7 @@ describe("Home Page", () => {
     it("starts on the upload tab with all downstream tabs and nav disabled", () => {
       render(<Home />);
       expect(screen.getByRole("tab", { name: /upload receipt/i })).toHaveAttribute("data-state", "active");
+      expect(screen.getByText(/upload receipts, add people, and split the day/i)).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /add people/i })).toBeDisabled();
       expect(screen.getByRole("tab", { name: /assign items/i })).toBeDisabled();
       expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
@@ -771,6 +772,10 @@ describe("Home Page", () => {
 
       render(<Home />);
 
+      expect(screen.getByRole("tab", { name: /results/i })).toHaveAttribute(
+        "data-state",
+        "active"
+      );
       expect(screen.getByRole("heading", { name: "Day total" })).toBeInTheDocument();
       expect(screen.getByRole("heading", { name: "By receipt" })).toBeInTheDocument();
       expect(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -599,7 +599,7 @@ export default function Home() {
         <div className="w-full sm:w-auto">
           <h1 className="text-3xl font-bold mb-2">Receipt Splitter</h1>
           <p className="text-muted-foreground">
-            Upload a receipt, add people, and easily split items
+            Upload receipts, add people, and split the day
           </p>
         </div>
 
@@ -651,7 +651,7 @@ export default function Home() {
             <TabsTrigger value="upload" className="gap-1.5 sm:gap-2">
               <UploadCloud className="h-4 w-4 flex-shrink-0" />
               <span className="hidden xs:inline sm:hidden">Upload</span>
-              <span className="hidden sm:inline">Upload Receipt</span>
+              <span className="hidden sm:inline">Upload Receipts</span>
             </TabsTrigger>
             <TabsTrigger value="people" disabled={!hasReceipt} className="gap-1.5 sm:gap-2">
               <Users className="h-4 w-4 flex-shrink-0" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #139. Base is now `main` after #153 merged. Last layer of the stack.

## Summary

Copy and screenshot-harness updates so multi-receipt is what you see in the UI and in visual review. Delete/assign/results behavior already shipped in PRs 2–4.

## Changes

- Tab label: Upload Receipts. Subtitle: "Upload receipts, add people, and split the day."
- Screenshot harness default `--mock-data` uses a v2 session. `--multi-receipt` injects Coffee + Lunch for assign/results review.

## Stack (merge bottom-up)

1. #149 — Data model (merged)
2. #151 — Multi-file upload (merged)
3. #152 — Per-receipt assignment cards (merged)
4. #153 — Per-receipt results + aggregate share (merged)
5. **This PR — Copy and screenshot mocks**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dca8126-7466-4f6a-95f9-b0d6894ecd87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

