### PR TITLE
fix: resolve theme split-brain between Toaster and ThemeProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "decimal.js": "^10.5.0",
         "lucide-react": "^1.32.0",
         "next": "16.3.1",
-        "next-themes": "^0.4.6",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-dropzone": "^14.3.8",
@@ -14662,16 +14661,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/@img/sharp-darwin-arm64": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "decimal.js": "^10.5.0",
     "lucide-react": "^1.32.0",
     "next": "16.3.1",
-    "next-themes": "^0.4.6",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-dropzone": "^14.3.8",

--- a/src/components/theme-provider.test.tsx
+++ b/src/components/theme-provider.test.tsx
@@ -1,5 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { ThemeProvider } from "./theme-provider";
+import { render } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "./theme-provider";
+import { Toaster } from "./ui/sonner";
+
+// sonner ships ESM-only; stub the underlying Toaster so we can assert what
+// our wrapper passes down.
+jest.mock("sonner", () => ({
+  Toaster: (props: { theme?: string }) => (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    <section data-sonner-toaster="" data-theme={(props as any).theme} />
+  ),
+}));
 
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -17,13 +27,47 @@ beforeAll(() => {
   });
 });
 
-describe("ThemeProvider", () => {
-  it("renders children", () => {
+describe("theme integration", () => {
+  it("Toaster reflects the ThemeProvider theme (not next-themes)", () => {
+    const { container } = render(
+      <ThemeProvider defaultTheme="dark" attribute="class">
+        <Toaster />
+      </ThemeProvider>
+    );
+
+    const toaster = container.querySelector("[data-sonner-toaster]");
+    expect(toaster).not.toBeNull();
+    expect(toaster!.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("attribute=class toggles theme classes without wiping other root classes", () => {
+    document.documentElement.className = "existing-class";
+
     render(
-      <ThemeProvider attribute="class">
+      <ThemeProvider defaultTheme="dark" attribute="class">
         <div>child</div>
       </ThemeProvider>
     );
-    expect(screen.getByText("child")).toBeInTheDocument();
+
+    const root = document.documentElement;
+    expect(root.classList.contains("dark")).toBe(true);
+    expect(root.classList.contains("existing-class")).toBe(true);
+  });
+});
+
+describe("useTheme context export", () => {
+  it("exposes the custom provider context", () => {
+    let observed: string | undefined;
+    function Probe() {
+      const { theme } = useTheme();
+      observed = theme;
+      return null;
+    }
+    render(
+      <ThemeProvider defaultTheme="light">
+        <Probe />
+      </ThemeProvider>
+    );
+    expect(observed).toBe("light");
   });
 });

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -24,6 +24,18 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
+// When attribute === "class", theme classes are toggled via classList above;
+// never overwrite the root's entire class attribute.
+function applyAttribute(
+  root: HTMLElement,
+  attribute: string,
+  value: Theme
+): void {
+  if (attribute !== "class") {
+    root.setAttribute(attribute, value);
+  }
+}
+
 export function ThemeProvider({
   children,
   defaultTheme = "system",
@@ -53,12 +65,12 @@ export function ThemeProvider({
         : "light";
 
       root.classList.add(systemTheme);
-      root.setAttribute(attribute, systemTheme);
+      applyAttribute(root, attribute, systemTheme);
       return;
     }
 
     root.classList.add(theme);
-    root.setAttribute(attribute, theme);
+    applyAttribute(root, attribute, theme);
   }, [theme, enableSystem, disableTransitionOnChange, attribute]);
 
   // Listen for system theme changes
@@ -74,7 +86,7 @@ export function ThemeProvider({
         
         root.classList.remove("light", "dark");
         root.classList.add(systemTheme);
-        root.setAttribute(attribute, systemTheme);
+        applyAttribute(root, attribute, systemTheme);
       }
     };
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useTheme } from "next-themes"
+import { useTheme } from "@/components/theme-provider"
 import { Toaster as Sonner, ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {


### PR DESCRIPTION
> [!NOTE]
> 🤖 Hermes is acting on behalf of Karan.

Part of #179 (item 2: split-brain theming).

## Summary
- `ui/sonner.tsx` reads `useTheme()` from the custom `ThemeProvider` (`@/components/theme-provider`) instead of `next-themes` — `next-themes`' provider was never mounted, so the Sonner Toaster never reflected the active theme
- Removes the now-unused `next-themes` dependency (and lockfile entries)
- Fixes `ThemeProvider attribute="class"` overwriting `<html>`'s entire class attribute: with `attribute="class"` it now relies purely on `classList` toggling; `setAttribute` is only used for non-class attributes

## Test plan
- [x] New tests: Toaster reflects provider state (via sonner stub), class-mode preserves unrelated root classes, custom `useTheme` exposes context
- [x] `npm test` — 32 suites / 576 tests pass
- [x] `npm run lint` — 0 errors (1 pre-existing warning in receipt-details.tsx)

---
🤖 *Automated via Hermes (AI assistant) — not Karan*
