### PR TITLE
fix: balance Lunch screenshot fixture to $45 subtotal (#163)

### DIFF
--- a/e2e/screenshot-fixture.spec.ts
+++ b/e2e/screenshot-fixture.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect, type Page } from "@playwright/test";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { buildMockSession } = require("../scripts/screenshot-fixtures.js") as {
+  buildMockSession: (
+    activeTab?: string,
+    options?: { multiReceipt?: boolean },
+  ) => Record<string, unknown>;
+};
+
+async function seedHarnessSession(
+  page: Page,
+  session: Record<string, unknown>,
+) {
+  await page.addInitScript((data) => {
+    window.localStorage.setItem(
+      "receiptSplitterSession",
+      JSON.stringify(data),
+    );
+  }, session);
+}
+
+test.describe("screenshot harness fixtures on Results", () => {
+  test("single-receipt mock has no item/subtotal validation banner", async ({
+    page,
+  }) => {
+    await seedHarnessSession(page, buildMockSession("results"));
+    await page.goto("/");
+
+    await expect(page.getByText("Alice").first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Split Validation Issues")).toHaveCount(0);
+    await expect(
+      page.getByText("Sum of item prices does not match subtotal"),
+    ).toHaveCount(0);
+  });
+
+  test("Coffee + Lunch mock has no item/subtotal validation banner", async ({
+    page,
+  }) => {
+    await seedHarnessSession(
+      page,
+      buildMockSession("results", { multiReceipt: true }),
+    );
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Day total" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole("heading", { name: "By receipt" })).toBeVisible();
+    await expect(page.getByText("Lunch").first()).toBeVisible();
+    await expect(page.getByText("Coffee").first()).toBeVisible();
+    await expect(page.getByText("Split Validation Issues")).toHaveCount(0);
+    await expect(
+      page.getByText("Sum of item prices does not match subtotal"),
+    ).toHaveCount(0);
+    await expect(page.getByText("Off by $2.00")).toHaveCount(0);
+  });
+});

--- a/e2e/screenshot-fixture.spec.ts
+++ b/e2e/screenshot-fixture.spec.ts
@@ -1,18 +1,19 @@
+import { execFileSync } from "node:child_process";
 import { test, expect, type Page } from "@playwright/test";
-import { createRequire } from "module";
 
-const require = createRequire(import.meta.url);
-const { buildMockSession } = require("../scripts/screenshot-fixtures.js") as {
-  buildMockSession: (
-    activeTab?: string,
-    options?: { multiReceipt?: boolean },
-  ) => Record<string, unknown>;
-};
+function harnessSession(activeTab: string, multiReceipt = false) {
+  const output = execFileSync(
+    "node",
+    [
+      "-e",
+      `const { buildMockSession } = require("./scripts/screenshot-fixtures"); console.log(JSON.stringify(buildMockSession(${JSON.stringify(activeTab)}, ${JSON.stringify({ multiReceipt })})));`,
+    ],
+    { encoding: "utf8", cwd: process.cwd() },
+  );
+  return JSON.parse(output) as Record<string, unknown>;
+}
 
-async function seedHarnessSession(
-  page: Page,
-  session: Record<string, unknown>,
-) {
+async function seedHarnessSession(page: Page, session: Record<string, unknown>) {
   await page.addInitScript((data) => {
     window.localStorage.setItem(
       "receiptSplitterSession",
@@ -25,7 +26,7 @@ test.describe("screenshot harness fixtures on Results", () => {
   test("single-receipt mock has no item/subtotal validation banner", async ({
     page,
   }) => {
-    await seedHarnessSession(page, buildMockSession("results"));
+    await seedHarnessSession(page, harnessSession("results"));
     await page.goto("/");
 
     await expect(page.getByText("Alice").first()).toBeVisible({
@@ -40,10 +41,7 @@ test.describe("screenshot harness fixtures on Results", () => {
   test("Coffee + Lunch mock has no item/subtotal validation banner", async ({
     page,
   }) => {
-    await seedHarnessSession(
-      page,
-      buildMockSession("results", { multiReceipt: true }),
-    );
+    await seedHarnessSession(page, harnessSession("results", true));
     await page.goto("/");
 
     await expect(page.getByRole("heading", { name: "Day total" })).toBeVisible({

--- a/scripts/screenshot-fixtures.js
+++ b/scripts/screenshot-fixtures.js
@@ -1,0 +1,200 @@
+/**
+ * Demo / screenshot session fixtures.
+ *
+ * Lunch line items must equal subtotal: 15 + (5×2) + (3×2) + 14 = 45.
+ * Results runs the same item/subtotal check; a mismatch shows
+ * "Split Validation Issues" on an otherwise clean mock walk.
+ */
+
+const MOCK_RECEIPT = {
+  restaurant: "Test Restaurant",
+  date: "2024-01-15",
+  subtotal: 45.00,
+  tax: 4.50,
+  tip: 9.00,
+  total: 58.50,
+  currency: "USD",
+  items: [
+    { name: "Burger", price: 15.00, quantity: 1 },
+    { name: "Fries", price: 5.00, quantity: 2 },
+    { name: "Soda", price: 3.00, quantity: 2 },
+    { name: "Salad", price: 14.00, quantity: 1 },
+  ],
+};
+
+const MOCK_RECEIPT_ID = "receipt-1";
+
+const MOCK_COFFEE_ID = "receipt-coffee";
+const MOCK_LUNCH_ID = "receipt-lunch";
+
+const MOCK_COFFEE_RECEIPT = {
+  restaurant: "Coffee",
+  date: "2024-01-15",
+  subtotal: 10.00,
+  tax: 1.00,
+  tip: 2.00,
+  total: 13.00,
+  currency: "USD",
+  items: [
+    { name: "Latte", price: 5.00, quantity: 1 },
+    { name: "Muffin", price: 5.00, quantity: 1 },
+  ],
+};
+
+const MOCK_LUNCH_RECEIPT = {
+  ...MOCK_RECEIPT,
+  restaurant: "Lunch",
+};
+
+function itemsTotal(receipt) {
+  return receipt.items.reduce(
+    (sum, item) => sum + item.price * (item.quantity || 1),
+    0
+  );
+}
+
+/**
+ * Screenshot fixtures must satisfy the same invariants Results validates,
+ * or --mock-data walks show a real "Split Validation Issues" banner.
+ */
+function assertReceiptBalances(receipt) {
+  const label = receipt.restaurant || "receipt";
+  const lineTotal = itemsTotal(receipt);
+  if (Math.abs(lineTotal - receipt.subtotal) > 0.001) {
+    throw new Error(
+      `Screenshot fixture "${label}" items sum to ${lineTotal.toFixed(2)}, subtotal is ${receipt.subtotal.toFixed(2)}`
+    );
+  }
+  const expectedTotal = receipt.subtotal + receipt.tax + receipt.tip;
+  if (Math.abs(expectedTotal - receipt.total) > 0.001) {
+    throw new Error(
+      `Screenshot fixture "${label}" subtotal+tax+tip is ${expectedTotal.toFixed(2)}, total is ${receipt.total.toFixed(2)}`
+    );
+  }
+}
+
+assertReceiptBalances(MOCK_RECEIPT);
+assertReceiptBalances(MOCK_COFFEE_RECEIPT);
+assertReceiptBalances(MOCK_LUNCH_RECEIPT);
+
+const MOCK_COFFEE_ASSIGNED_ITEMS = [
+  [0, [{ personId: "person-1", sharePercentage: 100 }]],
+  [1, [{ personId: "person-2", sharePercentage: 50 }, { personId: "person-3", sharePercentage: 50 }]],
+];
+
+// Person totals match calculatePersonTotals() for MOCK_ASSIGNED_ITEMS on Lunch:
+// Alice: Burger $15 + 50% of Fries $10 = $20; tax $2; tip $4; final $26
+// Bob: 50% of Fries $10 + Soda $6 = $11; tax $1.10; tip $2.20; final $14.30
+// Charlie: Salad $14; tax $1.40; tip $2.80; final $18.20
+const MOCK_PEOPLE = [
+  {
+    id: "person-1",
+    name: "Alice",
+    items: [
+      { itemId: 0, itemName: "Burger", originalPrice: 15.00, quantity: 1, sharePercentage: 100, amount: 15.00 },
+      { itemId: 1, itemName: "Fries", originalPrice: 5.00, quantity: 2, sharePercentage: 50, amount: 5.00 },
+    ],
+    totalBeforeTax: 20.00,
+    tax: 2.00,
+    tip: 4.00,
+    finalTotal: 26.00,
+  },
+  {
+    id: "person-2",
+    name: "Bob",
+    items: [
+      { itemId: 1, itemName: "Fries", originalPrice: 5.00, quantity: 2, sharePercentage: 50, amount: 5.00 },
+      { itemId: 2, itemName: "Soda", originalPrice: 3.00, quantity: 2, sharePercentage: 100, amount: 6.00 },
+    ],
+    totalBeforeTax: 11.00,
+    tax: 1.10,
+    tip: 2.20,
+    finalTotal: 14.30,
+  },
+  {
+    id: "person-3",
+    name: "Charlie",
+    items: [
+      { itemId: 3, itemName: "Salad", originalPrice: 14.00, quantity: 1, sharePercentage: 100, amount: 14.00 },
+    ],
+    totalBeforeTax: 14.00,
+    tax: 1.40,
+    tip: 2.80,
+    finalTotal: 18.20,
+  },
+];
+
+const MOCK_GROUPS = [
+  {
+    id: "group-1",
+    name: "Friends",
+    memberIds: ["person-1", "person-2"],
+    emoji: "1f3c8",
+  },
+];
+
+// assignedItems stored as array of [itemIndex, assignments[]] entries (serialized Map)
+const MOCK_ASSIGNED_ITEMS = [
+  [0, [{ personId: "person-1", sharePercentage: 100 }]],
+  [1, [{ personId: "person-1", sharePercentage: 50 }, { personId: "person-2", sharePercentage: 50 }]],
+  [2, [{ personId: "person-2", sharePercentage: 100 }]],
+  [3, [{ personId: "person-3", sharePercentage: 100 }]],
+];
+
+/**
+ * Build a v2 session matching serializeSession() in src/lib/session-persistence.ts.
+ * assignedItems is nested: [[receiptId, [[itemIndex, assignments]]]]
+ * @param {string} activeTab - Which tab to show (upload, people, assign, results)
+ * @param {{ multiReceipt?: boolean }} [options]
+ */
+function buildMockSession(activeTab = "results", { multiReceipt = false } = {}) {
+  if (multiReceipt) {
+    return {
+      version: 2,
+      state: {
+        receipts: [
+          { id: MOCK_COFFEE_ID, receipt: MOCK_COFFEE_RECEIPT },
+          { id: MOCK_LUNCH_ID, receipt: MOCK_LUNCH_RECEIPT },
+        ],
+        people: MOCK_PEOPLE,
+        assignedItems: [
+          [MOCK_COFFEE_ID, MOCK_COFFEE_ASSIGNED_ITEMS],
+          [MOCK_LUNCH_ID, MOCK_ASSIGNED_ITEMS],
+        ],
+        groups: MOCK_GROUPS,
+        isLoading: false,
+        error: null,
+      },
+      activeTab,
+    };
+  }
+
+  return {
+    version: 2,
+    state: {
+      receipts: [{ id: MOCK_RECEIPT_ID, receipt: MOCK_RECEIPT }],
+      people: MOCK_PEOPLE,
+      assignedItems: [[MOCK_RECEIPT_ID, MOCK_ASSIGNED_ITEMS]],
+      groups: MOCK_GROUPS,
+      isLoading: false,
+      error: null,
+    },
+    activeTab,
+  };
+}
+
+module.exports = {
+  MOCK_RECEIPT,
+  MOCK_RECEIPT_ID,
+  MOCK_COFFEE_ID,
+  MOCK_LUNCH_ID,
+  MOCK_COFFEE_RECEIPT,
+  MOCK_LUNCH_RECEIPT,
+  MOCK_PEOPLE,
+  MOCK_GROUPS,
+  MOCK_ASSIGNED_ITEMS,
+  MOCK_COFFEE_ASSIGNED_ITEMS,
+  buildMockSession,
+  itemsTotal,
+  assertReceiptBalances,
+};

--- a/scripts/screenshot-fixtures.test.ts
+++ b/scripts/screenshot-fixtures.test.ts
@@ -1,0 +1,55 @@
+const {
+  MOCK_RECEIPT,
+  MOCK_COFFEE_RECEIPT,
+  MOCK_LUNCH_RECEIPT,
+  MOCK_PEOPLE,
+  itemsTotal,
+} = require("./screenshot-fixtures");
+
+describe("screenshot harness fixtures", () => {
+  it("Lunch line items sum to the stated subtotal", () => {
+    expect(itemsTotal(MOCK_RECEIPT)).toBeCloseTo(MOCK_RECEIPT.subtotal, 2);
+    expect(itemsTotal(MOCK_LUNCH_RECEIPT)).toBeCloseTo(
+      MOCK_LUNCH_RECEIPT.subtotal,
+      2
+    );
+    expect(MOCK_LUNCH_RECEIPT.subtotal).toBe(45);
+  });
+
+  it("Coffee line items sum to the stated subtotal", () => {
+    expect(itemsTotal(MOCK_COFFEE_RECEIPT)).toBeCloseTo(
+      MOCK_COFFEE_RECEIPT.subtotal,
+      2
+    );
+  });
+
+  it("subtotal + tax + tip equals total for each receipt", () => {
+    for (const receipt of [
+      MOCK_RECEIPT,
+      MOCK_COFFEE_RECEIPT,
+      MOCK_LUNCH_RECEIPT,
+    ]) {
+      expect(receipt.subtotal + receipt.tax + receipt.tip).toBeCloseTo(
+        receipt.total,
+        2
+      );
+    }
+  });
+
+  it("Lunch person pre-tax totals sum to the Lunch subtotal", () => {
+    const peopleSubtotal = MOCK_PEOPLE.reduce(
+      (sum: number, person: { totalBeforeTax: number }) =>
+        sum + person.totalBeforeTax,
+      0
+    );
+    expect(peopleSubtotal).toBeCloseTo(MOCK_RECEIPT.subtotal, 2);
+  });
+
+  it("Lunch person finals sum to the Lunch total", () => {
+    const peopleTotal = MOCK_PEOPLE.reduce(
+      (sum: number, person: { finalTotal: number }) => sum + person.finalTotal,
+      0
+    );
+    expect(peopleTotal).toBeCloseTo(MOCK_RECEIPT.total, 2);
+  });
+});

--- a/scripts/screenshot-harness.js
+++ b/scripts/screenshot-harness.js
@@ -29,6 +29,10 @@
 const { chromium } = require('playwright');
 const path = require('path');
 const fs = require('fs');
+const {
+  MOCK_PEOPLE,
+  buildMockSession,
+} = require('./screenshot-fixtures');
 
 // Define viewport configurations
 const VIEWPORTS = [
@@ -43,149 +47,6 @@ const VIEWPORTS = [
 
 // localStorage key used by the app (must match src/app/page.tsx)
 const LOCAL_STORAGE_KEY = 'receiptSplitterSession';
-
-// Synthetic mock data matching the app's ReceiptState structure
-const MOCK_RECEIPT = {
-  restaurant: "Test Restaurant",
-  date: "2024-01-15",
-  subtotal: 45.00,
-  tax: 4.50,
-  tip: 9.00,
-  total: 58.50,
-  currency: "USD",
-  items: [
-    { name: "Burger", price: 15.00, quantity: 1 },
-    { name: "Fries", price: 5.00, quantity: 2 },
-    { name: "Soda", price: 3.00, quantity: 2 },
-    { name: "Salad", price: 12.00, quantity: 1 },
-  ]
-};
-
-const MOCK_RECEIPT_ID = "receipt-1";
-
-const MOCK_COFFEE_ID = "receipt-coffee";
-const MOCK_LUNCH_ID = "receipt-lunch";
-
-const MOCK_COFFEE_RECEIPT = {
-  restaurant: "Coffee",
-  date: "2024-01-15",
-  subtotal: 10.00,
-  tax: 1.00,
-  tip: 2.00,
-  total: 13.00,
-  currency: "USD",
-  items: [
-    { name: "Latte", price: 5.00, quantity: 1 },
-    { name: "Muffin", price: 5.00, quantity: 1 },
-  ],
-};
-
-const MOCK_LUNCH_RECEIPT = {
-  ...MOCK_RECEIPT,
-  restaurant: "Lunch",
-};
-
-const MOCK_COFFEE_ASSIGNED_ITEMS = [
-  [0, [{ personId: "person-1", sharePercentage: 100 }]],
-  [1, [{ personId: "person-2", sharePercentage: 50 }, { personId: "person-3", sharePercentage: 50 }]],
-];
-
-const MOCK_PEOPLE = [
-  {
-    id: "person-1",
-    name: "Alice",
-    items: [
-      { itemId: 0, itemName: "Burger", originalPrice: 15.00, quantity: 1, sharePercentage: 100, amount: 15.00 },
-      { itemId: 1, itemName: "Fries", originalPrice: 5.00, quantity: 1, sharePercentage: 50, amount: 2.50 }
-    ],
-    totalBeforeTax: 17.50,
-    tax: 1.75,
-    tip: 3.50,
-    finalTotal: 22.75
-  },
-  {
-    id: "person-2",
-    name: "Bob",
-    items: [
-      { itemId: 1, itemName: "Fries", originalPrice: 5.00, quantity: 1, sharePercentage: 50, amount: 2.50 },
-      { itemId: 2, itemName: "Soda", originalPrice: 3.00, quantity: 2, sharePercentage: 100, amount: 6.00 }
-    ],
-    totalBeforeTax: 8.50,
-    tax: 0.85,
-    tip: 1.70,
-    finalTotal: 11.05
-  },
-  {
-    id: "person-3",
-    name: "Charlie",
-    items: [
-      { itemId: 3, itemName: "Salad", originalPrice: 12.00, quantity: 1, sharePercentage: 100, amount: 12.00 }
-    ],
-    totalBeforeTax: 12.00,
-    tax: 1.20,
-    tip: 2.40,
-    finalTotal: 15.60
-  }
-];
-
-const MOCK_GROUPS = [
-  {
-    id: "group-1",
-    name: "Friends",
-    memberIds: ["person-1", "person-2"],
-    emoji: "1f3c8"
-  }
-];
-
-// assignedItems stored as array of [itemIndex, assignments[]] entries (serialized Map)
-const MOCK_ASSIGNED_ITEMS = [
-  [0, [{ personId: "person-1", sharePercentage: 100 }]],
-  [1, [{ personId: "person-1", sharePercentage: 50 }, { personId: "person-2", sharePercentage: 50 }]],
-  [2, [{ personId: "person-2", sharePercentage: 100 }]],
-  [3, [{ personId: "person-3", sharePercentage: 100 }]],
-];
-
-/**
- * Build a v2 session matching serializeSession() in src/lib/session-persistence.ts.
- * assignedItems is nested: [[receiptId, [[itemIndex, assignments]]]]
- * @param {string} activeTab - Which tab to show (upload, people, assign, results)
- * @param {{ multiReceipt?: boolean }} [options]
- */
-function buildMockSession(activeTab = 'results', { multiReceipt = false } = {}) {
-  if (multiReceipt) {
-    return {
-      version: 2,
-      state: {
-        receipts: [
-          { id: MOCK_COFFEE_ID, receipt: MOCK_COFFEE_RECEIPT },
-          { id: MOCK_LUNCH_ID, receipt: MOCK_LUNCH_RECEIPT },
-        ],
-        people: MOCK_PEOPLE,
-        assignedItems: [
-          [MOCK_COFFEE_ID, MOCK_COFFEE_ASSIGNED_ITEMS],
-          [MOCK_LUNCH_ID, MOCK_ASSIGNED_ITEMS],
-        ],
-        groups: MOCK_GROUPS,
-        isLoading: false,
-        error: null,
-      },
-      activeTab,
-    };
-  }
-
-  return {
-    version: 2,
-    state: {
-      receipts: [{ id: MOCK_RECEIPT_ID, receipt: MOCK_RECEIPT }],
-      people: MOCK_PEOPLE,
-      assignedItems: [[MOCK_RECEIPT_ID, MOCK_ASSIGNED_ITEMS]],
-      groups: MOCK_GROUPS,
-      isLoading: false,
-      error: null,
-    },
-    activeTab,
-  };
-}
 
 /**
  * Generate URL params for /split route from mock data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #163.

The Coffee + Lunch screenshot/demo fixture had line items that did not add up to the stated subtotal, so Results showed a real `ITEMS_SUBTOTAL_MISMATCH` banner on an otherwise clean mock walk.

## Change
- Bump Lunch **Salad** from $12 to **$14** so items hit $45:
  - Burger $15 + Fries $10 + Soda $6 + Salad $14 = **$45**
- Keep Alice / Bob / Charlie person totals in sync with `calculatePersonTotals()` for the existing assignments (Fries 50/50 is $5 each of the $10 line, not $2.50).
- Move harness mock data into `scripts/screenshot-fixtures.js` so Jest can assert the math without loading Playwright.

## Tests
- Unit: Lunch/Coffee fixtures must sum to subtotal, tax+tip+subtotal = total, and person totals match the Lunch receipt.
- E2E: single-receipt and Coffee+Lunch mock sessions on Results must not show “Split Validation Issues” / “Off by $2.00”.

## E2E walkthrough
Restored the Coffee + Lunch screenshot session on Results, confirmed no validation banner, then opened Assign to show Lunch Salad at $14.00.

[issue-163-lunch-fixture-results.mp4](https://cursor.com/agents/bc-887d61b4-14bf-4a91-8083-921f859ece34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-163-lunch-fixture-results.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-887d61b4-14bf-4a91-8083-921f859ece34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-887d61b4-14bf-4a91-8083-921f859ece34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

