### PR TITLE
feat: add itemized multi-receipt share details

### DIFF
--- a/src/components/results-summary.test.tsx
+++ b/src/components/results-summary.test.tsx
@@ -709,5 +709,31 @@ describe("ResultsSummary", () => {
         });
       }
     });
+
+    it("includes per-receipt amounts in a multi-receipt share URL", async () => {
+      render(
+        <ResultsSummary
+          people={[alice]}
+          receiptName="Coffee Shop, Lunch Place"
+          receiptDate="2024-01-01"
+          receiptBreakdown={twoReceiptBreakdown}
+        />
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("e.g. 555-123-4567"), {
+        target: { value: "5551234567" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /share split/i }));
+
+      await waitFor(() => {
+        const clipboardContent = (navigator.clipboard.writeText as jest.Mock).mock.calls.at(-1)?.[0];
+        expect(clipboardContent).toContain("receipts=");
+        const receipts = JSON.parse(new URL(clipboardContent).searchParams.get("receipts")!);
+        expect(receipts).toEqual([
+          { label: "Coffee Shop · 2024-01-01", amounts: [2500] },
+          { label: "Lunch Place · 2024-01-01", amounts: [3500] },
+        ]);
+      });
+    });
   });
 });

--- a/src/components/results-summary.tsx
+++ b/src/components/results-summary.tsx
@@ -15,6 +15,7 @@ import { formatCurrency, type ReceiptValidationResult } from "@/lib/receipt-util
 import {
   generateShareableUrl,
   validateSerializationInput,
+  type SharedReceiptBreakdown,
 } from "@/lib/split-sharing";
 
 import { useState } from "react";
@@ -181,7 +182,17 @@ export function ResultsSummary({
         note,
         cleanPhone,
         currencyCode,
-        receiptDate
+        receiptDate,
+        showBreakdown
+          ? receiptBreakdown?.map<SharedReceiptBreakdown>((receipt) => ({
+              label: receiptLabel(receipt),
+              amounts: people.map(
+                (person) =>
+                  receipt.people.find((receiptPerson) => receiptPerson.id === person.id)
+                    ?.finalTotal ?? 0
+              ),
+            }))
+          : undefined
       );
 
       // Copy to clipboard

--- a/src/components/split-summary.test.tsx
+++ b/src/components/split-summary.test.tsx
@@ -213,4 +213,28 @@ describe("SplitSummary", () => {
       screen.queryByRole("link", { name: /with Venmo/i })
     ).not.toBeInTheDocument();
   });
+
+  it("renders multi-receipt amounts without adding per-receipt Venmo actions", () => {
+    const splitData: SharedSplitData = {
+      names: ["Alice", "Bob"],
+      amounts: [30, 20],
+      total: 50,
+      note: "Dinner Split",
+      phone: "5551234567",
+      currency: "USD",
+      receipts: [
+        { label: "Cafe", amounts: [12, 8] },
+        { label: "Dessert Bar", amounts: [18, 12] },
+      ],
+    };
+
+    render(<SplitSummary splitData={splitData} phoneNumber={splitData.phone} />);
+
+    expect(screen.getByRole("heading", { name: "By receipt" })).toBeInTheDocument();
+    expect(screen.getByText("Cafe")).toBeInTheDocument();
+    expect(screen.getByText("Dessert Bar")).toBeInTheDocument();
+    expect(screen.getAllByText("$12.00")).toHaveLength(2);
+    expect(screen.getByText("$8.00")).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /Pay/ })).toHaveLength(2);
+  });
 });

--- a/src/components/split-summary.tsx
+++ b/src/components/split-summary.tsx
@@ -130,6 +130,35 @@ export function SplitSummary({ splitData, phoneNumber }: SplitSummaryProps) {
             ))}
           </ul>
         </section>
+        {splitData.receipts && splitData.receipts.length > 1 && (
+          <section aria-labelledby="receipt-breakdown-heading" className="mt-6">
+            <div className="border-t px-5 py-4 sm:px-6">
+              <h2 id="receipt-breakdown-heading" className="text-lg font-semibold">
+                By receipt
+              </h2>
+            </div>
+            <div className="flex flex-col gap-4 px-0">
+              {splitData.receipts.map((receipt, receiptIndex) => (
+                <div key={`${receipt.label}-${receiptIndex}`}>
+                  <h3 className="px-5 pb-2 text-sm font-semibold text-muted-foreground sm:px-6">
+                    {receipt.label}
+                  </h3>
+                  <ul className="flex flex-col divide-y divide-border border-y">
+                    {splitData.names.map((name, personIndex) => (
+                      <SplitPersonRow
+                        key={`${receiptIndex}-${name}-${personIndex}`}
+                        name={name}
+                        amount={receipt.amounts[personIndex]}
+                        currency={splitData.currency}
+                        venmoHref={null}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/lib/split-sharing.test.ts
+++ b/src/lib/split-sharing.test.ts
@@ -8,7 +8,9 @@ import {
   isValidDateFormat,
   SplitDataError,
   VALIDATION_LIMITS,
+  MAX_SHARE_URL_LENGTH,
   type SharedSplitData,
+  type SharedReceiptBreakdown,
 } from "./split-sharing";
 import { type Person } from "@/types";
 
@@ -41,6 +43,11 @@ const mockPeople: Person[] = [
     tip: 2.0,
     finalTotal: 13.0,
   },
+];
+
+const mockReceiptBreakdown: SharedReceiptBreakdown[] = [
+  { label: "Pizza Palace", amounts: [32.5, 19.5, 0] },
+  { label: "Dessert Bar · 2024-01-15", amounts: [0, 0, 13] },
 ];
 
 describe("serializeSplitData", () => {
@@ -126,6 +133,91 @@ describe("serializeSplitData", () => {
     // Should preserve special characters in URL encoding
     expect(params.get("names")).toBe("François & Co.,José María");
     expect(params.get("note")).toBe("Café René & Co.");
+  });
+
+  it("should serialize multi-receipt itemization in sorted person order", () => {
+    const params = serializeSplitData(
+      mockPeople,
+      "Pizza Palace, Dessert Bar",
+      "5551234567",
+      "USD",
+      null,
+      mockReceiptBreakdown
+    );
+
+    expect(JSON.parse(params.get("receipts")!)).toEqual([
+      { label: "Pizza Palace", amounts: [3250, 1950, 0] },
+      { label: "Dessert Bar · 2024-01-15", amounts: [0, 0, 1300] },
+    ]);
+  });
+
+  it("should preserve valid per-receipt amounts above the minor-unit value 99999", () => {
+    const people: Person[] = [{ ...mockPeople[0], finalTotal: 2000 }];
+    const params = serializeSplitData(
+      people,
+      "Large Split",
+      "5551234567",
+      "USD",
+      null,
+      [
+        { label: "First receipt", amounts: [1000] },
+        { label: "Second receipt", amounts: [1000] },
+      ]
+    );
+
+    expect(deserializeSplitData(params)?.receipts).toEqual([
+      { label: "First receipt", amounts: [1000] },
+      { label: "Second receipt", amounts: [1000] },
+    ]);
+  });
+
+  it("should align itemization with sorted names when people arrive unsorted", () => {
+    const unsortedPeople = [mockPeople[1], mockPeople[0]];
+    const params = serializeSplitData(
+      unsortedPeople,
+      "Unsorted Split",
+      "5551234567",
+      "USD",
+      null,
+      [
+        { label: "Lunch", amounts: [19.5, 32.5] },
+        { label: "Dessert", amounts: [0, 0] },
+      ]
+    );
+
+    expect(JSON.parse(params.get("receipts")!)).toEqual([
+      { label: "Lunch", amounts: [3250, 1950] },
+      { label: "Dessert", amounts: [0, 0] },
+    ]);
+  });
+
+  it("should omit itemization that does not reconcile with aggregate amounts", () => {
+    const params = serializeSplitData(
+      mockPeople,
+      "Pizza Palace, Dessert Bar",
+      "5551234567",
+      "USD",
+      null,
+      [
+        { label: "Pizza Palace", amounts: [30, 19.5, 13] },
+        { label: "Dessert Bar", amounts: [0, 0, 0] },
+      ]
+    );
+
+    expect(params.get("receipts")).toBeNull();
+  });
+
+  it("keeps single-receipt shares compact by omitting itemization", () => {
+    const params = serializeSplitData(
+      mockPeople,
+      "Pizza Palace",
+      "5551234567",
+      "USD",
+      null,
+      [{ label: "Pizza Palace", amounts: [32.5, 19.5, 13] }]
+    );
+
+    expect(params.get("receipts")).toBeNull();
   });
 });
 
@@ -311,6 +403,62 @@ describe("deserializeSplitData", () => {
     expect(result!.note).toBe("Café René & Co.");
     expect(result!.phone).toBe("5551234567");
   });
+
+  it("should round-trip optional multi-receipt itemization", () => {
+    const params = serializeSplitData(
+      mockPeople,
+      "Pizza Palace, Dessert Bar",
+      "5551234567",
+      "USD",
+      null,
+      mockReceiptBreakdown
+    );
+
+    const result = deserializeSplitData(params);
+
+    expect(result?.receipts).toEqual(mockReceiptBreakdown);
+  });
+
+  it("should preserve legacy links without itemization", () => {
+    const params = new URLSearchParams({
+      names: "Alice,Bob",
+      amounts: "30.00,20.00",
+      total: "50.00",
+      note: "Test Split",
+      phone: "5551234567",
+    });
+
+    expect(deserializeSplitData(params)?.receipts).toBeUndefined();
+  });
+
+  it("should reject malformed itemization instead of rendering partial data", () => {
+    const params = new URLSearchParams({
+      names: "Alice,Bob",
+      amounts: "30.00,20.00",
+      total: "50.00",
+      note: "Test Split",
+      phone: "5551234567",
+      receipts: JSON.stringify([{ label: "Lunch", amounts: [30] }]),
+    });
+
+    expect(deserializeSplitData(params)).toBeNull();
+  });
+
+  it("should reject itemization that conflicts with aggregate amounts", () => {
+    const params = new URLSearchParams({
+      names: "Alice,Bob",
+      amounts: "30.00,20.00",
+      total: "50.00",
+      note: "Test Split",
+      phone: "5551234567",
+      receipts: JSON.stringify([
+        { label: "Lunch", amounts: [3000, 2000] },
+        { label: "Dessert", amounts: [100, 0] },
+      ]),
+    });
+
+    expect(deserializeSplitData(params)).toBeNull();
+  });
 });
 
 describe("generateShareableUrl", () => {
@@ -359,6 +507,37 @@ describe("generateShareableUrl", () => {
 
     expect(url).toMatch(/^https:\/\/example\.com\/split\?/);
   });
+
+  it("should omit oversized optional itemization while keeping the URL valid", () => {
+    const oversizedBreakdown = Array.from({ length: 50 }, (_, index) => ({
+      label: `Restaurant ${index} ${"x".repeat(65)} & Café`,
+      amounts: [0.65, 0.39, 0.26],
+    }));
+
+    const rawParams = serializeSplitData(
+      mockPeople,
+      "Receipt Split",
+      "5551234567",
+      "USD",
+      null,
+      oversizedBreakdown
+    );
+    expect(rawParams.get("receipts")).not.toBeNull();
+
+    const url = generateShareableUrl(
+      "https://receipt-splitter.app",
+      mockPeople,
+      "Receipt Split",
+      "5551234567",
+      "USD",
+      null,
+      oversizedBreakdown
+    );
+
+    expect(url.length).toBeLessThanOrEqual(MAX_SHARE_URL_LENGTH);
+    expect(url).not.toContain("receipts=");
+    expect(deserializeSplitData(new URL(url).searchParams)).not.toBeNull();
+  });
 });
 
 describe("validateSplitData", () => {
@@ -387,6 +566,43 @@ describe("validateSplitData", () => {
     };
 
     expect(validateSplitDataDetailed(minimalData).isValid).toBe(true);
+  });
+
+  it("should validate per-receipt itemization with one amount per person", () => {
+    const itemizedData: SharedSplitData = {
+      ...validSplitData,
+      receipts: [{ label: "Lunch", amounts: [30, 20] }],
+    };
+
+    expect(validateSplitDataDetailed(itemizedData).isValid).toBe(true);
+  });
+
+  it("should reject itemization beyond the receipt-count limit", () => {
+    const itemizedData: SharedSplitData = {
+      ...validSplitData,
+      receipts: Array.from({ length: VALIDATION_LIMITS.MAX_RECEIPTS_COUNT + 1 }, (_, index) => ({
+        label: `Receipt ${index}`,
+        amounts: [30, 20],
+      })),
+    };
+
+    const result = validateSplitDataDetailed(itemizedData);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(SplitDataError.TOO_MANY_RECEIPTS);
+  });
+
+  it("should reject itemization that conflicts with aggregate amounts", () => {
+    const itemizedData: SharedSplitData = {
+      ...validSplitData,
+      receipts: [
+        { label: "Lunch", amounts: [30, 20] },
+        { label: "Dessert", amounts: [1, 0] },
+      ],
+    };
+
+    const result = validateSplitDataDetailed(itemizedData);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain(SplitDataError.INVALID_RECEIPT_BREAKDOWN);
   });
 
   it("should reject data missing required note field", () => {
@@ -893,6 +1109,44 @@ describe("Multi-Currency Support", () => {
       expect(params.get("total")).toBe("2250");
       expect(params.get("currency")).toBe("JPY");
       expect(params.get("note")).toBe("Sushi Restaurant");
+    });
+
+    it("should round-trip JPY receipt itemization after minor-unit conversion", () => {
+      const params = serializeSplitData(
+        mockPeopleJPY,
+        "Sushi Restaurant, Dessert Bar",
+        "5551234567",
+        "JPY",
+        null,
+        [
+          { label: "Sushi Restaurant", amounts: [750, 500] },
+          { label: "Dessert Bar", amounts: [500, 500] },
+        ]
+      );
+
+      expect(deserializeSplitData(params)?.receipts).toEqual([
+        { label: "Sushi Restaurant", amounts: [750, 500] },
+        { label: "Dessert Bar", amounts: [500, 500] },
+      ]);
+    });
+
+    it("should omit a JPY itemized amount that rounds beyond the shared limit", () => {
+      const people: Person[] = [{ ...mockPeopleJPY[0], finalTotal: 99999.5 }];
+      const url = generateShareableUrl(
+        "https://receipt-splitter.app",
+        people,
+        "Large Yen Split",
+        "5551234567",
+        "JPY",
+        null,
+        [
+          { label: "First receipt", amounts: [99999.5] },
+          { label: "Second receipt", amounts: [0] },
+        ]
+      );
+
+      expect(url).not.toContain("receipts=");
+      expect(deserializeSplitData(new URL(url).searchParams)).not.toBeNull();
     });
 
     it("should serialize KRW amounts correctly (0 decimal places)", () => {

--- a/src/lib/split-sharing.ts
+++ b/src/lib/split-sharing.ts
@@ -12,6 +12,17 @@ export interface SharedSplitData {
   phone: string; // Required: needed for Venmo payment links
   currency: string; // Currency code (e.g., 'USD', 'JPY', 'EUR')
   date?: string; // Optional: receipt date for display
+  receipts?: SharedReceiptBreakdown[]; // Optional multi-receipt detail
+}
+
+/**
+ * Per-receipt amounts follow the same person order as the `people` argument
+ * passed to serializeSplitData. They are normalized to the sorted name order
+ * in the URL payload.
+ */
+export interface SharedReceiptBreakdown {
+  label: string;
+  amounts: number[];
 }
 
 /**
@@ -33,6 +44,9 @@ export enum SplitDataError {
   TOO_MANY_PEOPLE = "TOO_MANY_PEOPLE",
   AMOUNT_TOO_LARGE = "AMOUNT_TOO_LARGE",
   INVALID_SPLIT_DETAILS = "INVALID_SPLIT_DETAILS",
+  INVALID_RECEIPT_BREAKDOWN = "INVALID_RECEIPT_BREAKDOWN",
+  RECEIPT_LABEL_TOO_LONG = "RECEIPT_LABEL_TOO_LONG",
+  TOO_MANY_RECEIPTS = "TOO_MANY_RECEIPTS",
 }
 
 /**
@@ -51,12 +65,18 @@ export const VALIDATION_LIMITS = {
   MAX_NAME_LENGTH: 50,
   MAX_NOTE_LENGTH: 100,
   MAX_PEOPLE_COUNT: 50,
+  MAX_RECEIPTS_COUNT: 50,
+  MAX_RECEIPT_LABEL_LENGTH: 100,
   MAX_AMOUNT: 99999.99,
   // Base tolerance for rounding differences when summing individual amounts
   // We will scale this dynamically by number of people to account for
   // compounding rounding errors (up to 1 cent per person)
   SPLIT_AMOUNT_DEVIATION_PER_PERSON: 0.01,
 } as const;
+
+/** Keep optional itemization bounded while leaving the required split usable. */
+export const MAX_SHARE_URL_LENGTH = 8000;
+const MAX_RECEIPT_PAYLOAD_LENGTH = 6000;
 
 /**
  * Serializes split data into URL-safe parameters
@@ -66,6 +86,7 @@ export const VALIDATION_LIMITS = {
  * @param phone - Required phone number for Venmo payments
  * @param currency - Currency code for the split (defaults to USD)
  * @param date - Optional receipt date
+ * @param receiptBreakdown - Optional per-receipt amounts for multi-receipt shares
  * @returns URLSearchParams object ready to be appended to a URL
  */
 export function serializeSplitData(
@@ -73,7 +94,8 @@ export function serializeSplitData(
   note: string,
   phone: string,
   currency: string = DEFAULT_CURRENCY,
-  date?: string | null
+  date?: string | null,
+  receiptBreakdown?: SharedReceiptBreakdown[]
 ): URLSearchParams {
   // Validate input before proceeding
   const validation = validateSerializationInput(people, note, phone, date);
@@ -84,7 +106,10 @@ export function serializeSplitData(
   }
 
   // Sort people by name for consistent ordering
-  const sortedPeople = [...people].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedPeopleWithIndexes = people
+    .map((person, index) => ({ person, index }))
+    .sort((a, b) => a.person.name.localeCompare(b.person.name));
+  const sortedPeople = sortedPeopleWithIndexes.map(({ person }) => person);
 
   const names = sortedPeople.map((person) => person.name);
   const amountsMinorUnits = sortedPeople.map((person) => toMinorUnits(person.finalTotal, currency));
@@ -106,7 +131,103 @@ export function serializeSplitData(
     params.set("date", date);
   }
 
+  const serializedReceipts = serializeReceiptBreakdown(
+    receiptBreakdown,
+    sortedPeopleWithIndexes.map(({ index }) => index),
+    sortedPeople.map((person) => person.finalTotal),
+    currency
+  );
+  if (serializedReceipts) {
+    params.set("receipts", serializedReceipts);
+  }
+
   return params;
+}
+
+function serializeReceiptBreakdown(
+  receiptBreakdown: SharedReceiptBreakdown[] | undefined,
+  sortedPersonIndexes: number[],
+  personTotals: number[],
+  currency: string
+): string | null {
+  if (!receiptBreakdown || receiptBreakdown.length <= 1) {
+    return null;
+  }
+  if (
+    !isValidReceiptBreakdown(
+      receiptBreakdown,
+      sortedPersonIndexes.length,
+      currency
+    )
+  ) {
+    return null;
+  }
+
+  const normalizedBreakdown = receiptBreakdown.map((receipt) => ({
+    label: receipt.label.trim(),
+    amounts: sortedPersonIndexes.map((index) => receipt.amounts[index]),
+  }));
+  if (!receiptBreakdownMatchesTotals(normalizedBreakdown, personTotals, currency)) {
+    return null;
+  }
+
+  const payload = normalizedBreakdown.map((receipt) => ({
+    label: receipt.label,
+    amounts: receipt.amounts.map((amount) => toMinorUnits(amount, currency)),
+  }));
+  const serialized = JSON.stringify(payload);
+  return serialized.length <= MAX_RECEIPT_PAYLOAD_LENGTH ? serialized : null;
+}
+
+function isValidReceiptBreakdown(
+  receiptBreakdown: SharedReceiptBreakdown[],
+  personCount: number,
+  currency: string
+): boolean {
+  if (
+    receiptBreakdown.length === 0 ||
+    receiptBreakdown.length > VALIDATION_LIMITS.MAX_RECEIPTS_COUNT
+  ) {
+    return false;
+  }
+
+  return receiptBreakdown.every(
+    (receipt) =>
+      typeof receipt.label === "string" &&
+      receipt.label.trim().length > 0 &&
+      receipt.label.trim().length <= VALIDATION_LIMITS.MAX_RECEIPT_LABEL_LENGTH &&
+      Array.isArray(receipt.amounts) &&
+      receipt.amounts.length === personCount &&
+      receipt.amounts.every((amount) =>
+        isValidReceiptAmount(amount, currency)
+      )
+  );
+}
+
+function isValidReceiptAmount(amount: number, currency: string): boolean {
+  if (!Number.isFinite(amount) || amount < 0) {
+    return false;
+  }
+  const normalized = fromMinorUnits(toMinorUnits(amount, currency), currency);
+  return normalized <= VALIDATION_LIMITS.MAX_AMOUNT;
+}
+
+function receiptBreakdownMatchesTotals(
+  receiptBreakdown: SharedReceiptBreakdown[],
+  personTotals: number[],
+  currency: string
+): boolean {
+  return personTotals.every((total, personIndex) => {
+    const itemizedTotal = receiptBreakdown.reduce(
+      (sum, receipt) =>
+        sum + toMinorUnits(receipt.amounts[personIndex], currency),
+      0
+    );
+    const totalMinorUnits = toMinorUnits(total, currency);
+    return (
+      Math.abs(itemizedTotal - totalMinorUnits) <= receiptBreakdown.length
+    );
+  });
 }
 
 /**
@@ -125,6 +246,7 @@ export function deserializeSplitData(
     const noteParam = searchParams.get("note");
     const phoneParam = searchParams.get("phone");
     const currencyParam = searchParams.get("currency");
+    const receiptsParam = searchParams.get("receipts");
 
     // Required parameters check (currency defaults to USD for backwards compatibility)
     if (
@@ -184,6 +306,13 @@ export function deserializeSplitData(
 
     // Optional parameters
     const date = searchParams.get("date") || undefined;
+    const receipts = parseReceiptBreakdown(receiptsParam, names.length, currency);
+    if (
+      receipts === null ||
+      (receipts && !receiptBreakdownMatchesTotals(receipts, amounts, currency))
+    ) {
+      return null;
+    }
 
     return {
       names,
@@ -193,11 +322,84 @@ export function deserializeSplitData(
       phone,
       currency,
       date,
+      ...(receipts ? { receipts } : {}),
     };
   } catch {
     // Return null for any parsing errors
     return null;
   }
+}
+
+function parseReceiptBreakdown(
+  serialized: string | null,
+  personCount: number,
+  currency: string
+): SharedReceiptBreakdown[] | null | undefined {
+  if (serialized === null) {
+    return undefined;
+  }
+  if (serialized.length > MAX_RECEIPT_PAYLOAD_LENGTH) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(serialized);
+    if (
+      !Array.isArray(parsed) ||
+      !isValidReceiptBreakdownShape(parsed, personCount, currency)
+    ) {
+      return null;
+    }
+
+    const receipts = parsed.map((receipt) => {
+      const item = receipt as { label: string; amounts: number[] };
+      return {
+        label: item.label.trim(),
+        amounts: item.amounts.map((amount) =>
+          Number.isInteger(amount) ? fromMinorUnits(amount, currency) : amount
+        ),
+      };
+    });
+    return receipts;
+  } catch {
+    return null;
+  }
+}
+
+function isValidReceiptBreakdownShape(
+  value: unknown[],
+  personCount: number,
+  currency: string
+): value is SharedReceiptBreakdown[] {
+  if (
+    value.length === 0 ||
+    value.length > VALIDATION_LIMITS.MAX_RECEIPTS_COUNT
+  ) {
+    return false;
+  }
+
+  return value.every((receipt) => {
+    if (!receipt || typeof receipt !== "object") return false;
+    const item = receipt as { label?: unknown; amounts?: unknown };
+    return (
+      typeof item.label === "string" &&
+      item.label.trim().length > 0 &&
+      item.label.trim().length <= VALIDATION_LIMITS.MAX_RECEIPT_LABEL_LENGTH &&
+      Array.isArray(item.amounts) &&
+      item.amounts.length === personCount &&
+      item.amounts.every(
+        (amount) =>
+          typeof amount === "number" &&
+          Number.isFinite(amount) &&
+          isValidReceiptAmount(
+            Number.isInteger(amount)
+              ? fromMinorUnits(amount, currency)
+              : amount,
+            currency
+          )
+      )
+    );
+  });
 }
 
 /**
@@ -209,6 +411,7 @@ export function deserializeSplitData(
  * @param phone - Required phone number for Venmo payments
  * @param currency - Currency code for the split (defaults to USD)
  * @param date - Optional receipt date
+ * @param receiptBreakdown - Optional per-receipt amounts for multi-receipt shares
  * @returns Complete shareable URL
  */
 export function generateShareableUrl(
@@ -217,11 +420,25 @@ export function generateShareableUrl(
   note: string,
   phone: string,
   currency: string = DEFAULT_CURRENCY,
-  date?: string | null
+  date?: string | null,
+  receiptBreakdown?: SharedReceiptBreakdown[]
 ): string {
-  const params = serializeSplitData(people, note, phone, currency, date);
+  const params = serializeSplitData(
+    people,
+    note,
+    phone,
+    currency,
+    date,
+    receiptBreakdown
+  );
   // Ensure baseUrl doesn't end with slash to avoid double slashes
   const cleanBaseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  if (params.has("receipts")) {
+    const withBreakdown = `${cleanBaseUrl}/split?${params.toString()}`;
+    if (withBreakdown.length > MAX_SHARE_URL_LENGTH) {
+      params.delete("receipts");
+    }
+  }
   return `${cleanBaseUrl}/split?${params.toString()}`;
 }
 
@@ -299,6 +516,64 @@ export function validateSplitDataDetailed(
       errorMessages.push(
         `Maximum ${VALIDATION_LIMITS.MAX_PEOPLE_COUNT} people allowed in a split`
       );
+    }
+
+    if (splitData.receipts) {
+      if (
+        splitData.receipts.length === 0 ||
+        splitData.receipts.length > VALIDATION_LIMITS.MAX_RECEIPTS_COUNT
+      ) {
+        errors.push(SplitDataError.TOO_MANY_RECEIPTS);
+        errorMessages.push(
+          `Between 1 and ${VALIDATION_LIMITS.MAX_RECEIPTS_COUNT} receipts are allowed in itemization`
+        );
+      }
+
+      splitData.receipts.forEach((receipt, index) => {
+        if (!receipt.label || receipt.label.trim().length === 0) {
+          errors.push(SplitDataError.INVALID_RECEIPT_BREAKDOWN);
+          errorMessages.push(`Receipt ${index + 1} has an empty label`);
+        } else if (
+          receipt.label.trim().length > VALIDATION_LIMITS.MAX_RECEIPT_LABEL_LENGTH
+        ) {
+          errors.push(SplitDataError.RECEIPT_LABEL_TOO_LONG);
+          errorMessages.push(
+            `Receipt label "${receipt.label.trim()}" exceeds ${VALIDATION_LIMITS.MAX_RECEIPT_LABEL_LENGTH} characters`
+          );
+        }
+
+        if (
+          !Array.isArray(receipt.amounts) ||
+          receipt.amounts.length !== splitData.names.length ||
+          receipt.amounts.some(
+            (amount) =>
+              !isValidReceiptAmount(amount, splitData.currency)
+          )
+        ) {
+          errors.push(SplitDataError.INVALID_RECEIPT_BREAKDOWN);
+          errorMessages.push(
+            `Receipt ${index + 1} must include one valid amount for each person`
+          );
+        }
+      });
+
+      if (
+        isValidReceiptBreakdown(
+          splitData.receipts,
+          splitData.names.length,
+          splitData.currency
+        ) &&
+        !receiptBreakdownMatchesTotals(
+          splitData.receipts,
+          splitData.amounts,
+          splitData.currency
+        )
+      ) {
+        errors.push(SplitDataError.INVALID_RECEIPT_BREAKDOWN);
+        errorMessages.push(
+          "Per-receipt amounts must add up to each person's aggregate amount"
+        );
+      }
     }
 
     // Validate names


### PR DESCRIPTION
## Summary
- Adds optional per-receipt labels and person amounts to shared multi-receipt links
- Keeps legacy links, single-receipt links, and aggregate Venmo actions compatible
- Bounds optional payloads and falls back to aggregate-only URLs when they are too large

## Test plan
- npm test -- --runInBand (593 passed)
- npm run lint
- npx tsc --noEmit
- npm run build

Part of #169