### PR TITLE
fix: prototype-safe currency check + webhook currency symbol

### DIFF
--- a/src/lib/currency.test.ts
+++ b/src/lib/currency.test.ts
@@ -146,6 +146,12 @@ describe('Currency utilities', () => {
       expect(isSupportedCurrency('INVALID')).toBe(false);
     });
 
+    it('returns false for Object.prototype property names', () => {
+      expect(isSupportedCurrency('toString')).toBe(false);
+      expect(isSupportedCurrency('constructor')).toBe(false);
+      expect(isSupportedCurrency('hasOwnProperty')).toBe(false);
+    });
+
     it('returns false for empty string', () => {
       expect(isSupportedCurrency('')).toBe(false);
     });

--- a/src/lib/currency.test.ts
+++ b/src/lib/currency.test.ts
@@ -62,6 +62,12 @@ describe('Currency utilities', () => {
       const info = getCurrencyInfo('INVALID');
       expect(info.code).toBe('USD');
     });
+
+    it('defaults to USD for Object.prototype property names', () => {
+      const info = getCurrencyInfo('toString');
+      expect(info.code).toBe('USD');
+      expect(info.symbol).toBe('$');
+    });
   });
 
   describe('toMinorUnits', () => {

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -255,5 +255,5 @@ export function getSupportedCurrencies(): CurrencyInfo[] {
  * Validate if a currency code is supported
  */
 export function isSupportedCurrency(currencyCode: string): boolean {
-  return currencyCode in CURRENCY_METADATA;
+  return Object.hasOwn(CURRENCY_METADATA, currencyCode);
 }

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -182,7 +182,7 @@ export function getCurrencyInfo(currencyCode: string): CurrencyInfo {
   }
 
   // Build and cache if supported
-  if (currencyCode in CURRENCY_METADATA) {
+  if (Object.hasOwn(CURRENCY_METADATA, currencyCode)) {
     const info = buildCurrencyInfo(currencyCode);
     currencyInfoCache.set(currencyCode, info);
     return info;

--- a/src/lib/webhook-notifications.test.ts
+++ b/src/lib/webhook-notifications.test.ts
@@ -459,6 +459,51 @@ describe('webhook-notifications', () => {
     });
   });
 
+
+  describe('currency symbol formatting', () => {
+    beforeEach(() => {
+      process.env.WEBHOOK_URL = 'https://hooks.slack.com/test';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+      jest.clearAllMocks();
+    });
+
+    const getPayload = () =>
+      JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+
+    it("uses the receipt currency's symbol in Slack amounts", async () => {
+      await sendReceiptParsedNotification(
+        { ...mockReceipt, currency: 'EUR' },
+        null,
+        'test-session-id',
+        'receipt.jpg',
+        'image/jpeg',
+        null
+      );
+
+      const bodyString = JSON.stringify(getPayload());
+      expect(bodyString).toContain('\u20ac25.00'); // Total
+      expect(bodyString).toContain('Burger - \u20ac10.00');
+      expect(bodyString).not.toContain('$25.00');
+    });
+
+    it('defaults to $ for USD and missing currency', async () => {
+      const noCurrency = { ...mockReceipt } as Partial<Receipt>;
+      delete noCurrency.currency;
+
+      await sendReceiptParsedNotification(
+        noCurrency as Receipt,
+        null,
+        'test-session-id',
+        'receipt.jpg',
+        'image/jpeg',
+        null
+      );
+
+      const bodyString = JSON.stringify(getPayload());
+      expect(bodyString).toContain('$25.00');
+    });
+  });
+
   describe('sendErrorNotification', () => {
     describe('with Slack formatter (default)', () => {
       beforeEach(() => {

--- a/src/lib/webhook-notifications.ts
+++ b/src/lib/webhook-notifications.ts
@@ -1,4 +1,13 @@
 import { type Receipt, type GeolocationData } from '@/types';
+import { getCurrencyInfo } from '@/lib/currency';
+
+/**
+ * Currency symbol for a receipt's currency (USD default), used to format
+ * monetary amounts in webhook payloads.
+ */
+function currencySymbol(receipt: Receipt): string {
+  return getCurrencyInfo(receipt.currency || 'USD').symbol;
+}
 
 export interface ErrorNotificationContext {
   sessionId?: string;
@@ -92,7 +101,7 @@ class SlackFormatter implements WebhookPayloadFormatter {
           },
           {
             type: 'mrkdwn',
-            text: `*Total:*\n$${receipt.total?.toFixed(2) || '0.00'}`,
+            text: `*Total:*\n${currencySymbol(receipt)}${receipt.total?.toFixed(2) || '0.00'}`,
           },
           {
             type: 'mrkdwn',
@@ -108,15 +117,15 @@ class SlackFormatter implements WebhookPayloadFormatter {
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Subtotal:*\n$${receipt.subtotal?.toFixed(2) || '0.00'}`,
+          text: `*Subtotal:*\n${currencySymbol(receipt)}${receipt.subtotal?.toFixed(2) || '0.00'}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Tax:*\n$${receipt.tax?.toFixed(2) || '0.00'}`,
+          text: `*Tax:*\n${currencySymbol(receipt)}${receipt.tax?.toFixed(2) || '0.00'}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Tip:*\n$${receipt.tip?.toFixed(2) || '0.00'}`,
+          text: `*Tip:*\n${currencySymbol(receipt)}${receipt.tip?.toFixed(2) || '0.00'}`,
         },
       ],
     });
@@ -144,7 +153,7 @@ class SlackFormatter implements WebhookPayloadFormatter {
     const itemsText = receipt.items
       .map(
         (item) =>
-          `• ${item.name} - $${item.price.toFixed(2)}${item.quantity > 1 ? ` (x${item.quantity})` : ''}`
+          `• ${item.name} - ${currencySymbol(receipt)}${item.price.toFixed(2)}${item.quantity > 1 ? ` (x${item.quantity})` : ''}`
       )
       .join('\n');
 


### PR DESCRIPTION
> [!NOTE]
> 🤖 Hermes is acting on behalf of Karan.

Part of #179 (items 4 & 6 — two small related hardening fixes).

## Summary
- `isSupportedCurrency()` used `code in CURRENCY_METADATA`, so `Object.prototype` names (`'toString'`, `'constructor'`, …) reported as supported currencies; now uses `Object.hasOwn`
- Slack webhook payloads hardcoded `$` for total/subtotal/tax/tip/item prices regardless of `receipt.currency`; they now use the currency's symbol via `getCurrencyInfo(receipt.currency || 'USD')` — USD behavior unchanged, but non-USD receipts (which #178 enables) will render correct symbols

## Test plan
- [x] New tests: prototype names rejected by `isSupportedCurrency`; EUR receipt renders € amounts in webhook payload and drops `$25.00`; missing/USD currency still renders `$25.00`
- [x] Full suite: 32 suites / 577 tests pass; `npm run lint` clean except a pre-existing warning fixed separately in #183

---
🤖 *Automated via Hermes (AI assistant) — not Karan*
