### PR TITLE
feat: persist a per-receipt thumbnail for each accepted receipt

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -146,8 +146,53 @@ describe("Home Page", () => {
       render(<Home />);
       expect(screen.getByRole("tab", { name: /add people/i })).toHaveAttribute("data-state", "active");
       expect(screen.getByRole("tab", { name: /add people/i })).toBeEnabled();
-      expect(screen.getByRole("tab", { name: /assign items/i })).toBeEnabled();
       expect(screen.getByRole("tab", { name: /results/i })).toBeDisabled();
+    });
+
+    // Regression test for the PR #177 review finding: ReceiptUploader's mount
+    // effect used to call migrateLegacyImage(null), which deleted the legacy
+    // receiptSplitterImage key before Home's session-restore effect (parent,
+    // runs after the child) could attach it to the newest receipt. The legacy
+    // image must survive the child's mount and be attached + removed only by
+    // the page-level migration.
+    it("migrates a legacy receiptSplitterImage onto the newest restored receipt despite child-effect ordering", async () => {
+      const legacyImage = "data:image/png;base64,legacy-image-bytes";
+      localStorage.setItem(RECEIPT_IMAGE_STORAGE_KEY, legacyImage);
+      const firstReceiptId = "00000000-0000-4000-8000-000000000001";
+      const lastReceiptId = "00000000-0000-4000-8000-000000000002";
+      localStorage.setItem(
+        "receiptSplitterSession",
+        JSON.stringify({
+          version: 2,
+          state: {
+            receipts: [
+              { id: firstReceiptId, receipt: mockReceipt },
+              { id: lastReceiptId, receipt: createMockReceipt({ restaurant: "Newest" }) },
+            ],
+            people: [],
+            assignedItems: [],
+            groups: [],
+            isLoading: false,
+            error: null,
+          },
+          activeTab: "upload",
+        })
+      );
+
+      // Render with real effects — this exercises the actual child-before-parent
+      // passive-effect ordering between ReceiptUploader and Home on mount.
+      render(<Home />);
+
+      await waitFor(() => {
+        // Legacy key is consumed only AFTER successful association...
+        expect(localStorage.getItem(RECEIPT_IMAGE_STORAGE_KEY)).toBeNull();
+        // ...onto the NEWEST receipt, not the first one.
+        const thumbnails = JSON.parse(
+          localStorage.getItem("receiptSplitterThumbnails") as string
+        );
+        expect(thumbnails[lastReceiptId]).toBe(legacyImage);
+        expect(thumbnails[firstReceiptId]).toBeUndefined();
+      });
     });
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,12 @@ import {
   safeSetItem,
 } from "@/lib/storage";
 import {
+  clearThumbnails,
+  migrateLegacyImage,
+  pruneThumbnails,
+  removeThumbnail,
+} from "@/lib/receipt-thumbnails";
+import {
   SESSION_STORAGE_KEY,
   emptyReceiptState,
   serializeSession,
@@ -209,6 +215,12 @@ export default function Home() {
       const restored = deserializeSession(session);
       if (restored) {
         setState(restored.state);
+        // Re-attach any thumbnails orphaned by a corrupted/rolled-back blob,
+        // then migrate the legacy singular image key onto the newest receipt.
+        pruneThumbnails(restored.state.receipts.map((r) => r.id));
+        migrateLegacyImage(
+          restored.state.receipts[restored.state.receipts.length - 1]?.id
+        );
         const restoredTab = restored.activeTab || "upload";
         const restoredAssigned = validateSessionAssignments(
           restored.state.receipts,
@@ -244,8 +256,9 @@ export default function Home() {
       const serialized = serializeSession(state, activeTab);
       const ok = safeSetItem(SESSION_STORAGE_KEY, serialized);
       if (!ok) {
-        // Quota exhausted — evict the cached image (largest consumer) and retry once
+        // Quota exhausted — evict cached images (largest consumers) and retry once
         safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
+        clearThumbnails();
         safeSetItem(SESSION_STORAGE_KEY, serialized);
       }
       setHasSession(!isDefaultSession(state, activeTab));
@@ -256,6 +269,7 @@ export default function Home() {
   const handleNewSplit = () => {
     safeRemoveItem(SESSION_STORAGE_KEY);
     safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
+    clearThumbnails();
     const empty = emptyReceiptState();
     stateRef.current = empty;
     setState(empty);
@@ -295,8 +309,9 @@ export default function Home() {
       : ((totalItems - unassigned.length) / totalItems) * 100;
   };
 
-  // Handle receipt upload — append to the current outing (people/groups stay)
-  const handleReceiptParsed = (receipt: Receipt): boolean => {
+  // Handle receipt upload — append to the current outing (people/groups stay).
+  // Returns the new receipt id so the uploader can key its thumbnail to it.
+  const handleReceiptParsed = (receipt: Receipt): string | false => {
     const result = addParsedReceipt(stateRef.current, receipt);
     if (result.status === "capped") {
       toast.error(
@@ -313,10 +328,11 @@ export default function Home() {
     stateRef.current = result.next;
     setState(result.next);
     toast.success("Receipt successfully parsed!");
-    return true;
+    return result.next.receipts[result.next.receipts.length - 1].id;
   };
 
   const handleRemoveReceipt = (receiptId: string) => {
+    removeThumbnail(receiptId);
     setState((prevState) => {
       const next = removeReceiptFromState(prevState, receiptId);
       stateRef.current = next;

--- a/src/components/parsed-receipts-list.test.tsx
+++ b/src/components/parsed-receipts-list.test.tsx
@@ -103,4 +103,36 @@ describe("ParsedReceiptsList", () => {
       screen.getByText("Starbucks · 2024-01-01 · #2")
     ).toBeInTheDocument();
   });
+
+  it("shows each receipt's own thumbnail next to its row", () => {
+    localStorage.setItem(
+      "receiptSplitterThumbnails",
+      JSON.stringify({ r1: "data:image/jpeg;base64,thumbA" })
+    );
+    const first = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe One" }),
+      "r1"
+    );
+    const second = createStoredReceipt(
+      createMockReceipt({ restaurant: "Cafe Two" }),
+      "r2"
+    );
+
+    render(
+      <ParsedReceiptsList
+        receipts={[first, second]}
+        onReceiptUpdate={jest.fn()}
+        onRemoveReceipt={jest.fn()}
+      />
+    );
+
+    // r1 has a persisted thumbnail; r2 (no entry) shows the placeholder icon.
+    expect(screen.getByAltText("Cafe One receipt preview")).toHaveAttribute(
+      "src",
+      "data:image/jpeg;base64,thumbA"
+    );
+    expect(
+      screen.queryByAltText("Cafe Two receipt preview")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/parsed-receipts-list.tsx
+++ b/src/components/parsed-receipts-list.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ChevronDown, Trash2 } from "lucide-react";
+import { ChevronDown, Trash2, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -14,6 +14,7 @@ import { ReceiptDetails } from "@/components/receipt-details";
 import { formatCurrency } from "@/lib/receipt-utils";
 import { MAX_RECEIPTS_PER_SESSION } from "@/lib/constants";
 import { receiptDisplayName } from "@/lib/receipt-labels";
+import { getThumbnails } from "@/lib/receipt-thumbnails";
 import { type Receipt, type StoredReceipt } from "@/types";
 
 interface ParsedReceiptsListProps {
@@ -30,6 +31,13 @@ export function ParsedReceiptsList({
   const lastId = receipts[receipts.length - 1]?.id ?? null;
   const [expandedId, setExpandedId] = useState<string | null>(lastId);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
+  // Snapshot of the thumbnail cache; re-read whenever the receipt set changes
+  // so newly accepted receipts pick up their persisted thumbnail.
+  const [thumbnails, setThumbnails] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setThumbnails(getThumbnails());
+  }, [receipts]);
 
   useEffect(() => {
     if (lastId) {
@@ -81,6 +89,18 @@ export function ParsedReceiptsList({
                   }
                   aria-expanded={isExpanded}
                 >
+                  {thumbnails[stored.id] ? (
+                    <img
+                      src={thumbnails[stored.id]}
+                      alt={`${label} receipt preview`}
+                      className="h-12 w-12 rounded object-cover border shrink-0"
+                    />
+                  ) : (
+                    <FileText
+                      aria-hidden="true"
+                      className="h-6 w-6 mt-0.5 shrink-0 text-muted-foreground"
+                    />
+                  )}
                   <ChevronDown
                     className={`h-4 w-4 mt-1 shrink-0 transition-transform ${
                       isExpanded ? "rotate-0" : "-rotate-90"

--- a/src/components/receipt-uploader.test.tsx
+++ b/src/components/receipt-uploader.test.tsx
@@ -428,9 +428,10 @@ describe("ReceiptUploader", () => {
       const previewAfterUsd = screen
         .getByAltText("Receipt preview")
         .getAttribute("src");
-      const cachedAfterUsd = localStorage.getItem("receiptSplitterImage");
       expect(previewAfterUsd).toBe(usdDataUrl);
-      expect(cachedAfterUsd).toBe(usdDataUrl);
+      // The legacy full-size key is no longer written at all (per-receipt
+      // thumbnails replace it), so nothing cached to be clobbered.
+      expect(localStorage.getItem("receiptSplitterImage")).toBeNull();
       expect(usdDataUrl).not.toBe(`data:image/jpeg;base64,${btoa("eur.jpg")}`);
 
       const eurFile = new File(["eur-image-different-bytes"], "eur.jpg", {
@@ -449,9 +450,93 @@ describe("ReceiptUploader", () => {
       expect(screen.getByAltText("Receipt preview").getAttribute("src")).toBe(
         previewAfterUsd
       );
-      expect(localStorage.getItem("receiptSplitterImage")).toBe(cachedAfterUsd);
+      expect(localStorage.getItem("receiptSplitterThumbnails")).toBeNull();
     } finally {
       global.FileReader = OriginalFileReader;
     }
+  });
+
+  it("persists a compressed thumbnail keyed by the accepted receipt id", async () => {
+    const OriginalFileReader = global.FileReader;
+    class FakeFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null =
+        null;
+      onerror: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null =
+        null;
+      readAsDataURL(file: Blob) {
+        const name = file instanceof File ? file.name : "blob";
+        this.result = file.size <= 2048
+          ? `data:${file.type};base64,${btoa(name)}`
+          : `data:image/jpeg;base64,${btoa(`thumb-${name}`)}`;
+        queueMicrotask(() => {
+          this.onload?.call(this as unknown as FileReader, {} as ProgressEvent<FileReader>);
+        });
+      }
+    }
+    global.FileReader = FakeFileReader as unknown as typeof FileReader;
+    (imageCompression as unknown as jest.Mock).mockImplementation(async (file: File) =>
+      new File([new ArrayBuffer(512)], file.name, { type: "image/jpeg" })
+    );
+
+    try {
+      mockOnReceiptParsed.mockReturnValueOnce("receipt-abc");
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          restaurant: "Cafe",
+          total: 10,
+          items: [],
+          currency: "USD",
+        }),
+      });
+
+      renderUploader();
+
+      const file = new File([new ArrayBuffer(4096)], "cafe.jpg", { type: "image/jpeg" });
+      await userEvent.upload(getFileInput(), file);
+
+      await waitFor(() => {
+        expect(mockOnReceiptParsed).toHaveBeenCalledTimes(1);
+      });
+
+      // Thumbnail persisted under the receipt's id in the single map key.
+      await waitFor(() => {
+        const raw = localStorage.getItem("receiptSplitterThumbnails");
+        expect(raw).not.toBeNull();
+        const map = JSON.parse(raw as string);
+        expect(map["receipt-abc"]).toMatch(/^data:image\//);
+      });
+      // No full-size data URL is written to the legacy key anymore.
+      expect(localStorage.getItem("receiptSplitterImage")).toBeNull();
+    } finally {
+      global.FileReader = OriginalFileReader;
+    }
+  });
+
+  it("does not write a thumbnail when the parse is rejected (currency mismatch)", async () => {
+    (imageCompression as unknown as jest.Mock).mockClear();
+    mockOnReceiptParsed.mockReturnValueOnce(false);
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        restaurant: "Paris Bistro",
+        total: 20,
+        items: [],
+        currency: "EUR",
+      }),
+    });
+
+    renderUploader();
+
+    const file = new File(["eur"], "eur.jpg", { type: "image/jpeg" });
+    await userEvent.upload(getFileInput(), file);
+
+    await waitFor(() => {
+      expect(mockOnReceiptParsed).toHaveBeenCalledTimes(1);
+    });
+    // Give any (incorrect) async thumbnail write a chance to land.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(localStorage.getItem("receiptSplitterThumbnails")).toBeNull();
   });
 });

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -16,7 +16,6 @@ import {
   clearThumbnails,
   getLatestThumbnailId,
   getThumbnails,
-  migrateLegacyImage,
 } from "@/lib/receipt-thumbnails";
 import {
   createReceiptThumbnail,
@@ -180,10 +179,13 @@ export function ReceiptUploader({
     total: number;
   } | null>(null);
 
-  // Restore the last accepted receipt's preview from the thumbnail cache on
-  // mount, migrating away from the legacy singular image key if present.
+  // Restore the last accepted receipt's preview from the thumbnail cache.
+  // NOTE: this component must NOT touch the legacy singular image key here.
+  // Child passive effects run before parent effects, and Home's restore effect
+  // (src/app/page.tsx) performs migrateLegacyImage() with the real newest
+  // receipt id once the session is available. Deleting or moving that key
+  // here would race ahead of it and silently lose a legacy user's image.
   useEffect(() => {
-    migrateLegacyImage(null);
     const latestId = getLatestThumbnailId();
     if (latestId) {
       const thumbnails = getThumbnails();

--- a/src/components/receipt-uploader.tsx
+++ b/src/components/receipt-uploader.tsx
@@ -11,19 +11,26 @@ import {
 } from "@/lib/constants";
 import imageCompression from "browser-image-compression";
 import { getSessionId } from "@/lib/session";
+import { RECEIPT_IMAGE_STORAGE_KEY, safeRemoveItem } from "@/lib/storage";
 import {
-  RECEIPT_IMAGE_STORAGE_KEY,
-  safeGetItem,
-  safeRemoveItem,
-  safeSetItem,
-} from "@/lib/storage";
+  clearThumbnails,
+  getLatestThumbnailId,
+  getThumbnails,
+  migrateLegacyImage,
+} from "@/lib/receipt-thumbnails";
+import {
+  createReceiptThumbnail,
+  persistReceiptThumbnail,
+} from "@/lib/receipt-thumbnail-image";
 
 interface ReceiptUploaderProps {
   /**
    * Called after a file is parsed. Return `false` to reject the receipt
-   * (currency mismatch, session cap). Preview/cache update only on accept.
+   * (currency mismatch, session cap). Return the new receipt's id on accept
+   * so the uploader can key the persisted thumbnail to that receipt.
+   * Preview/thumbnail updates only happen on accept.
    */
-  onReceiptParsed: (receipt: Receipt) => boolean | void;
+  onReceiptParsed: (receipt: Receipt) => string | false | void;
   isLoading: boolean;
   setIsLoading: (isLoading: boolean) => void;
   resetImageTrigger?: number;
@@ -132,13 +139,25 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
+/**
+ * Update the dropzone preview and persist the per-receipt thumbnail.
+ * `receiptId` is the id returned by onReceiptParsed; thumbnails are keyed by
+ * it so each accepted receipt keeps its own preview across refresh.
+ */
 async function updatePreview(
   file: File,
+  receiptId: string | undefined,
   setPreviewUrl: (url: string) => void
 ): Promise<void> {
   if (file.type.startsWith("image/")) {
+    if (receiptId) {
+      // Compressed thumbnail, persisted under this receipt's id (best-effort).
+      const thumbnail = await createReceiptThumbnail(file);
+      if (thumbnail) persistReceiptThumbnail(receiptId, thumbnail);
+    }
+    // Dropzone keeps showing the full-size preview for the last accepted file.
     const dataUrl = await readFileAsDataUrl(file);
-    safeSetItem(RECEIPT_IMAGE_STORAGE_KEY, dataUrl);
+    safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
     setPreviewUrl(dataUrl);
     return;
   }
@@ -161,11 +180,14 @@ export function ReceiptUploader({
     total: number;
   } | null>(null);
 
-  // Restore preview image from localStorage on mount
+  // Restore the last accepted receipt's preview from the thumbnail cache on
+  // mount, migrating away from the legacy singular image key if present.
   useEffect(() => {
-    const savedImage = safeGetItem(RECEIPT_IMAGE_STORAGE_KEY);
-    if (savedImage) {
-      setPreviewUrl(savedImage);
+    migrateLegacyImage(null);
+    const latestId = getLatestThumbnailId();
+    if (latestId) {
+      const thumbnails = getThumbnails();
+      setPreviewUrl(thumbnails[latestId]);
     }
   }, []);
 
@@ -177,6 +199,7 @@ export function ReceiptUploader({
       prevResetImageTrigger.current !== resetImageTrigger
     ) {
       setPreviewUrl(null);
+      clearThumbnails();
       safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
     }
     prevResetImageTrigger.current = resetImageTrigger;
@@ -214,10 +237,15 @@ export function ReceiptUploader({
             if (!prepared) continue;
 
             const receipt = await parseReceiptFile(prepared);
-            const accepted = onReceiptParsed(receipt) !== false;
+            const acceptedId = onReceiptParsed(receipt);
+            const accepted = acceptedId !== false && acceptedId !== undefined;
             if (!accepted) continue;
             try {
-              await updatePreview(prepared, setPreviewUrl);
+              await updatePreview(
+                prepared,
+                typeof acceptedId === "string" ? acceptedId : undefined,
+                setPreviewUrl
+              );
             } catch {
               // Preview caching is best-effort and must not block a successful parse
             }

--- a/src/lib/receipt-thumbnail-image.test.ts
+++ b/src/lib/receipt-thumbnail-image.test.ts
@@ -1,0 +1,128 @@
+import {
+  THUMBNAIL_MAX_BYTES,
+  createReceiptThumbnail,
+  persistReceiptThumbnail,
+} from "./receipt-thumbnail-image";
+import imageCompression from "browser-image-compression";
+import { RECEIPT_THUMBNAILS_STORAGE_KEY, getThumbnails } from "./receipt-thumbnails";
+
+jest.mock("browser-image-compression", () => jest.fn());
+
+const THUMB_BLOB = new Blob([new ArrayBuffer(512)], { type: "image/jpeg" });
+
+function fakeReadAsDataUrl(result: string | null) {
+  const OriginalFileReader = global.FileReader;
+  class FakeFileReader {
+    result: string | ArrayBuffer | null = null;
+    onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null = null;
+    onerror: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null = null;
+    readAsDataURL() {
+      this.result = result;
+      queueMicrotask(() => {
+        if (result) this.onload?.call(this as unknown as FileReader, {} as ProgressEvent<FileReader>);
+        else this.onerror?.call(this as unknown as FileReader, {} as ProgressEvent<FileReader>);
+      });
+    }
+  }
+  global.FileReader = FakeFileReader as unknown as typeof FileReader;
+  return () => {
+    global.FileReader = OriginalFileReader;
+  };
+}
+
+describe("receipt-thumbnail-image", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (imageCompression as unknown as jest.Mock).mockReset();
+  });
+
+  describe("createReceiptThumbnail", () => {
+    it("compresses an image to a small data URL", async () => {
+      (imageCompression as unknown as jest.Mock).mockResolvedValueOnce(THUMB_BLOB);
+      const restore = fakeReadAsDataUrl("data:image/jpeg;base64,thumb");
+
+      try {
+        const thumb = await createReceiptThumbnail(
+          new File([new ArrayBuffer(1024)], "r.jpg", { type: "image/jpeg" })
+        );
+        expect(thumb).toBe("data:image/jpeg;base64,thumb");
+        expect(imageCompression).toHaveBeenCalledWith(expect.anything(), {
+          maxSizeMB: THUMBNAIL_MAX_BYTES / (1024 * 1024),
+          maxWidthOrHeight: expect.any(Number),
+          useWebWorker: true,
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns null for non-image files (PDFs keep the placeholder)", async () => {
+      const thumb = await createReceiptThumbnail(
+        new File(["pdf"], "r.pdf", { type: "application/pdf" })
+      );
+      expect(thumb).toBeNull();
+      expect(imageCompression).not.toHaveBeenCalled();
+    });
+
+    it("returns null when compression fails", async () => {
+      (imageCompression as unknown as jest.Mock).mockRejectedValueOnce(new Error("boom"));
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const thumb = await createReceiptThumbnail(
+        new File([new ArrayBuffer(1024)], "r.jpg", { type: "image/jpeg" })
+      );
+      expect(thumb).toBeNull();
+      warn.mockRestore();
+    });
+
+    it("returns null when the encoded thumbnail exceeds the size cap", async () => {
+      (imageCompression as unknown as jest.Mock).mockResolvedValueOnce(THUMB_BLOB);
+      const restore = fakeReadAsDataUrl(
+        "data:image/jpeg;base64," + "R".repeat(THUMBNAIL_MAX_BYTES)
+      );
+      try {
+        const thumb = await createReceiptThumbnail(
+          new File([new ArrayBuffer(1024)], "r.jpg", { type: "image/jpeg" })
+        );
+        expect(thumb).toBeNull();
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe("persistReceiptThumbnail", () => {
+    it("stores the thumbnail under the receipt id", () => {
+      expect(persistReceiptThumbnail("r1", "data:image/png;base64,AA")).toBe(true);
+      expect(getThumbnails()).toEqual({ r1: "data:image/png;base64,AA" });
+    });
+
+    it("evicts older thumbnails on quota failure instead of dropping the newest", () => {
+      persistReceiptThumbnail("old1", "data:image/png;base64,1");
+      persistReceiptThumbnail("old2", "data:image/png;base64,2");
+      const originalSetItem = localStorage.setItem;
+      let failedOnce = false;
+      localStorage.setItem = jest.fn((key: string, value: string) => {
+        if (
+          key === RECEIPT_THUMBNAILS_STORAGE_KEY &&
+          value.includes('"newest"') &&
+          !failedOnce
+        ) {
+          // First write of the newest entry fails (quota), then succeeds once old1 is gone.
+          failedOnce = true;
+          throw new DOMException("Quota exceeded", "QuotaExceededError");
+        }
+        return originalSetItem.call(localStorage, key, value);
+      }) as typeof localStorage.setItem;
+
+      try {
+        expect(persistReceiptThumbnail("newest", "data:image/png;base64,N")).toBe(true);
+        const thumbs = getThumbnails();
+        expect(thumbs["newest"]).toBe("data:image/png;base64,N");
+        expect(thumbs["old2"]).toBeDefined();
+        expect(thumbs["old1"]).toBeUndefined();
+      } finally {
+        localStorage.setItem = originalSetItem;
+      }
+    });
+  });
+});

--- a/src/lib/receipt-thumbnail-image.ts
+++ b/src/lib/receipt-thumbnail-image.ts
@@ -1,0 +1,74 @@
+import imageCompression from "browser-image-compression";
+import { safeSetItem } from "@/lib/storage";
+import {
+  RECEIPT_THUMBNAILS_STORAGE_KEY,
+  setThumbnail,
+} from "@/lib/receipt-thumbnails";
+
+/** Max thumbnail edge in px. Small enough to be a few KB as a JPEG. */
+const THUMB_MAX_EDGE = 200;
+/** Hard size cap (bytes) for the encoded thumbnail data URL. */
+export const THUMBNAIL_MAX_BYTES = 50 * 1024;
+
+/**
+ * Compress an image File into a small data-URL thumbnail suitable for
+ * localStorage persistence (~a few KB). Returns null on any failure or when
+ * the result still exceeds THUMBNAIL_MAX_BYTES — thumbnails are best-effort.
+ */
+export async function createReceiptThumbnail(
+  file: File,
+  maxBytes: number = THUMBNAIL_MAX_BYTES
+): Promise<string | null> {
+  if (!file.type.startsWith("image/")) return null;
+  try {
+    const blob = await imageCompression(file, {
+      maxSizeMB: maxBytes / (1024 * 1024),
+      maxWidthOrHeight: THUMB_MAX_EDGE,
+      useWebWorker: true,
+    });
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () =>
+        typeof reader.result === "string"
+          ? resolve(reader.result)
+          : reject(new Error("Failed to read thumbnail"));
+      reader.onerror = () =>
+        reject(reader.error ?? new Error("Failed to read thumbnail"));
+      reader.readAsDataURL(blob);
+    });
+    if (!dataUrl.startsWith("data:image/") || dataUrl.length * 2 > maxBytes) {
+      return null;
+    }
+    return dataUrl;
+  } catch (error) {
+    console.warn("Thumbnail generation failed:", error);
+    return null;
+  }
+}
+
+/**
+ * Persist one receipt's thumbnail under its receipt id, evicting other
+ * thumbnails when quota is exceeded so the newest receipt always wins.
+ */
+export function persistReceiptThumbnail(
+  receiptId: string,
+  dataUrl: string
+): boolean {
+  if (setThumbnail(receiptId, dataUrl)) return true;
+  // Quota (or another write failure): drop older thumbnails to make room,
+  // never the entry we are about to write.
+  try {
+    const raw = localStorage.getItem(RECEIPT_THUMBNAILS_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    for (const id of Object.keys(parsed)) {
+      if (id === receiptId) continue;
+      delete parsed[id];
+      if (safeSetItem(RECEIPT_THUMBNAILS_STORAGE_KEY, JSON.stringify({ ...parsed, [receiptId]: dataUrl }))) {
+        return true;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return false;
+}

--- a/src/lib/receipt-thumbnails.test.ts
+++ b/src/lib/receipt-thumbnails.test.ts
@@ -1,0 +1,134 @@
+import {
+  RECEIPT_THUMBNAILS_STORAGE_KEY,
+  clearThumbnails,
+  getLatestThumbnailId,
+  getThumbnails,
+  migrateLegacyImage,
+  pruneThumbnails,
+  removeThumbnail,
+  setThumbnail,
+} from "./receipt-thumbnails";
+import { RECEIPT_IMAGE_STORAGE_KEY } from "./storage";
+
+const THUMB_A = "data:image/jpeg;base64,AAAA";
+const THUMB_B = "data:image/png;base64,BBBB";
+const LEGACY_FULL_SIZE = "data:image/jpeg;base64," + "R".repeat(1000);
+
+describe("receipt-thumbnails", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  describe("persistence across a simulated refresh", () => {
+    it("retains each receipt's thumbnail keyed by its own id", () => {
+      expect(setThumbnail("r1", THUMB_A)).toBe(true);
+      expect(setThumbnail("r2", THUMB_B)).toBe(true);
+
+      // Simulate refresh: read back from localStorage only.
+      const restored = getThumbnails();
+      expect(restored).toEqual({ r1: THUMB_A, r2: THUMB_B });
+      expect(getLatestThumbnailId()).toBe("r2");
+    });
+
+    it("keeps insertion order so the newest accepted receipt is last", () => {
+      setThumbnail("r1", THUMB_A);
+      setThumbnail("r2", THUMB_B);
+      // Re-accepting r1 makes it the most recent.
+      setThumbnail("r1", THUMB_B);
+      expect(getLatestThumbnailId()).toBe("r1");
+      // Both entries survive.
+      expect(Object.keys(getThumbnails()).sort()).toEqual(["r1", "r2"]);
+    });
+  });
+
+  describe("rejection protection", () => {
+    it("does not let a non-image value replace an accepted thumbnail", () => {
+      setThumbnail("r1", THUMB_A);
+      expect(setThumbnail("r1", "pdf-placeholder")).toBe(false);
+      expect(getThumbnails()["r1"]).toBe(THUMB_A);
+    });
+
+    it("ignores corrupted or hostile map contents on read", () => {
+      localStorage.setItem(
+        RECEIPT_THUMBNAILS_STORAGE_KEY,
+        JSON.stringify({ r1: "javascript:alert(1)", r2: 42, r3: THUMB_A })
+      );
+      expect(getThumbnails()).toEqual({ r3: THUMB_A });
+    });
+
+    it("returns empty map on invalid JSON", () => {
+      localStorage.setItem(RECEIPT_THUMBNAILS_STORAGE_KEY, "{not json");
+      expect(getThumbnails()).toEqual({});
+    });
+
+    it("removes exactly one receipt's thumbnail and leaves others", () => {
+      setThumbnail("r1", THUMB_A);
+      setThumbnail("r2", THUMB_B);
+      removeThumbnail("r1");
+      expect(getThumbnails()).toEqual({ r2: THUMB_B });
+    });
+  });
+
+  describe("cleanup", () => {
+    it("clears all thumbnails", () => {
+      setThumbnail("r1", THUMB_A);
+      setThumbnail("r2", THUMB_B);
+      clearThumbnails();
+      expect(getThumbnails()).toEqual({});
+      expect(
+        localStorage.getItem(RECEIPT_THUMBNAILS_STORAGE_KEY)
+      ).toBeNull();
+    });
+
+    it("prunes stale ids not present in the session", () => {
+      setThumbnail("keep", THUMB_A);
+      setThumbnail("stale", THUMB_B);
+      pruneThumbnails(["keep"]);
+      expect(getThumbnails()).toEqual({ keep: THUMB_A });
+    });
+
+    it("does not rewrite storage when nothing is stale", () => {
+      setThumbnail("r1", THUMB_A);
+      const before = localStorage.getItem(RECEIPT_THUMBNAILS_STORAGE_KEY);
+      pruneThumbnails(["r1"]);
+      expect(localStorage.getItem(RECEIPT_THUMBNAILS_STORAGE_KEY)).toBe(before);
+    });
+  });
+
+  describe("legacy migration", () => {
+    it("attaches the legacy full-size image to the newest receipt, then deletes the legacy key", () => {
+      localStorage.setItem(RECEIPT_IMAGE_STORAGE_KEY, LEGACY_FULL_SIZE);
+      const attachedTo = migrateLegacyImage("newest");
+      expect(attachedTo).toBe("newest");
+      expect(getThumbnails()).toEqual({ newest: LEGACY_FULL_SIZE });
+      expect(localStorage.getItem(RECEIPT_IMAGE_STORAGE_KEY)).toBeNull();
+    });
+
+    it("deletes the legacy key even when there is no receipt to attach to", () => {
+      localStorage.setItem(RECEIPT_IMAGE_STORAGE_KEY, LEGACY_FULL_SIZE);
+      expect(migrateLegacyImage(null)).toBeNull();
+      expect(localStorage.getItem(RECEIPT_IMAGE_STORAGE_KEY)).toBeNull();
+      expect(getThumbnails()).toEqual({});
+    });
+
+    it("is a no-op when no legacy key exists", () => {
+      expect(migrateLegacyImage("r1")).toBeNull();
+      expect(getThumbnails()).toEqual({});
+    });
+
+    it("never writes N full-size data URLs — one bounded JSON map under a single key", () => {
+      for (let i = 0; i < 10; i++) {
+        setThumbnail(`r${i}`, `data:image/jpeg;base64,${"x".repeat(200)}`);
+      }
+      const keys: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k) keys.push(k);
+      }
+      expect(keys.filter((k) => k.startsWith("receiptSplitter"))).toEqual([
+        RECEIPT_THUMBNAILS_STORAGE_KEY,
+      ]);
+    });
+  });
+});

--- a/src/lib/receipt-thumbnails.ts
+++ b/src/lib/receipt-thumbnails.ts
@@ -1,0 +1,112 @@
+import { RECEIPT_IMAGE_STORAGE_KEY, safeGetItem, safeRemoveItem, safeSetItem } from "./storage";
+
+/**
+ * Per-receipt preview thumbnails, persisted as ONE JSON map under a single
+ * localStorage key (`Record<receiptId, dataUrl>`).
+ *
+ * Thumbnails are small (~a few KB each, capped by MAX_THUMBNAIL_* below), so
+ * even a full session of MAX_RECEIPTS_PER_SESSION receipts costs tens of KB —
+ * unlike the legacy singular `receiptSplitterImage` key, which held a
+ * full-size ~5 MB data URL. Object key insertion order is preserved by
+ * JSON round-trips, so the last inserted entry is the most recently accepted
+ * receipt (used to restore the dropzone preview).
+ */
+export const RECEIPT_THUMBNAILS_STORAGE_KEY = "receiptSplitterThumbnails";
+
+export type ReceiptThumbnailMap = Record<string, string>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Read the whole thumbnail map. Returns {} on absence or any corruption. */
+export function getThumbnails(): ReceiptThumbnailMap {
+  const raw = safeGetItem(RECEIPT_THUMBNAILS_STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return {};
+    const result: ReceiptThumbnailMap = {};
+    for (const [id, value] of Object.entries(parsed)) {
+      if (typeof value === "string" && value.startsWith("data:image/")) {
+        result[id] = value;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Store (or replace) the thumbnail for one receipt. Re-inserting an existing
+ * id moves it to the end so it counts as the most recent.
+ * Returns true when the updated map was persisted.
+ */
+export function setThumbnail(receiptId: string, dataUrl: string): boolean {
+  if (!receiptId || !dataUrl.startsWith("data:image/")) return false;
+  const thumbnails = getThumbnails();
+  delete thumbnails[receiptId];
+  thumbnails[receiptId] = dataUrl;
+  return safeSetItem(
+    RECEIPT_THUMBNAILS_STORAGE_KEY,
+    JSON.stringify(thumbnails)
+  );
+}
+
+/** Drop one receipt's thumbnail. No-op when absent. */
+export function removeThumbnail(receiptId: string): void {
+  const thumbnails = getThumbnails();
+  if (!(receiptId in thumbnails)) return;
+  delete thumbnails[receiptId];
+  safeSetItem(RECEIPT_THUMBNAILS_STORAGE_KEY, JSON.stringify(thumbnails));
+}
+
+/** Remove every thumbnail (used by New Split). */
+export function clearThumbnails(): void {
+  safeRemoveItem(RECEIPT_THUMBNAILS_STORAGE_KEY);
+}
+
+/** Id of the most recently stored thumbnail, or null when the map is empty. */
+export function getLatestThumbnailId(): string | null {
+  const ids = Object.keys(getThumbnails());
+  return ids.length > 0 ? ids[ids.length - 1] : null;
+}
+
+/**
+ * Delete thumbnails whose receipt id is no longer in the session (e.g. stale
+ * entries left behind by a corrupted or rolled-back session blob).
+ */
+export function pruneThumbnails(knownReceiptIds: readonly string[]): void {
+  const known = new Set(knownReceiptIds);
+  const thumbnails = getThumbnails();
+  const stale = Object.keys(thumbnails).filter((id) => !known.has(id));
+  if (stale.length === 0) return;
+  for (const id of stale) {
+    delete thumbnails[id];
+  }
+  safeSetItem(RECEIPT_THUMBNAILS_STORAGE_KEY, JSON.stringify(thumbnails));
+}
+
+/**
+ * One-time migration from the legacy singular image key: best-effort attach
+ * the old full-size data URL to the newest receipt, then always remove the
+ * legacy key. Returns the id it was attached to, or null.
+ */
+export function migrateLegacyImage(
+  newestReceiptId?: string | null
+): string | null {
+  const legacy = safeGetItem(RECEIPT_IMAGE_STORAGE_KEY);
+  if (!legacy) return null;
+
+  let attachedTo: string | null = null;
+  if (
+    newestReceiptId &&
+    legacy.startsWith("data:image/") &&
+    setThumbnail(newestReceiptId, legacy)
+  ) {
+    attachedTo = newestReceiptId;
+  }
+  safeRemoveItem(RECEIPT_IMAGE_STORAGE_KEY);
+  return attachedTo;
+}


### PR DESCRIPTION
> [!NOTE]
> 🤖 Hermes is acting on behalf of Karan.

Closes #171

## Problem

A multi-receipt session restored parsed data on refresh but kept at most one image — the last accepted file, stored as a full-size (~5 MB) data URL under the singular `receiptSplitterImage` key. The Upload tab's parsed receipts list had no way to show which image belonged to which receipt.

## Approach (matches the scoping approved in #171)

- **Per-receipt thumbnails, one bounded key.** New `src/lib/receipt-thumbnails.ts` stores `Record<receiptId, dataUrl>` under a single localStorage key (`receiptSplitterThumbnails`). Thumbnails are compressed to ~200px / capped at 50 KB (`src/lib/receipt-thumbnail-image.ts`, separate from the existing upload-size compression pass), so a full 10-receipt session costs tens of KB — never N full-size data URLs.
- **Association.** `ReceiptUploader.onReceiptParsed` now returns the new receipt's id; the uploader keys the thumbnail to that id. `ParsedReceiptsList` renders each receipt's own thumbnail next to its row (placeholder icon for PDFs and image-less receipts).
- **Rejection protection (#162 carried forward).** Rejected receipts (currency mismatch, session cap) return no id and skip the preview branch entirely — accepted previews are never replaced. Covered by tests.
- **Cleanup/migration.** Removing a receipt deletes its thumbnail; New Split clears the map; the legacy singular key is migrated best-effort onto the newest receipt then deleted; stale ids are pruned when the session restores; session-save quota eviction clears thumbnails too.
- Dropzone keeps its existing "last accepted" full-size preview for continuity; it is in-memory only — nothing full-size is persisted anymore.

## Tests

- `receipt-thumbnails.test.ts`: persistence across refresh, per-id association/ordering, rejection of non-image values + corrupted maps, clear/prune cleanup, legacy migration, single-key bound.
- `receipt-thumbnail-image.test.ts`: compression params, PDF placeholder (null), failure and size-cap fallbacks, quota-eviction that keeps the newest entry.
- `receipt-uploader.test.tsx`: thumbnail persisted keyed by accepted id; rejected parse writes no thumbnail.
- `parsed-receipts-list.test.tsx`: each row shows its own thumbnail; rows without one show the placeholder.

## Checks

- `npm test` — 573 tests, 32 suites, all passing
- `npm run lint` — 0 errors (1 pre-existing warning in `receipt-details.tsx`, untouched by this diff)
- `npm run build` — succeeds
- Banned-PII scan over the staged diff — clean

## Risk / exclusions

Low risk: additive module plus narrow contract change (`boolean | void` → `string | false | void`) on one callback. No changes to `/split`, UploadThing flow, or the session blob shape (no SESSION_VERSION bump).

---
🤖 *Automated via Hermes (AI assistant) — not Karan*
