### PR TITLE
Redesign shared split page for a lighter, more modern layout

### DIFF
--- a/scripts/screenshot-harness.js
+++ b/scripts/screenshot-harness.js
@@ -197,7 +197,7 @@ async function takeScreenshots(options) {
             await page.waitForSelector('[role="tabpanel"]', { timeout: 5000 });
           } else if (options.route === '/split' && options.mockData) {
             // Wait for split summary to load
-            await page.waitForSelector('text=Receipt Split', { timeout: 5000 });
+            await page.waitForSelector('text=Test Restaurant', { timeout: 5000 });
           }
         } catch {
           // If specific elements don't appear, continue anyway after networkidle

--- a/src/app/split/page.test.tsx
+++ b/src/app/split/page.test.tsx
@@ -20,8 +20,8 @@ describe("/split route (client) with query params", () => {
 
     // Wait for final content
     await waitFor(() => {
-      expect(screen.getByText("Receipt Split")).toBeInTheDocument();
-      expect(screen.getByText("Total Bill")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Love Mama" })).toBeInTheDocument();
+      expect(screen.getByText("Total")).toBeInTheDocument();
       expect(screen.getByText("$67.52")).toBeInTheDocument();
     });
 

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -139,7 +139,7 @@ function SplitPageContent() {
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto flex w-full max-w-lg flex-col gap-8 px-4 py-6 sm:py-10">
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-5 sm:py-10">
         <Button variant="ghost" size="sm" asChild className="-ml-3 self-start">
           <Link href="/">
             <ArrowLeft data-icon="inline-start" />

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -139,7 +139,7 @@ function SplitPageContent() {
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-5 sm:py-10">
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-6 sm:py-10">
         <Button variant="ghost" size="sm" asChild className="-ml-3 self-start">
           <Link href="/">
             <ArrowLeft data-icon="inline-start" />

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState, Suspense } from "react";
-import { Card, CardContent } from "@/components/ui/card";
+import { useEffect, useState, Suspense, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
 import {
@@ -18,6 +17,28 @@ interface SplitPageState {
   splitData: SharedSplitData | null;
   isLoading: boolean;
   error: string | null;
+}
+
+function StatusScreen({
+  icon,
+  title,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="flex w-full max-w-sm flex-col items-center gap-4 text-center">
+        {icon}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-lg font-semibold">{title}</h1>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function SplitPageContent() {
@@ -74,123 +95,57 @@ function SplitPageContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 
-  // Loading state with enhanced design
   if (state.isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background p-4">
-        <Card className="w-full max-w-md animate-in fade-in-0 slide-in-from-bottom-4 duration-500">
-          <CardContent className="flex flex-col items-center justify-center py-8 px-6">
-            <div className="relative mb-6">
-              <Loader2 className="h-12 w-12 animate-spin text-primary" />
-              <div className="absolute inset-0 h-12 w-12 animate-ping rounded-full bg-primary/20" />
-            </div>
-            <h2 className="text-xl font-semibold mb-3 text-center">
-              Loading Split Details
-            </h2>
-            <p className="text-sm text-muted-foreground text-center leading-relaxed">
-              Processing your receipt split and payment information...
-            </p>
-            <div className="mt-4 w-full bg-muted/50 rounded-full h-1">
-              <div
-                className="bg-primary h-1 rounded-full animate-pulse"
-                style={{ width: "60%" }}
-              />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <StatusScreen
+        icon={
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        }
+        title="Loading split"
+      >
+        <p className="text-sm text-muted-foreground">
+          Getting payment details ready…
+        </p>
+      </StatusScreen>
     );
   }
 
-  // Error state with enhanced design and helpful information
   if (state.error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background p-4">
-        <Card className="w-full max-w-md animate-in fade-in-0 slide-in-from-bottom-4 duration-500">
-          <CardContent className="flex flex-col items-center justify-center py-8 px-6">
-            <div className="relative mb-6">
-              <AlertCircle className="h-16 w-16 text-destructive" />
-              <div className="absolute inset-0 h-16 w-16 animate-pulse rounded-full bg-destructive/10" />
-            </div>
-            <h2 className="text-xl font-semibold mb-3 text-center">
-              Unable to Load Split
-            </h2>
-            <p className="text-sm text-muted-foreground text-center mb-6 leading-relaxed">
-              {state.error}
-            </p>
-
-            {/* Help Tips */}
-            <div className="w-full mb-6 p-4 bg-muted/50 rounded-lg">
-              <p className="text-xs font-medium text-muted-foreground mb-2">
-                Common solutions:
-              </p>
-              <ul className="text-xs text-muted-foreground space-y-1">
-                <li>• Check if the URL was copied completely</li>
-                <li>• Ensure the original split was created successfully</li>
-                <li>• Try refreshing the page</li>
-              </ul>
-            </div>
-
-            <div className="flex flex-col gap-3 w-full">
-              <Button
-                variant="outline"
-                asChild
-                className="w-full h-11 text-base transition-all duration-200 hover:bg-muted active:scale-95"
-              >
-                <Link href="/">
-                  <ArrowLeft className="h-5 w-5 mr-2" />
-                  Create New Split
-                </Link>
-              </Button>
-
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => window.location.reload()}
-                className="w-full transition-all duration-200"
-              >
-                Try Refreshing Page
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <StatusScreen
+        icon={<AlertCircle className="size-8 text-destructive" />}
+        title="Unable to Load Split"
+      >
+        <p className="text-sm text-muted-foreground">{state.error}</p>
+        <div className="flex w-full flex-col gap-2 pt-2">
+          <Button variant="outline" asChild>
+            <Link href="/">
+              <ArrowLeft data-icon="inline-start" />
+              Create New Split
+            </Link>
+          </Button>
+          <Button variant="ghost" onClick={() => window.location.reload()}>
+            Refresh
+          </Button>
+        </div>
+      </StatusScreen>
     );
   }
 
-  // Success state - split data loaded
   const { splitData } = state;
   if (!splitData) {
-    return null; // This shouldn't happen, but TypeScript safety
+    return null;
   }
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 sm:px-6 py-6 sm:py-8 max-w-4xl">
-        {/* Header */}
-        <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-8">
-          <Button
-            variant="ghost"
-            size="sm"
-            asChild
-            className="self-start h-10 px-3 transition-all duration-200 hover:bg-muted active:scale-95"
-          >
-            <Link href="/">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to App
-            </Link>
-          </Button>
-          <div className="flex-1">
-            <h1 className="text-2xl sm:text-3xl font-bold mb-1">
-              Receipt Split
-            </h1>
-            <p className="text-sm sm:text-base text-muted-foreground">
-              Review the split details and pay your amount
-            </p>
-          </div>
-        </div>
-
-        {/* Split Summary */}
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-8 px-4 py-6 sm:py-10">
+        <Button variant="ghost" size="sm" asChild className="-ml-3 self-start">
+          <Link href="/">
+            <ArrowLeft data-icon="inline-start" />
+            Back
+          </Link>
+        </Button>
         <SplitSummary splitData={splitData} phoneNumber={splitData.phone} />
       </div>
     </div>
@@ -201,19 +156,16 @@ export default function SplitPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen flex items-center justify-center bg-background">
-          <Card className="w-full max-w-md mx-4">
-            <CardContent className="flex flex-col items-center justify-center py-8">
-              <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
-              <h2 className="text-lg font-semibold mb-2">
-                Loading Split Details
-              </h2>
-              <p className="text-sm text-muted-foreground text-center">
-                Processing your receipt split...
-              </p>
-            </CardContent>
-          </Card>
-        </div>
+        <StatusScreen
+          icon={
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          }
+          title="Loading split"
+        >
+          <p className="text-sm text-muted-foreground">
+            Getting payment details ready…
+          </p>
+        </StatusScreen>
       }
     >
       <SplitPageContent />

--- a/src/components/split-summary.test.tsx
+++ b/src/components/split-summary.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { SplitSummary } from "./split-summary";
 import { type SharedSplitData } from "@/lib/split-sharing";
 
-// Mock the formatCurrency function
 jest.mock("@/lib/receipt-utils", () => ({
   formatCurrency: jest.fn((amount: number) => `$${amount.toFixed(2)}`),
 }));
@@ -27,20 +26,16 @@ const mockMinimalSplitData: SharedSplitData = {
 };
 
 describe("SplitSummary", () => {
-  it("renders complete split summary with all information", () => {
+  it("renders restaurant, total, date, and people", () => {
     render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
 
-    // Check main title - text is now split across elements
-    expect(screen.getByText("Split from")).toBeInTheDocument();
-
-    // Check note/description info (required field) - now in header
-    expect(screen.getByText("Pizza Palace")).toBeInTheDocument();
-
-    // Check total amount
-    expect(screen.getByText("Total Bill")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Pizza Palace" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mon, Jan 15, 2024 · 3 people")).toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
     expect(screen.getByText("$65.00")).toBeInTheDocument();
 
-    // Check individual breakdown - cards are still present
     expect(screen.getByText("Alice")).toBeInTheDocument();
     expect(screen.getByText("Bob")).toBeInTheDocument();
     expect(screen.getByText("Charlie")).toBeInTheDocument();
@@ -49,30 +44,21 @@ describe("SplitSummary", () => {
     expect(screen.getByText("$13.00")).toBeInTheDocument();
   });
 
-  it("renders minimal split summary without optional date field", () => {
+  it("omits the date when it is not provided", () => {
     render(
       <SplitSummary splitData={mockMinimalSplitData} phoneNumber="5551234567" />
     );
 
-    // Check main title - text is now split across elements
-    expect(screen.getByText("Split from")).toBeInTheDocument();
-
-    // Note should be present (required field) - now in header
-    expect(screen.getByText("Test Split")).toBeInTheDocument();
-
-    // Date should not be present (optional field not provided)
-    // Note: Date cards have been removed from the UI
-
-    // Check total amount - use getAllByText since $25.00 appears twice
-    expect(screen.getByText("Total Bill")).toBeInTheDocument();
-    const amounts = screen.getAllByText("$25.00");
-    expect(amounts.length).toBeGreaterThan(0);
-
-    // Check single person data is displayed
-    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Test Split" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 person")).toBeInTheDocument();
+    expect(screen.queryByText(/Jan/)).not.toBeInTheDocument();
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getAllByText("$25.00").length).toBeGreaterThan(0);
   });
 
-  it("handles date formatting correctly", () => {
+  it("formats dates without shifting the calendar day", () => {
     const splitDataWithDate: SharedSplitData = {
       ...mockMinimalSplitData,
       date: "2024-12-25",
@@ -82,9 +68,7 @@ describe("SplitSummary", () => {
       <SplitSummary splitData={splitDataWithDate} phoneNumber="5551234567" />
     );
 
-    // Date cards have been removed from the UI, but date still appears in title
-    // Should format as a readable date - be flexible about the day due to timezone differences
-    expect(screen.getByText(/Dec.*2[4-5].*2024/)).toBeInTheDocument();
+    expect(screen.getByText(/Wed, Dec 25, 2024 · 1 person/)).toBeInTheDocument();
   });
 
   it("handles invalid date gracefully", () => {
@@ -97,64 +81,10 @@ describe("SplitSummary", () => {
       <SplitSummary splitData={splitDataWithBadDate} phoneNumber="5551234567" />
     );
 
-    // Date cards have been removed from the UI, but invalid date still appears in title
-    // Should fall back to original string when date parsing fails
-    expect(screen.getByText("invalid-date")).toBeInTheDocument();
+    expect(screen.getByText(/invalid-date · 1 person/)).toBeInTheDocument();
   });
 
-  it("displays verification note with correct calculation", () => {
-    render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
-
-    // Verification note has been removed for cleaner design
-    // Component now focuses on core split information display
-  });
-
-  it("handles single person correctly", () => {
-    render(
-      <SplitSummary splitData={mockMinimalSplitData} phoneNumber="5551234567" />
-    );
-
-    // Single person data is displayed in individual breakdown cards
-    expect(screen.getByText("Alice")).toBeInTheDocument();
-    // $25.00 appears twice (Total Bill and individual amount), so use getAllByText
-    const amounts = screen.getAllByText("$25.00");
-    expect(amounts.length).toBeGreaterThan(0);
-  });
-
-  it("handles multiple people correctly", () => {
-    render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
-
-    // Multiple people data is displayed in individual breakdown cards
-    expect(screen.getByText("Alice")).toBeInTheDocument();
-    expect(screen.getByText("Bob")).toBeInTheDocument();
-    expect(screen.getByText("Charlie")).toBeInTheDocument();
-    expect(screen.getByText("$32.50")).toBeInTheDocument();
-    expect(screen.getByText("$19.50")).toBeInTheDocument();
-    expect(screen.getByText("$13.00")).toBeInTheDocument();
-  });
-
-  it("displays all individual amounts in breakdown", () => {
-    render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
-
-    // All names should be present
-    mockSplitData.names.forEach((name) => {
-      expect(screen.getByText(name)).toBeInTheDocument();
-    });
-
-    // All amounts should be present (formatted by mock function)
-    mockSplitData.amounts.forEach((amount) => {
-      expect(screen.getByText(`$${amount.toFixed(2)}`)).toBeInTheDocument();
-    });
-  });
-
-  it("always displays required note field", () => {
-    render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
-
-    // Note is required, so should always be present in the header
-    expect(screen.getByText("Pizza Palace")).toBeInTheDocument();
-  });
-
-  it("handles long note names with truncation", () => {
+  it("keeps long restaurant names in the document", () => {
     const longNoteData: SharedSplitData = {
       ...mockMinimalSplitData,
       note: "This is a very long restaurant name that should be truncated properly",
@@ -162,11 +92,62 @@ describe("SplitSummary", () => {
 
     render(<SplitSummary splitData={longNoteData} phoneNumber="5551234567" />);
 
-    // The full text should be present in the DOM (truncation is CSS-based)
     expect(
-      screen.getByText(
-        "This is a very long restaurant name that should be truncated properly"
-      )
+      screen.getByRole("heading", {
+        name: "This is a very long restaurant name that should be truncated properly",
+      })
     ).toBeInTheDocument();
+  });
+
+  it("shows Venmo pay actions for USD splits", () => {
+    render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
+
+    expect(
+      screen.getByRole("button", { name: "Pay $32.50 for Alice with Venmo" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Pay $19.50 for Bob with Venmo" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Pay $13.00 for Charlie with Venmo" })
+    ).toBeInTheDocument();
+  });
+
+  it("opens a Venmo link when Pay is clicked", () => {
+    render(<SplitSummary splitData={mockSplitData} phoneNumber="5551234567" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Pay $32.50 for Alice with Venmo" })
+    );
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("https://venmo.com/"),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+
+  it("always shows amounts even without a payment phone number", () => {
+    render(<SplitSummary splitData={mockSplitData} />);
+
+    expect(screen.getByText("$32.50")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /with Venmo/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Venmo actions for non-USD currencies but still shows amounts", () => {
+    const euroSplit: SharedSplitData = {
+      ...mockSplitData,
+      currency: "EUR",
+    };
+
+    render(<SplitSummary splitData={euroSplit} phoneNumber="5551234567" />);
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("$32.50")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /with Venmo/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/split-summary.tsx
+++ b/src/components/split-summary.tsx
@@ -1,4 +1,10 @@
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "@/components/ui/card";
 import { type SharedSplitData } from "@/lib/split-sharing";
 import { formatCurrency } from "@/lib/receipt-utils";
 import { formatVenmoNote, openVenmoPayment } from "@/lib/venmo-utils";
@@ -30,15 +36,15 @@ function SplitPersonRow({
   const formattedAmount = formatCurrency(amount, currency);
 
   return (
-    <li className="flex items-center gap-3 py-1">
+    <li className="flex items-center gap-3 px-5 py-3 sm:px-6">
       <div
-        className="flex size-8 shrink-0 items-center justify-center rounded-full bg-background text-xs font-medium"
+        className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium"
         aria-hidden="true"
       >
         {name.charAt(0).toUpperCase()}
       </div>
       <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
-      <span className="shrink-0 tabular-nums text-sm font-medium">
+      <span className="shrink-0 tabular-nums font-medium">
         {formattedAmount}
       </span>
       {canPayWithVenmo && (
@@ -46,7 +52,7 @@ function SplitPersonRow({
           size="sm"
           onClick={onPay}
           aria-label={`Pay ${formattedAmount} for ${name} with Venmo`}
-          className="shrink-0 rounded-full bg-[#008CFF] px-3 text-white hover:bg-[#0074D9]"
+          className="shrink-0 bg-[#008CFF] px-3 text-white hover:bg-[#0074D9]"
         >
           <Image src="/venmo.png" alt="" width={14} height={14} />
           Pay
@@ -64,46 +70,47 @@ export function SplitSummary({ splitData, phoneNumber }: SplitSummaryProps) {
   ].filter(Boolean);
 
   return (
-    <div className="flex flex-col gap-6">
-      <header className="flex flex-col gap-4">
+    <Card className="gap-0 py-0">
+      <CardHeader className="gap-4 px-5 py-5 sm:px-6 sm:py-6">
         <div className="flex flex-col gap-1">
           <h1 className="text-2xl font-semibold tracking-tight text-balance">
             {splitData.note}
           </h1>
-          <p className="text-sm text-muted-foreground">{meta.join(" · ")}</p>
+          <CardDescription>{meta.join(" · ")}</CardDescription>
         </div>
         <div className="flex flex-col gap-1">
-          <p className="text-4xl font-semibold tracking-tight tabular-nums">
+          <p className="text-3xl font-semibold tracking-tight tabular-nums">
             {formatCurrency(splitData.total, splitData.currency)}
           </p>
           <p className="text-sm text-muted-foreground">Total</p>
         </div>
-      </header>
-
-      <section aria-labelledby="split-amounts-heading">
-        <h2 id="split-amounts-heading" className="sr-only">
-          Individual amounts
-        </h2>
-        <ul className="flex flex-col divide-y divide-border overflow-hidden rounded-xl bg-muted/50 px-3">
-          {splitData.names.map((name, index) => (
-            <SplitPersonRow
-              key={`${name}-${index}`}
-              name={name}
-              amount={splitData.amounts[index]}
-              currency={splitData.currency}
-              canPayWithVenmo={canPayWithVenmo}
-              onPay={() => {
-                if (!phoneNumber) return;
-                openVenmoPayment(
-                  phoneNumber,
-                  splitData.amounts[index],
-                  formatVenmoNote(splitData.note, name)
-                );
-              }}
-            />
-          ))}
-        </ul>
-      </section>
-    </div>
+      </CardHeader>
+      <CardContent className="px-0 pb-2">
+        <section aria-labelledby="split-amounts-heading">
+          <h2 id="split-amounts-heading" className="sr-only">
+            Individual amounts
+          </h2>
+          <ul className="flex flex-col divide-y divide-border border-t">
+            {splitData.names.map((name, index) => (
+              <SplitPersonRow
+                key={`${name}-${index}`}
+                name={name}
+                amount={splitData.amounts[index]}
+                currency={splitData.currency}
+                canPayWithVenmo={canPayWithVenmo}
+                onPay={() => {
+                  if (!phoneNumber) return;
+                  openVenmoPayment(
+                    phoneNumber,
+                    splitData.amounts[index],
+                    formatVenmoNote(splitData.note, name)
+                  );
+                }}
+              />
+            ))}
+          </ul>
+        </section>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/split-summary.tsx
+++ b/src/components/split-summary.tsx
@@ -1,9 +1,8 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Receipt, DollarSign } from "lucide-react";
 import { type SharedSplitData } from "@/lib/split-sharing";
 import { formatCurrency } from "@/lib/receipt-utils";
-import { generateVenmoLink } from "@/lib/venmo-utils";
+import { formatVenmoNote, openVenmoPayment } from "@/lib/venmo-utils";
+import { formatDisplayDate } from "@/lib/date-utils";
 import Image from "next/image";
 
 interface SplitSummaryProps {
@@ -11,125 +10,100 @@ interface SplitSummaryProps {
   phoneNumber?: string;
 }
 
-export function SplitSummary({ splitData, phoneNumber }: SplitSummaryProps) {
-  const formatDate = (dateString: string): string => {
-    try {
-      const date = new Date(dateString);
-      // Check if the date is valid
-      if (isNaN(date.getTime())) {
-        return dateString; // Fallback to original string if invalid
-      }
-      return date.toLocaleDateString("en-US", {
-        weekday: "short",
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      });
-    } catch {
-      return dateString; // Fallback to original string if parsing fails
-    }
-  };
+function personCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "person" : "people"}`;
+}
+
+function SplitPersonRow({
+  name,
+  amount,
+  currency,
+  canPayWithVenmo,
+  onPay,
+}: {
+  name: string;
+  amount: number;
+  currency: string;
+  canPayWithVenmo: boolean;
+  onPay: () => void;
+}) {
+  const formattedAmount = formatCurrency(amount, currency);
 
   return (
-    <Card className="w-full transition-all duration-300 hover:shadow-lg">
-      <CardHeader>
-        <CardTitle className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 text-xl sm:text-2xl text-center sm:text-left">
-          <div className="flex items-center justify-start gap-3">
-            <div className="p-2 rounded-lg bg-primary/10">
-              <Receipt className="h-6 w-6 text-primary" />
-            </div>
-            <span>Split from </span>
-          </div>
-          <span className="px-3 py-1 bg-primary/10 rounded-lg border border-primary/20 text-primary font-medium">
-            {splitData.note}
-          </span>
-          {splitData.date && (
-            <>
-              <span className="text-muted-foreground">on</span>
-              <span className="px-3 py-1 bg-primary/10 rounded-lg border border-primary/20 text-primary font-medium">
-                {formatDate(splitData.date)}
-              </span>
-            </>
-          )}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        <div className="flex justify-center">
-          <div className="w-full max-w-sm sm:max-w-md md:w-auto md:max-w-none">
-            <div className="flex md:inline-flex w-full md:w-auto flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 px-6 py-5 bg-gradient-to-br from-primary/10 to-primary/5 rounded-xl border border-primary/20 shadow-inner transition-all duration-200 hover:border-primary/30">
-              <div className="h-9 w-9 rounded-full bg-primary/15 ring-1 ring-primary/20 flex items-center justify-center">
-                <DollarSign className="h-5 w-5 text-primary" />
-              </div>
-              <div className="text-center">
-                <p className="text-xs tracking-wide uppercase text-muted-foreground">
-                  Total Bill
-                </p>
-                <p className="font-extrabold text-2xl sm:text-3xl text-primary mt-1">
-                  {formatCurrency(splitData.total, splitData.currency)}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+    <li className="flex items-center gap-3 py-3">
+      <div
+        className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium"
+        aria-hidden="true"
+      >
+        {name.charAt(0).toUpperCase()}
+      </div>
+      <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+      <span className="shrink-0 tabular-nums text-sm font-medium">
+        {formattedAmount}
+      </span>
+      {canPayWithVenmo && (
+        <Button
+          size="sm"
+          onClick={onPay}
+          aria-label={`Pay ${formattedAmount} for ${name} with Venmo`}
+          className="shrink-0 bg-[#008CFF] px-3 text-white hover:bg-[#0074D9]"
+        >
+          <Image src="/venmo.png" alt="" width={14} height={14} />
+          Pay
+        </Button>
+      )}
+    </li>
+  );
+}
 
-        {/* Individual Breakdown */}
-        <div className="space-y-4">
-          <div className="space-y-3">
-            {splitData.names.map((name, index) => (
-              <div
-                key={`${name}-${index}`}
-                className="flex justify-between items-center py-4 px-4 bg-gradient-to-r from-muted/40 to-muted/20 rounded-xl"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-                    <span className="text-sm font-semibold text-primary">
-                      {name[0]}
-                    </span>
-                  </div>
-                  <span className="font-semibold text-base">{name}</span>
-                </div>
-                <div className="flex items-center gap-3">
-                  {phoneNumber && splitData.currency === 'USD' && (
-                    <Button
-                      onClick={() => {
-                        const note = `${splitData.note} - ${name}`;
-                        const venmoLink = generateVenmoLink(
-                          phoneNumber,
-                          splitData.amounts[index],
-                          note
-                        );
-                        if (venmoLink) {
-                          window.open(
-                            venmoLink,
-                            "_blank",
-                            "noopener,noreferrer"
-                          );
-                        }
-                      }}
-                      size="sm"
-                      className="px-3 text-xs font-medium transition-all duration-200 hover:shadow-md active:scale-95 bg-[#008CFF] hover:bg-[#0074D9] text-white dark:bg-[#008CFF] dark:hover:bg-[#0074D9]"
-                    >
-                      <Image
-                        src="/venmo.png"
-                        alt="Venmo"
-                        width={12}
-                        height={12}
-                        className="mr-1"
-                      />
-                      {formatCurrency(splitData.amounts[index], splitData.currency)}
-                    </Button>
-                  )}
-                  {phoneNumber && splitData.currency !== 'USD' && (
-                    <span className="text-sm font-semibold">
-                      {formatCurrency(splitData.amounts[index], splitData.currency)}
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+export function SplitSummary({ splitData, phoneNumber }: SplitSummaryProps) {
+  const canPayWithVenmo = Boolean(phoneNumber) && splitData.currency === "USD";
+  const meta = [
+    splitData.date ? formatDisplayDate(splitData.date) : null,
+    personCountLabel(splitData.names.length),
+  ].filter(Boolean);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="flex flex-col gap-5">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-balance">
+            {splitData.note}
+          </h1>
+          <p className="text-sm text-muted-foreground">{meta.join(" · ")}</p>
         </div>
-      </CardContent>
-    </Card>
+        <div className="flex flex-col gap-1">
+          <p className="text-4xl font-semibold tracking-tight tabular-nums">
+            {formatCurrency(splitData.total, splitData.currency)}
+          </p>
+          <p className="text-sm text-muted-foreground">Total</p>
+        </div>
+      </header>
+
+      <section aria-labelledby="split-amounts-heading">
+        <h2 id="split-amounts-heading" className="sr-only">
+          Individual amounts
+        </h2>
+        <ul className="flex flex-col divide-y divide-border border-y">
+          {splitData.names.map((name, index) => (
+            <SplitPersonRow
+              key={`${name}-${index}`}
+              name={name}
+              amount={splitData.amounts[index]}
+              currency={splitData.currency}
+              canPayWithVenmo={canPayWithVenmo}
+              onPay={() => {
+                if (!phoneNumber) return;
+                openVenmoPayment(
+                  phoneNumber,
+                  splitData.amounts[index],
+                  formatVenmoNote(splitData.note, name)
+                );
+              }}
+            />
+          ))}
+        </ul>
+      </section>
+    </div>
   );
 }

--- a/src/components/split-summary.tsx
+++ b/src/components/split-summary.tsx
@@ -30,9 +30,9 @@ function SplitPersonRow({
   const formattedAmount = formatCurrency(amount, currency);
 
   return (
-    <li className="flex items-center gap-3 py-3">
+    <li className="flex items-center gap-3 py-1">
       <div
-        className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium"
+        className="flex size-8 shrink-0 items-center justify-center rounded-full bg-background text-xs font-medium"
         aria-hidden="true"
       >
         {name.charAt(0).toUpperCase()}
@@ -46,7 +46,7 @@ function SplitPersonRow({
           size="sm"
           onClick={onPay}
           aria-label={`Pay ${formattedAmount} for ${name} with Venmo`}
-          className="shrink-0 bg-[#008CFF] px-3 text-white hover:bg-[#0074D9]"
+          className="shrink-0 rounded-full bg-[#008CFF] px-3 text-white hover:bg-[#0074D9]"
         >
           <Image src="/venmo.png" alt="" width={14} height={14} />
           Pay
@@ -64,8 +64,8 @@ export function SplitSummary({ splitData, phoneNumber }: SplitSummaryProps) {
   ].filter(Boolean);
 
   return (
-    <div className="flex flex-col gap-8">
-      <header className="flex flex-col gap-5">
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h1 className="text-2xl font-semibold tracking-tight text-balance">
             {splitData.note}
@@ -84,7 +84,7 @@ export function SplitSummary({ splitData, phoneNumber }: SplitSummaryProps) {
         <h2 id="split-amounts-heading" className="sr-only">
           Individual amounts
         </h2>
-        <ul className="flex flex-col divide-y divide-border border-y">
+        <ul className="flex flex-col divide-y divide-border overflow-hidden rounded-xl bg-muted/50 px-3">
           {splitData.names.map((name, index) => (
             <SplitPersonRow
               key={`${name}-${index}`}

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -1,0 +1,26 @@
+import { formatDisplayDate, parseDateString } from "./date-utils";
+
+describe("parseDateString", () => {
+  it("parses YYYY-MM-DD as a local calendar date", () => {
+    const date = parseDateString("2026-08-20");
+    expect(date).not.toBeNull();
+    expect(date?.getFullYear()).toBe(2026);
+    expect(date?.getMonth()).toBe(7);
+    expect(date?.getDate()).toBe(20);
+  });
+
+  it("returns null for invalid dates", () => {
+    expect(parseDateString("invalid-date")).toBeNull();
+  });
+});
+
+describe("formatDisplayDate", () => {
+  it("formats ISO dates without timezone shift", () => {
+    expect(formatDisplayDate("2026-08-20")).toBe("Thu, Aug 20, 2026");
+    expect(formatDisplayDate("2024-12-25")).toBe("Wed, Dec 25, 2024");
+  });
+
+  it("returns the original string when parsing fails", () => {
+    expect(formatDisplayDate("invalid-date")).toBe("invalid-date");
+  });
+});

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,36 @@
+const ISO_DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parse a date string without shifting calendar dates across timezones.
+ * `YYYY-MM-DD` is treated as a local calendar date (not UTC midnight).
+ */
+export function parseDateString(dateString: string): Date | null {
+  const isoDate = ISO_DATE_ONLY.exec(dateString);
+  const date = isoDate
+    ? new Date(
+        Number(isoDate[1]),
+        Number(isoDate[2]) - 1,
+        Number(isoDate[3])
+      )
+    : new Date(dateString);
+
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Format a date for display on the split page.
+ * Invalid values fall back to the original string.
+ */
+export function formatDisplayDate(dateString: string): string {
+  const date = parseDateString(dateString);
+  if (!date) {
+    return dateString;
+  }
+
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The shared `/split` page used nested cards, stacked location/date pills, and a second “total bill” box. That made a simple payment screen feel bulky, especially on mobile.

This redesign keeps a receipt-style header, then lands between the original cards and the first compressed pass:

- Restaurant name is the heading, with date and party size on one muted line
- Total is large type inside one standard card, not a nested “total bill” box
- People sit in a roomier list (not a narrow, heavily rounded pill group)
- Venmo is a **Pay** action next to the amount, using the usual button radius
- Loading and error states drop the extra chrome (fake progress bar, ping animation)

`YYYY-MM-DD` receipt dates are parsed as local calendar days, so a link like `date=2026-08-20` shows August 20 instead of shifting to the previous day in US timezones.

Existing Venmo helpers (`openVenmoPayment`, `formatVenmoNote`) are reused instead of duplicating link-opening logic in the summary component.

## Screenshots

Dark mode (iPhone):

[Split page dark mode](https://cursor.com/agents/bc-01a0223a-345e-7a9a-9ca1-ae2ffa84bdc3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsplit-page-dark.png)

Light mode (iPhone):

[Split page light mode](https://cursor.com/agents/bc-01a0223a-345e-7a9a-9ca1-ae2ffa84bdc3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsplit-page-light.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0223a-345e-7a9a-9ca1-ae2ffa84bdc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0223a-345e-7a9a-9ca1-ae2ffa84bdc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

