### PR TITLE
fix: stop Venmo notes from showing plus signs instead of spaces

### DIFF
--- a/src/lib/venmo-utils.test.ts
+++ b/src/lib/venmo-utils.test.ts
@@ -57,7 +57,24 @@ describe('generateVenmoLink', () => {
   it('generates correct Venmo link with all parameters', () => {
     const link = generateVenmoLink('5551234567', 25.50, 'Pizza Palace');
     
-    expect(link).toBe('https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Pizza+Palace');
+    expect(link).toBe('https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Pizza%20Palace');
+  });
+
+  it('encodes spaces in notes as %20 so Venmo does not show plus signs', () => {
+    const link = generateVenmoLink('5551234567', 29.53, 'Olive Garden - Karan');
+
+    expect(link).toBe(
+      'https://venmo.com/?txn=pay&recipients=5551234567&amount=29.53&note=Olive%20Garden%20-%20Karan'
+    );
+    expect(link).not.toContain('+');
+  });
+
+  it('encodes literal plus signs in notes as %2B', () => {
+    const link = generateVenmoLink('5551234567', 25.50, 'A+B special');
+
+    expect(link).toBe(
+      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=A%2BB%20special'
+    );
   });
 
   it('generates link without note when note is empty', () => {
@@ -107,7 +124,7 @@ describe('generateVenmoLink', () => {
   it('handles special characters in note', () => {
     const link = generateVenmoLink('5551234567', 25.50, 'Café & Co.');
 
-    expect(link).toContain('note=Caf%C3%A9+%26+Co.');
+    expect(link).toContain('note=Caf%C3%A9%20%26%20Co.');
   });
 
   it('generates link for USD currency (explicit)', () => {
@@ -158,7 +175,7 @@ describe('openVenmoPayment', () => {
     
     expect(result).toBe(true);
     expect(getMockWindowOpen()).toHaveBeenCalledWith(
-      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test+Restaurant',
+      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test%20Restaurant',
       '_blank',
       'noopener,noreferrer'
     );
@@ -200,7 +217,7 @@ describe('shareVenmoPayment', () => {
     expect(getMockNavigatorShare()).toHaveBeenCalledWith({
       title: 'Pay Alice via Venmo',
       text: 'Pay Alice $25.50 via Venmo',
-      url: 'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test+Restaurant',
+      url: 'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test%20Restaurant',
     });
     expect(getMockWindowOpen()).not.toHaveBeenCalled();
   });
@@ -213,7 +230,7 @@ describe('shareVenmoPayment', () => {
     
     expect(getMockNavigatorShare()).toHaveBeenCalled();
     expect(getMockWindowOpen()).toHaveBeenCalledWith(
-      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test+Restaurant',
+      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test%20Restaurant',
       '_blank',
       'noopener,noreferrer'
     );
@@ -272,7 +289,7 @@ describe('shareVenmoPayment', () => {
     await shareVenmoPayment('5551234567', 25.50, 'Test Restaurant', 'Alice');
 
     expect(getMockWindowOpen()).toHaveBeenCalledWith(
-      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test+Restaurant',
+      'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test%20Restaurant',
       '_blank',
       'noopener,noreferrer'
     );
@@ -308,7 +325,7 @@ describe('shareVenmoPayment', () => {
     expect(getMockNavigatorShare()).toHaveBeenCalledWith({
       title: 'Pay Alice via Venmo',
       text: 'Pay Alice $25.50 via Venmo',
-      url: 'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test+Restaurant',
+      url: 'https://venmo.com/?txn=pay&recipients=5551234567&amount=25.50&note=Test%20Restaurant',
     });
   });
 });

--- a/src/lib/venmo-utils.ts
+++ b/src/lib/venmo-utils.ts
@@ -92,7 +92,20 @@ export function generateVenmoLink(
     urlParams.set('note', note.trim());
   }
 
-  return `${VENMO_CONFIG.BASE_URL}?${urlParams.toString()}`;
+  // Venmo displays `+` as a literal character, so encode spaces as %20.
+  return `${VENMO_CONFIG.BASE_URL}?${toVenmoQueryString(urlParams)}`;
+}
+
+/**
+ * Serializes query params for Venmo deep links.
+ *
+ * `URLSearchParams#toString()` encodes spaces as `+`. Venmo does not treat
+ * `+` as a space, so notes like "Olive Garden - Karan" would show up as
+ * "Olive+Garden+-+Karan". Literal `+` characters are already `%2B` and are
+ * left unchanged.
+ */
+function toVenmoQueryString(params: URLSearchParams): string {
+  return params.toString().replace(/\+/g, '%20');
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Venmo payment notes were showing plus signs instead of spaces, e.g. `"Olive+Garden+-+Karan"` instead of `"Olive Garden - Karan"`.

`generateVenmoLink` built the query string with `URLSearchParams`, which form-encodes spaces as `+`. Venmo’s app treats those plus signs as literal characters in the note.

## Change

Percent-encode spaces as `%20` after serializing query params. Literal `+` characters in a note stay `%2B`.

Added a regression test for the Olive Garden note from the reported screenshot.

## Testing

- `npx jest src/lib/venmo-utils.test.ts` — 41 passed
- `npx jest --passWithNoTests` — 548 passed
- `npx eslint src/lib/venmo-utils.ts src/lib/venmo-utils.test.ts` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02238-f3ea-7573-a6cf-2a65fe13a3fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02238-f3ea-7573-a6cf-2a65fe13a3fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

