### PR TITLE
feat: allow explicit mixed-currency receipt overrides

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -54,6 +54,7 @@ if (typeof window !== "undefined") {
 
     // Mock window.alert
     window.alert = jest.fn();
+    window.confirm = jest.fn(() => false);
 
     // =============================================================================
     // Navigator API Mocks

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -618,6 +618,45 @@ describe("Home Page", () => {
       expect(toast.error).not.toHaveBeenCalled();
     });
 
+    it("renders separate result cards and disables Venmo sharing for mixed currencies", () => {
+      const euroReceipt = createMockReceipt({
+        restaurant: "Paris Bistro",
+        currency: "EUR",
+        subtotal: 10,
+        tax: 1,
+        tip: 0,
+        total: 11,
+        items: [{ name: "Croissant", price: 10, quantity: 1 }],
+      });
+      loadV2({
+        people: mockPeople,
+        activeTab: "results",
+        receipts: [
+          { id: "r1", receipt: mockReceipt },
+          { id: "r2", receipt: euroReceipt },
+        ],
+        assignedItems: [
+          [
+            "r1",
+            [
+              [0, [{ personId: "a", sharePercentage: 100 }]],
+              [1, [{ personId: "b", sharePercentage: 100 }]],
+            ],
+          ],
+          ["r2", [[0, [{ personId: "a", sharePercentage: 100 }]]]],
+        ],
+      });
+      render(<Home />);
+
+      expect(screen.getByText("Results Summary · USD")).toBeInTheDocument();
+      expect(screen.getByText("Results Summary · EUR")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("Venmo sharing is available only for single-currency splits.")
+      ).toHaveLength(2);
+      expect(screen.getByText("USD")).toBeInTheDocument();
+      expect(screen.getByText("EUR")).toBeInTheDocument();
+    });
+
   });
 
   describe("multi-receipt assign tab", () => {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -379,6 +379,44 @@ describe("Home Page", () => {
       expect(screen.getByText(/2 receipts · USD/)).toBeInTheDocument();
     });
 
+    it("accepts a mismatched currency after explicit confirmation", async () => {
+      (window.confirm as jest.Mock).mockReturnValueOnce(true);
+      loadV2({ people: mockPeople });
+      render(<Home />);
+
+      await uploadParsedReceipt(
+        createMockReceipt({ restaurant: "Paris Bistro", currency: "EUR" })
+      );
+
+      await waitFor(() => {
+        expect(window.confirm).toHaveBeenCalledWith(
+          "This receipt is EUR but this split is USD — keep anyway?"
+        );
+        expect(screen.getAllByText("Paris Bistro").length).toBeGreaterThan(0);
+      });
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("rejects a mismatched currency when confirmation is cancelled", async () => {
+      (window.confirm as jest.Mock).mockReturnValueOnce(false);
+      loadV2({ people: mockPeople });
+      render(<Home />);
+
+      await uploadParsedReceipt(
+        createMockReceipt({ restaurant: "Paris Bistro", currency: "EUR" })
+      );
+
+      await waitFor(() => {
+        expect(window.confirm).toHaveBeenCalledWith(
+          "This receipt is EUR but this split is USD — keep anyway?"
+        );
+        expect(toast.error).toHaveBeenCalledWith(
+          "This receipt is EUR, but this split is in USD."
+        );
+      });
+      expect(screen.queryByText("Paris Bistro")).not.toBeInTheDocument();
+    });
+
     it("rejects a mismatched currency without adding it or dropping existing people", async () => {
       loadV2({ people: mockPeople });
       render(<Home />);
@@ -548,6 +586,38 @@ describe("Home Page", () => {
       });
       expect(toast.error).not.toHaveBeenCalled();
     });
+
+    it("accepts a currency edit after explicit confirmation", async () => {
+      (window.confirm as jest.Mock).mockReturnValueOnce(true);
+      loadV2({
+        receipts: [
+          { id: "r1", receipt: mockReceipt },
+          {
+            id: "r2",
+            receipt: createMockReceipt({ restaurant: "Second Cafe" }),
+          },
+        ],
+        assignedItems: [
+          ["r1", []],
+          ["r2", []],
+        ],
+      });
+      render(<Home />);
+
+      fireEvent.click(screen.getAllByRole("button", { name: /edit/i })[0]);
+      fireEvent.click(screen.getByRole("combobox", { name: /currency/i }));
+      fireEvent.click(screen.getByRole("option", { name: /EUR - Euro/i }));
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(window.confirm).toHaveBeenCalledWith(
+          "This receipt is EUR but this split is USD — keep anyway?"
+        );
+        expect(screen.getByText(/EUR - Euro/)).toBeInTheDocument();
+      });
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
   });
 
   describe("multi-receipt assign tab", () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,13 +71,17 @@ type ParseResult =
   | { status: "capped"; next: ReceiptState }
   | { status: "mismatch"; next: ReceiptState; pinned: string };
 
-function addParsedReceipt(prev: ReceiptState, receipt: Receipt): ParseResult {
+function addParsedReceipt(
+  prev: ReceiptState,
+  receipt: Receipt,
+  allowCurrencyOverride = false
+): ParseResult {
   if (prev.receipts.length >= MAX_RECEIPTS_PER_SESSION) {
     return { status: "capped", next: prev };
   }
 
   const pinned = sessionCurrency(prev.receipts);
-  if (!validateReceiptCurrency(receipt, pinned)) {
+  if (!allowCurrencyOverride && !validateReceiptCurrency(receipt, pinned)) {
     return { status: "mismatch", next: prev, pinned: pinned as string };
   }
 
@@ -143,11 +147,15 @@ function updateReceiptInState(
   prev: ReceiptState,
   receiptId: string,
   updatedReceipt: Receipt,
-  remappedAssignments?: Map<number, PersonItemAssignment[]>
+  remappedAssignments?: Map<number, PersonItemAssignment[]>,
+  allowCurrencyOverride = false
 ): ReceiptState {
   const existing = prev.receipts.find((stored) => stored.id === receiptId);
   if (!existing) return prev;
-  if (currencyChangeConflict(prev.receipts, receiptId, updatedReceipt)) {
+  if (
+    !allowCurrencyOverride &&
+    currencyChangeConflict(prev.receipts, receiptId, updatedReceipt)
+  ) {
     return prev;
   }
 
@@ -312,7 +320,7 @@ export default function Home() {
   // Handle receipt upload — append to the current outing (people/groups stay).
   // Returns the new receipt id so the uploader can key its thumbnail to it.
   const handleReceiptParsed = (receipt: Receipt): string | false => {
-    const result = addParsedReceipt(stateRef.current, receipt);
+    let result = addParsedReceipt(stateRef.current, receipt);
     if (result.status === "capped") {
       toast.error(
         `This split already has ${MAX_RECEIPTS_PER_SESSION} receipts. Remove one to add another.`
@@ -320,10 +328,16 @@ export default function Home() {
       return false;
     }
     if (result.status === "mismatch") {
-      toast.error(
-        `This receipt is ${receipt.currency}, but this split is in ${result.pinned}.`
+      const confirmed = window.confirm(
+        `This receipt is ${receipt.currency} but this split is ${result.pinned} — keep anyway?`
       );
-      return false;
+      if (!confirmed) {
+        toast.error(
+          `This receipt is ${receipt.currency}, but this split is in ${result.pinned}.`
+        );
+        return false;
+      }
+      result = addParsedReceipt(stateRef.current, receipt, true);
     }
     stateRef.current = result.next;
     setState(result.next);
@@ -387,7 +401,7 @@ export default function Home() {
     });
   };
 
-  // Handle receipt updates. Currency mismatches are rejected like uploads.
+  // Handle receipt updates. Currency changes require explicit confirmation.
   const handleReceiptUpdate = (
     receiptId: string,
     updatedReceipt: Receipt,
@@ -398,18 +412,25 @@ export default function Home() {
       receiptId,
       updatedReceipt
     );
+    let allowCurrencyOverride = false;
     if (pinned) {
-      toast.error(
-        `This receipt is ${updatedReceipt.currency}, but this split is in ${pinned}.`
+      allowCurrencyOverride = window.confirm(
+        `This receipt is ${updatedReceipt.currency} but this split is ${pinned} — keep anyway?`
       );
-      return false;
+      if (!allowCurrencyOverride) {
+        toast.error(
+          `This receipt is ${updatedReceipt.currency}, but this split is in ${pinned}.`
+        );
+        return false;
+      }
     }
     setState((prevState) => {
       const next = updateReceiptInState(
         prevState,
         receiptId,
         updatedReceipt,
-        remappedAssignments
+        remappedAssignments,
+        allowCurrencyOverride
       );
       stateRef.current = next;
       return next;
@@ -785,7 +806,10 @@ export default function Home() {
             receiptBreakdown={receiptBreakdown}
           />
 
-          <PersonItems people={state.people} currencyCode={sessionCurrency(state.receipts)} />
+          <PersonItems
+            people={state.people}
+            currencyCode={sessionCurrency(state.receipts)}
+          />
         </TabsContent>
       </Tabs>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,7 @@ import {
   getUnassignedItems,
   getSessionUnassigned,
   calculateSessionPersonTotals,
+  calculateSessionPersonTotalsByCurrency,
   calculatePerReceiptPersonTotals,
   sessionShareNote,
   sessionShareDate,
@@ -211,8 +212,19 @@ export default function Home() {
       ).map(({ stored, people }) => ({
         name: stored.receipt.restaurant || "Untitled receipt",
         date: stored.receipt.date,
+        currency: stored.receipt.currency.trim().toUpperCase(),
         people,
       })),
+    [state.receipts, state.people, state.assignedItems]
+  );
+
+  const currencyTotals = useMemo(
+    () =>
+      calculateSessionPersonTotalsByCurrency(
+        state.receipts,
+        state.people,
+        state.assignedItems
+      ),
     [state.receipts, state.people, state.assignedItems]
   );
 
@@ -797,18 +809,25 @@ export default function Home() {
         <TabsContent value="results" className="space-y-6">
           <ValidationErrors errors={validationResult.errors} currencyCode={activeReceipt?.currency} />
 
-          <ResultsSummary
-            people={state.people}
-            receiptName={sessionShareNote(state.receipts)}
-            receiptDate={sessionShareDate(state.receipts)}
-            currencyCode={sessionCurrency(state.receipts)}
-            validationResult={validationResult}
-            receiptBreakdown={receiptBreakdown}
-          />
+          {currencyTotals.map((group) => (
+            <ResultsSummary
+              key={group.currency}
+              people={group.people}
+              receiptName={sessionShareNote(state.receipts)}
+              receiptDate={sessionShareDate(state.receipts)}
+              currencyCode={group.currency}
+              validationResult={validationResult}
+              receiptBreakdown={receiptBreakdown.filter(
+                (receipt) => receipt.currency === group.currency
+              )}
+              currencyGroups={currencyTotals}
+            />
+          ))}
 
           <PersonItems
             people={state.people}
             currencyCode={sessionCurrency(state.receipts)}
+            currencyGroups={currencyTotals}
           />
         </TabsContent>
       </Tabs>

--- a/src/components/person-items.tsx
+++ b/src/components/person-items.tsx
@@ -94,6 +94,7 @@ export function PersonItems({ people, currencyCode, currencyGroups }: PersonItem
               ) : null}
               {currencyGroup.people.map(person => {
             const displayCurrency = currencyGroup.currency;
+            const personKey = `${currencyGroup.currency}:${person.id}`;
             const grouped = hasReceiptGrouping(person.items);
             const groups = grouped ? groupItemsByReceipt(person.items) : [];
 
@@ -101,7 +102,7 @@ export function PersonItems({ people, currencyCode, currencyGroups }: PersonItem
             <div key={`${currencyGroup.currency}-${person.id}`} className="border rounded-md">
               <div 
                 className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted"
-                onClick={() => toggleExpand(person.id)}
+                onClick={() => toggleExpand(personKey)}
               >
                 <div className="font-medium">{person.name}</div>
                 <div className="flex items-center gap-3">
@@ -112,10 +113,10 @@ export function PersonItems({ people, currencyCode, currencyGroups }: PersonItem
                     className="p-0"
                     onClick={(e) => {
                       e.stopPropagation();
-                      toggleExpand(person.id);
+                      toggleExpand(personKey);
                     }}
                   >
-                    {expandedPerson === person.id ? (
+                    {expandedPerson === personKey ? (
                       <ChevronUp className="h-4 w-4" />
                     ) : (
                       <ChevronDown className="h-4 w-4" />
@@ -124,7 +125,7 @@ export function PersonItems({ people, currencyCode, currencyGroups }: PersonItem
                 </div>
               </div>
               
-              {expandedPerson === person.id && (
+              {expandedPerson === personKey && (
                 <div className="px-4 pb-4">
                   {person.items.length === 0 ? (
                     <p className="text-sm text-muted-foreground italic">No items assigned</p>

--- a/src/components/person-items.tsx
+++ b/src/components/person-items.tsx
@@ -12,10 +12,12 @@ import {
 } from '@/components/ui/table';
 import { type Person, type PersonItem } from '@/types';
 import { formatCurrency } from '@/lib/receipt-utils';
+import { type SessionCurrencyTotals } from '@/lib/receipt-utils';
 
 interface PersonItemsProps {
   people: Person[];
   currencyCode?: string;
+  currencyGroups?: SessionCurrencyTotals[];
 }
 
 interface ReceiptItemGroup {
@@ -57,7 +59,7 @@ function renderItemRows(items: PersonItem[], currencyCode?: string, keyPrefix = 
   ));
 }
 
-export function PersonItems({ people, currencyCode }: PersonItemsProps) {
+export function PersonItems({ people, currencyCode, currencyGroups }: PersonItemsProps) {
   const [expandedPerson, setExpandedPerson] = useState<string | null>(null);
   
   // Toggle the expanded/collapsed state
@@ -73,6 +75,10 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
     return null;
   }
 
+  const displayGroups = currencyGroups?.length
+    ? currencyGroups
+    : [{ currency: currencyCode ?? "USD", people }];
+
   return (
     <Card className="w-full">
       <CardHeader>
@@ -80,20 +86,26 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
       </CardHeader>
       
       <CardContent>
-        <div className="flex flex-col gap-4">
-          {people.map(person => {
+        <div className="flex flex-col gap-6">
+          {displayGroups.map((currencyGroup) => (
+            <section key={currencyGroup.currency} className="flex flex-col gap-4">
+              {displayGroups.length > 1 ? (
+                <h2 className="font-semibold">{currencyGroup.currency}</h2>
+              ) : null}
+              {currencyGroup.people.map(person => {
+            const displayCurrency = currencyGroup.currency;
             const grouped = hasReceiptGrouping(person.items);
             const groups = grouped ? groupItemsByReceipt(person.items) : [];
 
             return (
-            <div key={person.id} className="border rounded-md">
+            <div key={`${currencyGroup.currency}-${person.id}`} className="border rounded-md">
               <div 
                 className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted"
                 onClick={() => toggleExpand(person.id)}
               >
                 <div className="font-medium">{person.name}</div>
                 <div className="flex items-center gap-3">
-                  <span className="font-bold">{formatCurrency(person.finalTotal, currencyCode)}</span>
+                  <span className="font-bold">{formatCurrency(person.finalTotal, displayCurrency)}</span>
                   <Button
                     variant="ghost"
                     size="icon"
@@ -137,24 +149,24 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
                                   {group.name}
                                 </TableCell>
                               </TableRow>,
-                              ...renderItemRows(group.items, currencyCode, `${group.id}-`),
+                              ...renderItemRows(group.items, displayCurrency, `${group.id}-`),
                             ])
-                          : renderItemRows(person.items, currencyCode)}
+                          : renderItemRows(person.items, displayCurrency)}
                         <TableRow>
                           <TableCell colSpan={2} className="font-medium">Subtotal</TableCell>
-                          <TableCell className="text-right">{formatCurrency(person.totalBeforeTax, currencyCode)}</TableCell>
+                          <TableCell className="text-right">{formatCurrency(person.totalBeforeTax, displayCurrency)}</TableCell>
                         </TableRow>
                         <TableRow>
                           <TableCell colSpan={2} className="font-medium">Tax</TableCell>
-                          <TableCell className="text-right">{formatCurrency(person.tax, currencyCode)}</TableCell>
+                          <TableCell className="text-right">{formatCurrency(person.tax, displayCurrency)}</TableCell>
                         </TableRow>
                         <TableRow>
                           <TableCell colSpan={2} className="font-medium">Tip</TableCell>
-                          <TableCell className="text-right">{formatCurrency(person.tip, currencyCode)}</TableCell>
+                          <TableCell className="text-right">{formatCurrency(person.tip, displayCurrency)}</TableCell>
                         </TableRow>
                         <TableRow>
                           <TableCell colSpan={2} className="font-medium">Total</TableCell>
-                          <TableCell className="text-right font-bold">{formatCurrency(person.finalTotal, currencyCode)}</TableCell>
+                          <TableCell className="text-right font-bold">{formatCurrency(person.finalTotal, displayCurrency)}</TableCell>
                         </TableRow>
                       </TableBody>
                     </Table>
@@ -162,8 +174,10 @@ export function PersonItems({ people, currencyCode }: PersonItemsProps) {
                 </div>
               )}
             </div>
-            );
-          })}
+              );
+            })}
+            </section>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -11,7 +11,11 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { type Person } from "@/types";
-import { formatCurrency, type ReceiptValidationResult } from "@/lib/receipt-utils";
+import {
+  formatCurrency,
+  type ReceiptValidationResult,
+  type SessionCurrencyTotals,
+} from "@/lib/receipt-utils";
 import {
   generateShareableUrl,
   validateSerializationInput,
@@ -22,6 +26,7 @@ import { useState } from "react";
 export interface ReceiptBreakdown {
   name: string;
   date: string | null;
+  currency?: string;
   people: Person[];
 }
 
@@ -32,6 +37,8 @@ interface ResultsSummaryProps {
   currencyCode?: string;
   validationResult?: ReceiptValidationResult;
   receiptBreakdown?: ReceiptBreakdown[];
+  /** All currency groups in the session, used to gate Venmo sharing. */
+  currencyGroups?: SessionCurrencyTotals[];
 }
 
 function receiptLabel(receipt: ReceiptBreakdown): string {
@@ -45,6 +52,7 @@ export function ResultsSummary({
   currencyCode,
   validationResult,
   receiptBreakdown,
+  currencyGroups,
 }: ResultsSummaryProps) {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [shareStatus, setShareStatus] = useState<
@@ -53,6 +61,8 @@ export function ResultsSummary({
   // Sort people by final total (highest first)
   const sortedPeople = [...people].sort((a, b) => b.finalTotal - a.finalTotal);
   const showBreakdown = (receiptBreakdown?.length ?? 0) > 1;
+  const isSingleCurrency = (currencyGroups?.length ?? 1) === 1;
+  const showDayTotalHeading = showBreakdown || !isSingleCurrency;
 
   // Create a shareable text summary matching on-screen order:
   // Day total (people amounts), then By receipt (restaurant + date).
@@ -202,6 +212,7 @@ export function ResultsSummary({
     people.length > 0 &&
     people.every((person) => person.finalTotal > 0) &&
     phoneNumber.replace(/\D/g, "").length >= 10 &&
+    isSingleCurrency &&
     (!validationResult || validationResult.isValid);
 
   if (people.length === 0) {
@@ -258,7 +269,12 @@ export function ResultsSummary({
 
       <Card className="w-full">
         <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <CardTitle className="text-xl sm:text-2xl">Results Summary</CardTitle>
+          <CardTitle className="text-xl sm:text-2xl">
+            Results Summary
+            {currencyGroups && currencyGroups.length > 1 && currencyCode
+              ? ` · ${currencyCode}`
+              : ""}
+          </CardTitle>
           <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
             <Button
               variant="outline"
@@ -270,14 +286,21 @@ export function ResultsSummary({
             </Button>
           </div>
         </CardHeader>
+        {!isSingleCurrency ? (
+          <p className="px-6 text-sm text-muted-foreground">
+            Venmo sharing is available only for single-currency splits.
+          </p>
+        ) : null}
         <CardContent className="p-6">
           <div className="flex flex-col gap-6">
           <div
             data-testid={showBreakdown ? "day-total" : undefined}
             className="flex flex-col gap-2"
           >
-            {showBreakdown ? (
-              <h2 className="font-semibold text-base sm:text-lg">Day total</h2>
+            {showDayTotalHeading ? (
+              <h2 className="font-semibold text-base sm:text-lg">
+                Day total{!isSingleCurrency && currencyCode ? ` · ${currencyCode}` : ""}
+              </h2>
             ) : null}
 
           {/* Mobile-friendly responsive table */}

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -69,6 +69,10 @@ export function ResultsSummary({
   const createShareText = (): string => {
     let text = "";
 
+    if (!isSingleCurrency && currencyCode) {
+      text += `Currency: ${currencyCode}\n`;
+    }
+
     if (showBreakdown) {
       text += "Day total\n";
       sortedPeople.forEach((person) => {
@@ -223,14 +227,14 @@ export function ResultsSummary({
     <div className="w-full flex flex-col gap-4">
       <div className="flex flex-col gap-3">
         <label
-          htmlFor="venmo-phone"
+          htmlFor={`venmo-phone-${currencyCode ?? "default"}`}
           className="font-medium text-sm sm:text-base"
         >
           Your Phone Number (for Venmo):
         </label>
         <div className="flex gap-3">
           <input
-            id="venmo-phone"
+            id={`venmo-phone-${currencyCode ?? "default"}`}
             type="tel"
             placeholder="e.g. 555-123-4567"
             value={phoneNumber}

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -62,6 +62,9 @@ export function ResultsSummary({
   const sortedPeople = [...people].sort((a, b) => b.finalTotal - a.finalTotal);
   const showBreakdown = (receiptBreakdown?.length ?? 0) > 1;
   const isSingleCurrency = (currencyGroups?.length ?? 1) === 1;
+  const phoneInputId = isSingleCurrency
+    ? "venmo-phone"
+    : `venmo-phone-${currencyCode ?? "default"}`;
   const showDayTotalHeading = showBreakdown || !isSingleCurrency;
 
   // Create a shareable text summary matching on-screen order:
@@ -227,14 +230,14 @@ export function ResultsSummary({
     <div className="w-full flex flex-col gap-4">
       <div className="flex flex-col gap-3">
         <label
-          htmlFor={`venmo-phone-${currencyCode ?? "default"}`}
+          htmlFor={phoneInputId}
           className="font-medium text-sm sm:text-base"
         >
           Your Phone Number (for Venmo):
         </label>
         <div className="flex gap-3">
           <input
-            id={`venmo-phone-${currencyCode ?? "default"}`}
+            id={phoneInputId}
             type="tel"
             placeholder="e.g. 555-123-4567"
             value={phoneNumber}

--- a/src/lib/receipt-utils.test.ts
+++ b/src/lib/receipt-utils.test.ts
@@ -11,6 +11,7 @@ import {
   sessionCurrency,
   validateReceiptCurrency,
   calculateSessionPersonTotals,
+  calculateSessionPersonTotalsByCurrency,
   calculatePerReceiptPersonTotals,
   sessionShareNote,
   sessionShareDate,
@@ -886,6 +887,27 @@ describe("session-level receipt helpers", () => {
     // Bob has no assignments across either receipt
     expect(session[1].finalTotal).toBe(0);
     expect(session[1].items).toHaveLength(0);
+  });
+
+  it("groups session totals by currency without combining amounts", () => {
+    const euroReceipt: StoredReceipt = {
+      id: "rec-eur",
+      receipt: { ...receiptB, currency: "EUR", restaurant: "Cafe EUR" },
+    };
+    const groups = calculateSessionPersonTotalsByCurrency(
+      [storedA, euroReceipt],
+      mockPeople,
+      new Map([
+        ["rec-a", innerA],
+        ["rec-eur", innerB],
+      ])
+    );
+
+    expect(groups.map((group) => group.currency)).toEqual(["USD", "EUR"]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].people[0].finalTotal).toBe(60);
+    expect(groups[1].people[0].finalTotal).toBe(50);
+    expect(groups[0].people[0].finalTotal + groups[1].people[0].finalTotal).toBe(110);
   });
 
   it("validateSessionAssignments is false when receipt B is incomplete", () => {

--- a/src/lib/receipt-utils.ts
+++ b/src/lib/receipt-utils.ts
@@ -551,8 +551,9 @@ export function validateReceiptInvariants(
 }
 
 /**
- * Session currency is the first receipt's currency. Mixed-currency splits
- * are not supported; later receipts must match this code.
+ * Session currency is the first receipt's currency. It remains the session
+ * pin for display and confirmation messaging; accepted overrides are grouped
+ * separately in calculateSessionPersonTotalsByCurrency.
  */
 export function sessionCurrency(receipts: StoredReceipt[]): string | undefined {
   return receipts[0]?.receipt.currency;
@@ -618,6 +619,35 @@ export function calculateSessionPersonTotals(
     tax: person.tax.toNumber(),
     tip: person.tip.toNumber(),
     finalTotal: person.finalTotal.toNumber(),
+  }));
+}
+
+export interface SessionCurrencyTotals {
+  currency: string;
+  people: Person[];
+}
+
+/**
+ * Aggregates session totals independently for each currency. Currency groups
+ * preserve first-seen order and never combine amounts across exchange rates.
+ */
+export function calculateSessionPersonTotalsByCurrency(
+  receipts: StoredReceipt[],
+  people: Person[],
+  assignedItems: Map<string, ItemAssignments>
+): SessionCurrencyTotals[] {
+  const receiptGroups = new Map<string, StoredReceipt[]>();
+
+  for (const stored of receipts) {
+    const currency = stored.receipt.currency.trim().toUpperCase();
+    const group = receiptGroups.get(currency) ?? [];
+    group.push(stored);
+    receiptGroups.set(currency, group);
+  }
+
+  return [...receiptGroups.entries()].map(([currency, groupedReceipts]) => ({
+    currency,
+    people: calculateSessionPersonTotals(groupedReceipts, people, assignedItems),
   }));
 }
 


### PR DESCRIPTION
:::note
🤖 Hermes is acting on behalf of Karan.
:::

## Summary
- Replace hard currency mismatch rejection with explicit confirmation for receipt uploads and edits.
- Preserve each accepted receipt currency and group result/day totals independently by currency.
- Keep Venmo split sharing disabled for mixed-currency sessions while retaining single-currency behavior.

Part of #170

## Test plan
- `npm test -- --runInBand` (31 suites, 581 tests)
- `npm run lint`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `.githooks/pre-commit` unavailable in this checkout (`No such file or directory`)
