### PR TITLE
feat: add reset for manually edited totals

### DIFF
--- a/src/components/receipt-details.test.tsx
+++ b/src/components/receipt-details.test.tsx
@@ -662,6 +662,65 @@ describe("ReceiptDetails", () => {
       }
     );
 
+    it("resets a manually edited total to the current auto-calculated amount", () => {
+      openDialogAndEdit();
+      expect(
+        screen.queryByRole("button", { name: /reset total to auto-calculated/i })
+      ).not.toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText("Total"), {
+        target: { value: "118" },
+      });
+
+      expect(
+        screen.getByRole("button", { name: /reset total to auto-calculated/i })
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /reset total to auto-calculated/i })
+      );
+
+      expect(screen.getByLabelText("Total")).toHaveValue(125);
+      expect(
+        screen.queryByRole("button", { name: /reset total to auto-calculated/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("auto-recalculates again when an amount changes after reset", () => {
+      openDialogAndEdit();
+      fireEvent.change(screen.getByLabelText("Total"), {
+        target: { value: "118" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /reset total to auto-calculated/i })
+      );
+
+      fireEvent.change(screen.getByLabelText("Subtotal"), {
+        target: { value: "200" },
+      });
+
+      expect(screen.getByLabelText("Total")).toHaveValue(225);
+    });
+
+    it("preserves a total when it is manually edited again after reset", () => {
+      openDialogAndEdit();
+      fireEvent.change(screen.getByLabelText("Total"), {
+        target: { value: "118" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /reset total to auto-calculated/i })
+      );
+      fireEvent.change(screen.getByLabelText("Total"), {
+        target: { value: "119" },
+      });
+
+      fireEvent.change(screen.getByLabelText("Tax"), {
+        target: { value: "20" },
+      });
+
+      expect(screen.getByLabelText("Total")).toHaveValue(119);
+    });
+
     it("resets to auto-calculation when the dialog is reopened", () => {
       const { cancel } = openDialogAndEdit();
 

--- a/src/components/receipt-details.tsx
+++ b/src/components/receipt-details.tsx
@@ -67,6 +67,17 @@ export function ReceiptDetails({
     });
   };
 
+  const resetTotalToAutoCalculated = () => {
+    setEditedReceipt((prev) => ({
+      ...prev,
+      total: new Decimal(prev.subtotal || 0)
+        .add(new Decimal(prev.tax || 0))
+        .add(new Decimal(prev.tip || 0))
+        .toNumber(),
+    }));
+    setTotalManuallyEdited(false);
+  };
+
   // Handles the save operation
   const handleSave = () => {
     // Validate the numbers
@@ -297,6 +308,18 @@ export function ReceiptDetails({
                 />
                 <p className="text-xs text-muted-foreground">
                   Auto-calculated from subtotal + tax + tip unless edited
+                  {totalManuallyEdited && (
+                    <>
+                      {" "}
+                      <button
+                        type="button"
+                        className="text-primary underline underline-offset-2 hover:no-underline"
+                        onClick={resetTotalToAutoCalculated}
+                      >
+                        Reset total to auto-calculated
+                      </button>
+                    </>
+                  )}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
:::note
🤖 Hermes is acting on behalf of Karan.
:::

## Summary
- Add a reset-to-auto-calculated control for manually edited receipt totals.
- Recompute totals with Decimal and resume automatic recalculation after reset.
- Add regression coverage for reset visibility, recalculation, and manual-total preservation.

## Verification
- `npm test -- --runInBand` (579 tests passed)
- `npm run lint`
- `npm run build`
- `npm run screenshots -- --mock-data --tab all` (baseline and updated captures across 7 viewports)

Closes #186
